### PR TITLE
feat: add Freedman–Diaconis dynamic binning option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ An analysis framework for rare cross-section measurements.
     ./plot_analysis ../config.json
     ```
 
+## Dynamic Binning Strategies
+
+Variables can request automatic binning by setting their `bins` configuration to
+`{"mode": "dynamic"}`. By default, the bin edges are chosen so that each bin
+contains an equal total weight. To preserve the natural shape of the
+distribution, a Freedman–Diaconis strategy is also available:
+
+```json
+{
+  "bins": {
+    "mode": "dynamic",
+    "min": 0.0,
+    "max": 3000.0,
+    "include_out_of_range_bins": true,
+    "strategy": "freedman_diaconis"
+  }
+}
+```
+
+Omitting `strategy` or setting it to `equal_weight` retains the original
+equal-weight quantile binning.
+
 ```json
 {
   "path": "build/EventDisplayPlugin.so",

--- a/libapp/AnalysisDefinition.h
+++ b/libapp/AnalysisDefinition.h
@@ -16,6 +16,8 @@
 #include "RegionAnalysis.h"
 #include "Selection.h"
 #include "SelectionRegistry.h"
+#include "DynamicBinning.h"
+
 
 namespace analysis {
 
@@ -90,7 +92,8 @@ public:
                                     const BinningDefinition& bdef,
                                     const std::string& strat,
                                     bool is_dynamic = false,
-                                    bool include_out_of_range_bins = false)
+                                    bool include_out_of_range_bins = false,
+                                    DynamicBinningStrategy strategy = DynamicBinningStrategy::EqualWeight)
     {
         VariableKey var_key{key};
         if (variable_expressions_.count(var_key))
@@ -106,6 +109,7 @@ public:
         variable_stratifiers_[var_key] = strat;
         is_dynamic_[var_key] = is_dynamic;
         include_out_of_range_[var_key] = include_out_of_range_bins;
+        dynamic_strategy_[var_key] = strategy;
 
         return *this;
     }
@@ -180,6 +184,11 @@ public:
     bool includeOutOfRangeBins(const VariableKey& key) const {
         auto it = include_out_of_range_.find(key);
         return it != include_out_of_range_.end() && it->second;
+    }
+
+    DynamicBinningStrategy dynamicBinningStrategy(const VariableKey& key) const {
+        auto it = dynamic_strategy_.find(key);
+        return it != dynamic_strategy_.end() ? it->second : DynamicBinningStrategy::EqualWeight;
     }
 
     void setBinning(const VariableKey& key, BinningDefinition&& bdef) {
@@ -282,6 +291,7 @@ private:
     std::map<VariableKey, std::string> variable_stratifiers_;
     std::map<VariableKey, bool> is_dynamic_;
     std::map<VariableKey, bool> include_out_of_range_;
+    std::map<VariableKey, DynamicBinningStrategy> dynamic_strategy_;
 
     std::map<RegionKey, std::string> region_names_;
     std::map<RegionKey, Selection> region_selections_;

--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -67,6 +67,7 @@ public:
                 // For weighted counts: n_eff = (sum w_i)^2 / (sum w_i^2), and rel_stat_err ≈ 1/sqrt(n_eff).
                 // Hence min_neff_per_bin = 400 (~5% stats; total ≈ sqrt(0.10^2 + 0.05^2) ≈ 11.2%).
                 bool include_oob = analysis_definition_.includeOutOfRangeBins(var_handle.key_);
+                auto strategy = analysis_definition_.dynamicBinningStrategy(var_handle.key_);
                 BinningDefinition new_bins = DynamicBinning::calculate(
                     mc_nodes,
                     var_handle.binning(),
@@ -74,7 +75,8 @@ public:
                     400.0,
                     0.0,
                     1.0,
-                    include_oob
+                    include_oob,
+                    strategy
                 );
 
                 log::info("AnalysisRunner::run", "--> Optimal bin count resolved:", new_bins.getBinNumber());

--- a/libplug/VariablesPlugin.h
+++ b/libplug/VariablesPlugin.h
@@ -9,6 +9,7 @@
 #include "AnalysisDefinition.h"
 #include "AnalysisLogger.h"
 #include "BinningDefinition.h"
+#include "DynamicBinning.h"
 #include "IAnalysisPlugin.h"
 
 namespace analysis {
@@ -43,12 +44,17 @@ public:
                 double domain_min = bins_cfg.value("min", -std::numeric_limits<double>::infinity());
                 double domain_max = bins_cfg.value("max",  std::numeric_limits<double>::infinity());
                 bool include_oob = bins_cfg.value("include_out_of_range_bins", true);
+                std::string strat_mode = bins_cfg.value("strategy", std::string("equal_weight"));
+                DynamicBinningStrategy strategy = DynamicBinningStrategy::EqualWeight;
+                if (strat_mode == "freedman_diaconis") {
+                    strategy = DynamicBinningStrategy::FreedmanDiaconis;
+                }
                 BinningDefinition placeholder_bins({domain_min, domain_max},
                                                   branch,
                                                   label,
                                                   {},
                                                   strat);
-                def.addVariable(name, branch, label, placeholder_bins, strat, true, include_oob);
+                def.addVariable(name, branch, label, placeholder_bins, strat, true, include_oob, strategy);
             } else {
                 std::vector<double> edges;
                 if (bins_cfg.is_array()) {

--- a/numu_plugins.json
+++ b/numu_plugins.json
@@ -26,7 +26,8 @@
             "mode": "dynamic",
             "min": 0.0,
             "max": 3000.0,
-            "include_out_of_range_bins": true
+            "include_out_of_range_bins": true,
+            "strategy": "freedman_diaconis"
           },
           "regions": [
             "NUMU_CC_SEL"


### PR DESCRIPTION
## Summary
- add configurable `DynamicBinningStrategy` with new Freedman–Diaconis rule
- allow variables to specify binning strategy via plugin config and propagate through analysis
- document dynamic binning strategies and show usage in example plugin config
- include `DynamicBinning.h` in `AnalysisDefinition` so default strategy compiles cleanly

## Testing
- `bash ./.build.sh` *(fails: CMake could not find ROOT package)*
- `apt-get update` *(fails: repository InRelease files not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac74d65968832e96e3d6fb9fa87a5f