### PR TITLE
Guard histogram bin addition against empty binning

### DIFF
--- a/libhist/BinningDefinition.h
+++ b/libhist/BinningDefinition.h
@@ -39,7 +39,9 @@ class BinningDefinition {
         return selec_keys_;
     }
     const StratifierKey &getStratifierKey() const { return strat_key_; }
-    size_t getBinNumber() const { return edges_.size() - 1; }
+    size_t getBinNumber() const {
+        return edges_.size() > 1 ? edges_.size() - 1 : 0;
+    }
 
     ROOT::RDF::TH1DModel toTH1DModel() const {
         return ROOT::RDF::TH1DModel(getVariable().c_str(),

--- a/tests/histogram_uncertainty_tests.cpp
+++ b/tests/histogram_uncertainty_tests.cpp
@@ -48,5 +48,15 @@ int main() {
     double expected_corr = 0.02 / std::sqrt((0.01 + 0.01) * (0.04 + 0.04));
     assert(std::abs(corr2(0, 1) - expected_corr) < 1e-12);
 
+    // Verify default-constructed binning behaves sensibly
+    BinningDefinition empty_bn;
+    assert(empty_bn.getBinNumber() == 0);
+
+    // Ensure adding a populated histogram to an empty one works
+    HistogramUncertainty empty_hist;
+    auto h_sum2 = empty_hist + h1;
+    assert(h_sum2.size() == h1.size());
+    assert(h_sum2.count(0) == h1.count(0));
+
     return 0;
 }


### PR DESCRIPTION
Treat binning definitions with fewer than two edges as empty