### PR TITLE
Use TLatex empty set label and neutral color for unmatched particles

### DIFF
--- a/libhist/StratifierRegistry.h
+++ b/libhist/StratifierRegistry.h
@@ -75,7 +75,7 @@ public:
             {2112,  "neutron",            "n",                 kGray+1,    1001},
             {321,   "kaon",               R"(K^{#pm})",        kMagenta-9, 1001},
             {3222,  "sigma",              R"(#Sigma^{#pm})",   kRed-9,     1001},
-            {0,     "none",              "∅",      kTeal,      1001},
+            {0,     "none",              R"(#emptyset)",      kGray+2,    1001},
             {-1,    "other",              "Other",             kBlack,     3005}
         },
         [](const ROOT::RVec<int>& pdg_codes, int key) {


### PR DESCRIPTION
## Summary
- Display unmatched particle category with TLatex empty set symbol
- Switch unmatched particle colour to a neutral grey

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac79bea6b4832e96d47d12f598b5a2