### PR TITLE
Direct event display output into dedicated subdirectory

### DIFF
--- a/event_display_plugins.json
+++ b/event_display_plugins.json
@@ -35,7 +35,7 @@
           "n_events": 5,
           "pdf_name": "numu_empty_event_displays.pdf",
           "image_size": 800,
-          "output_directory": "./plots"
+          "output_directory": "./plots/event_displays"
         },
         {
           "sample": "mc_inclusive_run1_fhc",
@@ -43,7 +43,7 @@
           "n_events": 5,
           "pdf_name": "numu_quality_pre_event_displays.pdf",
           "image_size": 800,
-          "output_directory": "./plots"
+          "output_directory": "./plots/event_displays"
         },
         {
           "sample": "mc_inclusive_run1_fhc",
@@ -51,7 +51,7 @@
           "n_events": 5,
           "pdf_name": "numu_cc_sel_event_displays.pdf",
           "image_size": 800,
-          "output_directory": "./plots"
+          "output_directory": "./plots/event_displays"
         }
       ]
     }

--- a/libplug/EventDisplayPlugin.h
+++ b/libplug/EventDisplayPlugin.h
@@ -24,7 +24,7 @@ class EventDisplayPlugin : public IAnalysisPlugin {
         int n_events{1};
         std::string pdf_name{"event_displays.pdf"};
         int image_size{800};
-        std::string output_directory{"./plots"};
+        std::string output_directory{"./plots/event_displays"};
     };
 
     inline explicit EventDisplayPlugin(const nlohmann::json &cfg) {
@@ -42,7 +42,7 @@ class EventDisplayPlugin : public IAnalysisPlugin {
                 ed.value("pdf_name", std::string{"event_displays.pdf"});
             dc.image_size = ed.value("image_size", 800);
             dc.output_directory =
-                ed.value("output_directory", std::string{"./plots"});
+                ed.value("output_directory", std::string{"./plots/event_displays"});
             auto p = std::filesystem::path(dc.output_directory);
             if (!p.is_absolute()) {
                 dc.output_directory =


### PR DESCRIPTION
Save EventDisplayPlugin outputs under `plots/event_displays` by default