### PR TITLE
Load run configurations once outside beam loop

### DIFF
--- a/analyse.cpp
+++ b/analyse.cpp
@@ -57,6 +57,9 @@ int main(int argc, char *argv[]) {
                             config_data.at("run_configurations").size(),
                             "beamlines.");
 
+        analysis::RunConfigRegistry rc_reg;
+        analysis::RunConfigLoader::loadRunConfigurations(argv[1], rc_reg);
+
         for (auto const &[beam, run_configs] :
              config_data.at("run_configurations").items()) {
 
@@ -64,9 +67,6 @@ int main(int argc, char *argv[]) {
             for (auto const &[period, period_details] : run_configs.items()) {
                 periods.push_back(period);
             }
-
-            analysis::RunConfigRegistry rc_reg;
-            analysis::RunConfigLoader::loadRunConfigurations(argv[1], rc_reg);
 
             analysis::EventVariableRegistry ev_reg;
             analysis::SelectionRegistry sel_reg;


### PR DESCRIPTION
## Summary
- Preload run configuration registry once and reuse it for each beamline iteration

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc298368c832e979d9e62f49c5ecd