### PR TITLE
Add systematic breakdown plot and plugin

### DIFF
--- a/libplot/CMakeLists.txt
+++ b/libplot/CMakeLists.txt
@@ -1,13 +1,16 @@
-add_library(libplot INTERFACE)
+add_library(libplot
+  SystematicBreakdownPlot.cpp
+)
 
 target_include_directories(libplot
-  INTERFACE
+  PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>   
+    $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries(libplot
-  INTERFACE
+  PUBLIC
     libdata
     libutils
+    ${ROOT_LIBRARIES}
 )

--- a/libplot/SystematicBreakdownPlot.cpp
+++ b/libplot/SystematicBreakdownPlot.cpp
@@ -1,0 +1,72 @@
+#include "SystematicBreakdownPlot.h"
+
+#include <algorithm>
+
+#include "TCanvas.h"
+#include "TColor.h"
+
+namespace analysis {
+
+SystematicBreakdownPlot::SystematicBreakdownPlot(std::string plot_name,
+                                                 const VariableResult& var_result,
+                                                 bool normalise,
+                                                 std::string output_directory)
+    : HistogramPlotterBase(std::move(plot_name), std::move(output_directory)),
+      variable_result_(var_result),
+      normalise_(normalise),
+      stack_(nullptr),
+      legend_(nullptr) {}
+
+SystematicBreakdownPlot::~SystematicBreakdownPlot() {
+    delete stack_;
+    delete legend_;
+    for (auto* h : histograms_) {
+        delete h;
+    }
+}
+
+void SystematicBreakdownPlot::draw(TCanvas& canvas) {
+    canvas.cd();
+
+    const auto& edges = variable_result_.binning_.getEdges();
+    const int nbins = variable_result_.binning_.getBinNumber();
+
+    std::vector<double> bin_totals(nbins, 0.0);
+    for (const auto& [key, cov] : variable_result_.covariance_matrices_) {
+        for (int i = 0; i < nbins; ++i) {
+            bin_totals[i] += cov(i, i);
+        }
+    }
+
+    stack_ = new THStack("syst_stack", "");
+    legend_ = new TLegend(0.65, 0.7, 0.9, 0.9);
+    legend_->SetBorderSize(0);
+    legend_->SetFillStyle(0);
+    legend_->SetTextFont(42);
+
+    int color = kRed + 1;
+    for (const auto& [key, cov] : variable_result_.covariance_matrices_) {
+        TH1D* hist = new TH1D(key.str().c_str(), "", nbins, edges.data());
+        for (int i = 0; i < nbins; ++i) {
+            double val = cov(i, i);
+            if (normalise_ && bin_totals[i] > 0.0) {
+                val /= bin_totals[i];
+            }
+            hist->SetBinContent(i + 1, val);
+        }
+        hist->SetFillColor(color);
+        hist->SetLineColor(kBlack);
+        stack_->Add(hist);
+        legend_->AddEntry(hist, key.str().c_str(), "f");
+        histograms_.push_back(hist);
+        ++color;
+    }
+
+    stack_->Draw("hist");
+    stack_->GetXaxis()->SetTitle(variable_result_.binning_.getTexLabel().c_str());
+    stack_->GetYaxis()->SetTitle(normalise_ ? "Fractional Contribution" : "Variance");
+    legend_->Draw();
+}
+
+} // namespace analysis
+

--- a/libplot/SystematicBreakdownPlot.h
+++ b/libplot/SystematicBreakdownPlot.h
@@ -1,0 +1,36 @@
+#ifndef SYSTEMATIC_BREAKDOWN_PLOT_H
+#define SYSTEMATIC_BREAKDOWN_PLOT_H
+
+#include <string>
+#include <vector>
+
+#include "THStack.h"
+#include "TH1D.h"
+#include "TLegend.h"
+
+#include "HistogramPlotterBase.h"
+#include "AnalysisTypes.h"
+
+namespace analysis {
+
+class SystematicBreakdownPlot : public HistogramPlotterBase {
+public:
+    SystematicBreakdownPlot(std::string plot_name,
+                            const VariableResult& var_result,
+                            bool normalise = false,
+                            std::string output_directory = "plots");
+    ~SystematicBreakdownPlot() override;
+
+private:
+    void draw(TCanvas& canvas) override;
+
+    const VariableResult& variable_result_;
+    bool normalise_;
+    THStack* stack_;
+    std::vector<TH1D*> histograms_;
+    TLegend* legend_;
+};
+
+} // namespace analysis
+
+#endif

--- a/libplug/CMakeLists.txt
+++ b/libplug/CMakeLists.txt
@@ -38,8 +38,9 @@ add_plugin(StackedHistogramPlugin StackedHistogramPlugin.cpp  libplot)
 add_plugin(EventDisplayPlugin     EventDisplayPlugin.cpp      libplot)
 add_plugin(SelectionEfficiencyPlugin SelectionEfficiencyPlugin.cpp libplot)
 add_plugin(UnstackedHistogramPlugin UnstackedHistogramPlugin.cpp libplot)
+add_plugin(SystematicBreakdownPlugin SystematicBreakdownPlugin.cpp libplot)
 
-foreach(_p IN ITEMS RegionsPlugin VariablesPlugin StackedHistogramPlugin EventDisplayPlugin UnstackedHistogramPlugin SelectionEfficiencyPlugin)
+foreach(_p IN ITEMS RegionsPlugin VariablesPlugin StackedHistogramPlugin EventDisplayPlugin UnstackedHistogramPlugin SelectionEfficiencyPlugin SystematicBreakdownPlugin)
 
   set_target_properties(${_p} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/libplug/SystematicBreakdownPlugin.cpp
+++ b/libplug/SystematicBreakdownPlugin.cpp
@@ -1,0 +1,6 @@
+#include "SystematicBreakdownPlugin.h"
+#include <nlohmann/json.hpp>
+
+extern "C" analysis::IAnalysisPlugin* createPlugin(const nlohmann::json& cfg) {
+    return new analysis::SystematicBreakdownPlugin(cfg);
+}

--- a/libplug/SystematicBreakdownPlugin.h
+++ b/libplug/SystematicBreakdownPlugin.h
@@ -1,0 +1,80 @@
+#ifndef SYSTEMATICBREAKDOWNPLUGIN_H
+#define SYSTEMATICBREAKDOWNPLUGIN_H
+
+#include <string>
+#include <vector>
+#include <stdexcept>
+
+#include <nlohmann/json.hpp>
+
+#include <TSystem.h>
+
+#include "AnalysisLogger.h"
+#include "IAnalysisPlugin.h"
+#include "SystematicBreakdownPlot.h"
+
+namespace analysis {
+
+class SystematicBreakdownPlugin : public IAnalysisPlugin {
+public:
+    struct PlotConfig {
+        std::string variable;
+        std::string region;
+        std::string output_directory = "plots";
+        bool fractional = false;
+    };
+
+    explicit SystematicBreakdownPlugin(const nlohmann::json& cfg) {
+        if (!cfg.contains("plots") || !cfg.at("plots").is_array())
+            throw std::runtime_error("SystematicBreakdownPlugin missing plots");
+        for (auto const& p : cfg.at("plots")) {
+            PlotConfig pc;
+            pc.variable         = p.at("variable").get<std::string>();
+            pc.region           = p.at("region").get<std::string>();
+            pc.output_directory = p.value("output_directory", std::string("plots"));
+            pc.fractional       = p.value("fractional", false);
+            plots_.push_back(std::move(pc));
+        }
+    }
+
+    void onInitialisation(AnalysisDefinition&, const SelectionRegistry&) override {}
+    void onPreSampleProcessing(const SampleKey&, const RegionKey&, const RunConfig&) override {}
+    void onPostSampleProcessing(const SampleKey&, const RegionKey&, const RegionAnalysisMap&) override {}
+
+    void onFinalisation(const RegionAnalysisMap& region_map) override {
+        gSystem->mkdir("plots", true);
+        for (auto const& pc : plots_) {
+            RegionKey rkey{pc.region};
+            auto it = region_map.find(rkey);
+
+            if (it == region_map.end()) {
+                log::error("SystematicBreakdownPlugin::onFinalisation", "Could not find analysis region for key:", rkey.str());
+                continue;
+            }
+
+            VariableKey vkey{pc.variable};
+            if (!it->second.hasFinalVariable(vkey)) {
+                log::error("SystematicBreakdownPlugin::onFinalisation", "Could not find variable", vkey.str(), "in region", rkey.str());
+                continue;
+            }
+
+            const auto& region_analysis = it->second;
+            const auto& variable_result = region_analysis.getFinalVariable(vkey);
+
+            SystematicBreakdownPlot plot(
+                "syst_breakdown_" + pc.variable + "_" + pc.region,
+                variable_result,
+                pc.fractional,
+                pc.output_directory
+            );
+            plot.drawAndSave("pdf");
+        }
+    }
+
+private:
+    std::vector<PlotConfig> plots_;
+};
+
+} // namespace analysis
+
+#endif


### PR DESCRIPTION
## Summary
- Implement SystematicBreakdownPlot using THStack to show per-bin systematic contributions with optional fractional normalisation.
- Introduce SystematicBreakdownPlugin to configure variables/regions and invoke the new plot during finalisation.
- Wire new components into build system.

## Testing
- ⚠️ `cmake -S . -B build` *(missing ROOT package)*


------
https://chatgpt.com/codex/tasks/task_e_68ac9b28a694832ebf727d3dde7687e3