### PR TITLE
Add systematics test to CMake suite

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,3 +10,17 @@ target_link_libraries(histogram_uncertainty_tests
 )
 
 add_test(NAME histogram_uncertainty_tests COMMAND histogram_uncertainty_tests)
+
+add_executable(test_systematics test_systematics.cpp)
+
+target_link_libraries(test_systematics
+  PRIVATE
+    libapp
+    libhist
+    libutils
+    libsyst
+    Eigen3::Eigen
+    ${ROOT_LIBRARIES}
+)
+
+add_test(NAME test_systematics COMMAND test_systematics)


### PR DESCRIPTION
Include `test_systematics` in the test build