### PR TITLE
Include ROOT legend entry header to fix build

### DIFF
--- a/libplot/SelectionEfficiencyPlot.h
+++ b/libplot/SelectionEfficiencyPlot.h
@@ -7,6 +7,7 @@
 #include "TGraphErrors.h"
 #include "TH1F.h"
 #include "TLegend.h"
+#include "TLegendEntry.h"
 
 #include "HistogramPlotterBase.h"
 


### PR DESCRIPTION
Include `TLegendEntry.h` in `SelectionEfficiencyPlot`