### PR TITLE
Add preselection plugin configuration and register event variables for NuMu analysis

### DIFF
--- a/libdata/EventVariableRegistry.h
+++ b/libdata/EventVariableRegistry.h
@@ -108,7 +108,8 @@ private:
             "reco_neutrino_vertex_sce_z", "num_slices",
             "slice_num_hits", "selection_pass", "slice_id",
             "optical_filter_pe_beam", "optical_filter_pe_veto",
-            "num_pfps", "num_tracks", "num_showers", "event_total_hits"
+            "num_pfps", "num_tracks", "num_showers", "event_total_hits",
+            "quality_event", "n_pfps_gen2", "n_pfps_gen3"
         };
         return v;
     }

--- a/numu_preselection_plugins.json
+++ b/numu_preselection_plugins.json
@@ -1,0 +1,171 @@
+{
+  "plugins": [
+    {
+      "path": "build/RegionsPlugin.so",
+      "regions": [
+        {
+          "region_key": "NUMU_EMPTY",
+          "label": "Muon Neutrino No Selection",
+          "selection_rule": "NONE",
+          "beam_config": "numi_fhc",
+          "runs": ["run1"]
+        },
+        {
+          "region_key": "NUMU_QUALITY_PRE",
+          "label": "Muon Neutrino Quality Preselection",
+          "selection_rule": "QUALITY",
+          "beam_config": "numi_fhc",
+          "runs": ["run1"]
+        }
+      ]
+    },
+    {
+      "path": "build/VariablesPlugin.so",
+      "variables": [
+        {
+          "name": "pfp track length",
+          "branch": "track_length",
+          "label": "Track Length [cm]",
+          "stratum": "backtracked_pdg_codes",
+          "bins": {
+            "mode": "dynamic",
+            "min": 0.0,
+            "max": 3000.0,
+            "include_out_of_range_bins": true,
+            "strategy": "freedman_diaconis"
+          },
+          "regions": ["NUMU_EMPTY", "NUMU_QUALITY_PRE"]
+        },
+        {
+          "name": "n_pfps_gen2",
+          "branch": "n_pfps_gen2",
+          "label": "Number of Gen2 PFPs",
+          "stratum": "backtracked_pdg_codes",
+          "bins": {
+            "mode": "dynamic",
+            "min": 0.0,
+            "max": 10.0,
+            "include_out_of_range_bins": true,
+            "strategy": "freedman_diaconis"
+          },
+          "regions": ["NUMU_EMPTY", "NUMU_QUALITY_PRE"]
+        },
+        {
+          "name": "n_muons",
+          "branch": "n_muons",
+          "label": "Number of Muons",
+          "stratum": "backtracked_pdg_codes",
+          "bins": {
+            "mode": "dynamic",
+            "min": 0.0,
+            "max": 5.0,
+            "include_out_of_range_bins": true,
+            "strategy": "freedman_diaconis"
+          },
+          "regions": ["NUMU_EMPTY", "NUMU_QUALITY_PRE"]
+        },
+        {
+          "name": "neutrino energy",
+          "branch": "neutrino_energy",
+          "label": "True Neutrino Energy [GeV]",
+          "stratum": "backtracked_pdg_codes",
+          "bins": {
+            "mode": "dynamic",
+            "min": 0.0,
+            "max": 10.0,
+            "include_out_of_range_bins": true,
+            "strategy": "freedman_diaconis"
+          },
+          "regions": ["NUMU_QUALITY_PRE"]
+        }
+      ]
+    },
+    {
+      "path": "build/StackedHistogramPlugin.so",
+      "plots": [
+        {
+          "variable": "pfp track length",
+          "region": "NUMU_EMPTY",
+          "category_column": "backtracked_pdg_codes",
+          "output_directory": "plots",
+          "overlay_signal": true,
+          "annotate_numbers": true,
+          "log_y": true,
+          "y_axis_label": "Particle Flows"
+        },
+        {
+          "variable": "pfp track length",
+          "region": "NUMU_QUALITY_PRE",
+          "category_column": "backtracked_pdg_codes",
+          "output_directory": "plots",
+          "overlay_signal": true,
+          "annotate_numbers": true,
+          "log_y": true,
+          "y_axis_label": "Particle Flows"
+        },
+        {
+          "variable": "n_pfps_gen2",
+          "region": "NUMU_EMPTY",
+          "category_column": "backtracked_pdg_codes",
+          "output_directory": "plots",
+          "overlay_signal": true,
+          "annotate_numbers": true,
+          "log_y": true,
+          "y_axis_label": "Particle Flows",
+          "cuts": [
+            {"threshold": 1.0, "direction": "GreaterThan"}
+          ]
+        },
+        {
+          "variable": "n_pfps_gen2",
+          "region": "NUMU_QUALITY_PRE",
+          "category_column": "backtracked_pdg_codes",
+          "output_directory": "plots",
+          "overlay_signal": true,
+          "annotate_numbers": true,
+          "log_y": true,
+          "y_axis_label": "Particle Flows",
+          "cuts": [
+            {"threshold": 1.0, "direction": "GreaterThan"}
+          ]
+        },
+        {
+          "variable": "n_muons",
+          "region": "NUMU_EMPTY",
+          "category_column": "backtracked_pdg_codes",
+          "output_directory": "plots",
+          "overlay_signal": true,
+          "annotate_numbers": true,
+          "log_y": true,
+          "y_axis_label": "Particle Flows",
+          "cuts": [
+            {"threshold": 0.0, "direction": "GreaterThan"}
+          ]
+        },
+        {
+          "variable": "n_muons",
+          "region": "NUMU_QUALITY_PRE",
+          "category_column": "backtracked_pdg_codes",
+          "output_directory": "plots",
+          "overlay_signal": true,
+          "annotate_numbers": true,
+          "log_y": true,
+          "y_axis_label": "Particle Flows",
+          "cuts": [
+            {"threshold": 0.0, "direction": "GreaterThan"}
+          ]
+        },
+        {
+          "variable": "neutrino energy",
+          "region": "NUMU_QUALITY_PRE",
+          "category_column": "backtracked_pdg_codes",
+          "output_directory": "plots",
+          "overlay_signal": true,
+          "annotate_numbers": true,
+          "log_y": true,
+          "y_axis_label": "Events"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Register `quality_event`, `n_pfps_gen2`, and `n_pfps_gen3` in the event variable registry