### PR TITLE
Optimize histogram error storage

### DIFF
--- a/libapp/HistogramPolicy.h
+++ b/libapp/HistogramPolicy.h
@@ -65,7 +65,11 @@ struct TH1DStorage {
 
     double sumErr() const {
         int n = size();
-        if (n == 0 || shifts.cols() == 0) return 0;
+        if (n == 0 || shifts.size() == 0) return 0;
+        if (shifts.cols() == 1) {
+            double var = shifts.col(0).squaredNorm();
+            return var > 0 ? std::sqrt(var) : 0;
+        }
         Eigen::VectorXd ones = Eigen::VectorXd::Ones(n);
         double var = (shifts.transpose() * ones).squaredNorm();
         return var > 0 ? std::sqrt(var) : 0;
@@ -76,7 +80,12 @@ struct TH1DStorage {
         TMatrixDSym out(n);
         out.Zero();
         if (shifts.size() == 0) return out;
-        Eigen::MatrixXd cov = shifts * shifts.transpose();
+        Eigen::MatrixXd cov;
+        if (shifts.cols() == 1) {
+            cov = shifts.col(0).array().square().matrix().asDiagonal();
+        } else {
+            cov = shifts * shifts.transpose();
+        }
         for (int i = 0; i < n; ++i) {
             for (int j = 0; j <= i; ++j) {
                 double val = cov(i, j);

--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -66,8 +66,9 @@ public:
             SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
             if (!futures.variations.count(uni_key)) continue;
 
-            Eigen::MatrixXd shifts = Eigen::MatrixXd::Zero(n, n);
-            BinnedHistogram h_universe(binning, std::vector<double>(n, 0.0), shifts);
+            Eigen::VectorXd shifts = Eigen::VectorXd::Zero(n);
+            Eigen::MatrixXd shifts_mat = shifts;
+            BinnedHistogram h_universe(binning, std::vector<double>(n, 0.0), shifts_mat);
             for(auto& [sample_key, future] : futures.variations.at(uni_key)) {
                 if (future.GetPtr())
                     h_universe = h_universe + BinnedHistogram::createFromTH1D(binning, *future.GetPtr());

--- a/libsyst/WeightSystematicStrategy.h
+++ b/libsyst/WeightSystematicStrategy.h
@@ -46,9 +46,10 @@ public:
         TMatrixDSym cov(n);
         cov.Zero();
 
-        Eigen::MatrixXd shifts = Eigen::MatrixXd::Zero(n, n);
-        BinnedHistogram hu(binning, std::vector<double>(n, 0.0), shifts);
-        BinnedHistogram hd(binning, std::vector<double>(n, 0.0), shifts);
+        Eigen::VectorXd shifts = Eigen::VectorXd::Zero(n);
+        Eigen::MatrixXd shifts_mat = shifts;
+        BinnedHistogram hu(binning, std::vector<double>(n, 0.0), shifts_mat);
+        BinnedHistogram hd(binning, std::vector<double>(n, 0.0), shifts_mat);
 
         SystematicKey up_key{identifier_ + "_up"};
         SystematicKey dn_key{identifier_ + "_dn"};


### PR DESCRIPTION
## Summary
- store histogram error shifts as vectors instead of dense matrices
- adjust error aggregation and covariance logic for new storage
- simplify systematic strategies to avoid large zero matrices

## Testing
- `cmake ..` *(fails: could not find ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3bb60f1c832eb1c132246bc52820