### PR TITLE
fix: adjust under/overflow bin display

### DIFF
--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -304,6 +304,18 @@ protected:
     frame->GetXaxis()->SetTitleOffset(1.0);
     frame->GetYaxis()->SetTitleOffset(1.0);
 
+    const auto &edges = variable_result_.binning_.getEdges();
+    mc_stack_->GetXaxis()->SetLimits(edges.front(), edges.back());
+    if (edges.size() >= 3) {
+      std::ostringstream uf_label, of_label;
+      uf_label << "<" << edges[1];
+      of_label << ">" << edges[edges.size() - 2];
+      frame->GetXaxis()->ChangeLabel(1, -1, -1, -1, -1, -1,
+                                     uf_label.str().c_str());
+      frame->GetXaxis()->ChangeLabel(frame->GetXaxis()->GetNbins(), -1, -1,
+                                     -1, -1, -1, of_label.str().c_str());
+    }
+
     drawWatermark(p_main, total_mc_events);
 
     p_main->RedrawAxis();

--- a/libutils/DynamicBinning.h
+++ b/libutils/DynamicBinning.h
@@ -273,9 +273,11 @@ private:
         if (include_out_of_range_bins) {
             double first_width = edges.size() > 1 ? (edges[1] - edges[0]) : (domain_max - domain_min);
             double last_width  = edges.size() > 1 ? (edges[edges.size()-1] - edges[edges.size()-2]) : (domain_max - domain_min);
-            edges.insert(edges.begin(), domain_min - first_width);
-            edges.push_back(domain_max + last_width);
-            log::info("DynamicBinning::finalize_edges", "Added underflow/overflow bins spanning", domain_min - first_width, "to", domain_max + last_width);
+            double underflow_width = 0.5 * first_width;
+            double overflow_width  = 0.5 * last_width;
+            edges.insert(edges.begin(), domain_min - underflow_width);
+            edges.push_back(domain_max + overflow_width);
+            log::info("DynamicBinning::finalize_edges", "Added underflow/overflow bins spanning", domain_min - underflow_width, "to", domain_max + overflow_width);
         }
 
         auto last = std::unique(edges.begin(), edges.end());


### PR DESCRIPTION
## Summary
- tighten explicit under/overflow bins in dynamic binning and log span
- set histogram axis limits and label under/overflow bins explicitly

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a9a3de0832ea7877df5eb9cec8d