### PR TITLE
Enable PIC for libplot to support shared plugins

### DIFF
--- a/libplot/CMakeLists.txt
+++ b/libplot/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(libplot
   SystematicBreakdownPlot.cpp
 )
 
+# Ensure position independent code so libplot can be linked into shared plugins
+set_target_properties(libplot PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 target_include_directories(libplot
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
Build libplot with position independent code so plugins can link it without relocation errors