### PR TITLE
Fix covariance handling after shifts refactor

### DIFF
--- a/libapp/BinnedHistogram.h
+++ b/libapp/BinnedHistogram.h
@@ -112,7 +112,7 @@ public:
     }
 
     BinnedHistogram operator+(const BinnedHistogram& o) const {
-        log::debug("BinnedHistogram::operator+", "Adding '", o.GetName(), "' (", o.getNumberOfBins(), " bins, cov ", o.cov.GetNrows(), "x", o.cov.GetNcols(), ") to '", this->GetName(), "' (", this->getNumberOfBins(), " bins, cov ", this->cov.GetNrows(), "x", this->cov.GetNcols(), ")");
+        log::debug("BinnedHistogram::operator+", "Adding '", o.GetName(), "' (", o.getNumberOfBins(), " bins, shifts ", o.shifts.cols(), ") to '", this->GetName(), "' (", this->getNumberOfBins(), " bins, shifts ", this->shifts.cols(), ")");
 
         if (this->getNumberOfBins() <= 0) return o;
         if (o.getNumberOfBins() <= 0) return *this;
@@ -125,11 +125,11 @@ public:
         for (int i = 0; i < getNumberOfBins(); ++i) {
             tmp.counts[i] += o.counts[i];
         }
-        if (tmp.cov.GetNrows() != o.cov.GetNrows()) {
+        if (tmp.shifts.rows() != o.shifts.rows()) {
             log::error(
                 "BinnedHistogram::operator+",
-                "Covariance matrix dimension mismatch: ",
-                tmp.cov.GetNrows(), " vs ", o.cov.GetNrows());
+                "Shifts matrix dimension mismatch: ",
+                tmp.shifts.rows(), " vs ", o.shifts.rows());
             return BinnedHistogram();
         }
         int c1 = shifts.cols();
@@ -167,11 +167,11 @@ public:
         for (int i = 0; i < getNumberOfBins(); ++i) {
             tmp.counts[i] -= o.counts[i];
         }
-        if (tmp.cov.GetNrows() != o.cov.GetNrows()) {
+        if (tmp.shifts.rows() != o.shifts.rows()) {
             log::error(
                 "BinnedHistogram::operator-",
-                "Covariance matrix dimension mismatch: ",
-                tmp.cov.GetNrows(), " vs ", o.cov.GetNrows());
+                "Shifts matrix dimension mismatch: ",
+                tmp.shifts.rows(), " vs ", o.shifts.rows());
             return BinnedHistogram();
         }
         int c1 = shifts.cols();

--- a/libapp/HistogramPolicy.h
+++ b/libapp/HistogramPolicy.h
@@ -52,7 +52,8 @@ struct TH1DStorage {
     double count(int i) const { return counts.at(i); }
 
     double err(int i) const {
-        double v = cov(i, i);
+        if (i < 0 || i >= shifts.rows()) return 0;
+        double v = shifts.row(i).squaredNorm();
         return v > 0 ? std::sqrt(v) : 0;
     }
 

--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -64,7 +64,8 @@ public:
             SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
             if (!futures.variations.count(uni_key)) continue;
 
-            BinnedHistogram h_universe(binning, std::vector<double>(n, 0.0), cov);
+            Eigen::MatrixXd shifts = Eigen::MatrixXd::Zero(n, n);
+            BinnedHistogram h_universe(binning, std::vector<double>(n, 0.0), shifts);
             for(auto& [sample_key, future] : futures.variations.at(uni_key)) {
                 if (future.GetPtr())
                     h_universe = h_universe + BinnedHistogram::createFromTH1D(binning, *future.GetPtr());

--- a/libsyst/WeightSystematicStrategy.h
+++ b/libsyst/WeightSystematicStrategy.h
@@ -46,8 +46,9 @@ public:
         TMatrixDSym cov(n);
         cov.Zero();
 
-        BinnedHistogram hu(binning, std::vector<double>(n, 0.0), cov);
-        BinnedHistogram hd(binning, std::vector<double>(n, 0.0), cov);
+        Eigen::MatrixXd shifts = Eigen::MatrixXd::Zero(n, n);
+        BinnedHistogram hu(binning, std::vector<double>(n, 0.0), shifts);
+        BinnedHistogram hd(binning, std::vector<double>(n, 0.0), shifts);
 
         SystematicKey up_key{identifier_ + "_up"};
         SystematicKey dn_key{identifier_ + "_dn"};


### PR DESCRIPTION
## Summary
- compute bin errors from shift vectors rather than undefined covariance matrix
- replace obsolete covariance access in histogram arithmetic with shift-based logic
- update systematic strategies to construct histograms with shift matrices

## Testing
- `source .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68ab7cfc8408832e9eb10d4e219ef97d