### PR TITLE
Add uniform binning option for stacked histograms

### DIFF
--- a/libplug/StackedHistogramPlugin.h
+++ b/libplug/StackedHistogramPlugin.h
@@ -30,6 +30,9 @@ class StackedHistogramPlugin : public IAnalysisPlugin {
         bool use_log_y = false;
         std::string y_axis_label = "Events";
         bool selection_cuts = false;
+        int n_bins{-1};
+        double min{0.0};
+        double max{0.0};
     };
 
     explicit StackedHistogramPlugin(const nlohmann::json &cfg) {
@@ -47,6 +50,9 @@ class StackedHistogramPlugin : public IAnalysisPlugin {
             pc.use_log_y = p.value("log_y", false);
             pc.y_axis_label = p.value("y_axis_label", "Events");
             pc.selection_cuts = p.value("selection_cuts", false);
+            pc.n_bins = p.value("n_bins", -1);
+            pc.min = p.value("min", 0.0);
+            pc.max = p.value("max", 0.0);
             if (p.contains("cuts")) {
                 for (auto const &c : p.at("cuts")) {
                     auto dir =
@@ -125,7 +131,7 @@ class StackedHistogramPlugin : public IAnalysisPlugin {
                 "stack_" + pc.variable + "_" + pc.region, variable_result,
                 region_analysis, pc.category_column, pc.output_directory,
                 pc.overlay_signal, cuts, pc.annotate_numbers, pc.use_log_y,
-                pc.y_axis_label);
+                pc.y_axis_label, pc.n_bins, pc.min, pc.max);
             plot.drawAndSave("pdf");
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,26 +1,29 @@
 add_executable(histogram_uncertainty_tests histogram_uncertainty_tests.cpp)
 
-target_link_libraries(histogram_uncertainty_tests
-  PRIVATE
-    libapp
-    libhist
-    libutils
-    Eigen3::Eigen
-    ${ROOT_LIBRARIES}
-)
+    target_link_libraries(histogram_uncertainty_tests PRIVATE libapp libhist
+                              libutils Eigen3::Eigen ${ROOT_LIBRARIES})
 
-add_test(NAME histogram_uncertainty_tests COMMAND histogram_uncertainty_tests)
+        add_test(NAME histogram_uncertainty_tests COMMAND
+                     histogram_uncertainty_tests)
 
-add_executable(test_systematics test_systematics.cpp)
+            add_executable(test_systematics test_systematics.cpp)
 
-target_link_libraries(test_systematics
-  PRIVATE
-    libapp
-    libhist
-    libutils
-    libsyst
-    Eigen3::Eigen
-    ${ROOT_LIBRARIES}
-)
+                target_link_libraries(test_systematics PRIVATE libapp libhist
+                                          libutils libsyst Eigen3::Eigen ${
+                                              ROOT_LIBRARIES})
 
-add_test(NAME test_systematics COMMAND test_systematics)
+                    add_test(NAME test_systematics COMMAND test_systematics)
+
+                        add_executable(
+                            stacked_histogram_uniform_binning
+                                stacked_histogram_uniform_binning.cpp)
+
+                            target_link_libraries(
+                                stacked_histogram_uniform_binning PRIVATE libapp
+                                    libhist libplot libutils Eigen3::Eigen ${
+                                        ROOT_LIBRARIES})
+
+                                add_test(
+                                    NAME stacked_histogram_uniform_binning
+                                        COMMAND
+                                            stacked_histogram_uniform_binning)

--- a/tests/stacked_histogram_uniform_binning.cpp
+++ b/tests/stacked_histogram_uniform_binning.cpp
@@ -1,0 +1,54 @@
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+#include "Eigen/Dense"
+#include "TCanvas.h"
+#include "TFile.h"
+#include "TH1.h"
+#include "THStack.h"
+
+#include "AnalysisTypes.h"
+#include "BinningDefinition.h"
+#include "RegionAnalysis.h"
+#include "StackedHistogramPlot.h"
+
+using namespace analysis;
+
+int main() {
+    // Original variable binning with four bins
+    std::vector<double> edges{0.0, 1.0, 2.0, 3.0, 4.0};
+    BinningDefinition binning(edges, "x", "x", {});
+
+    // Create a simple histogram with counts in each bin
+    std::vector<double> counts{1.0, 2.0, 3.0, 4.0};
+    Eigen::VectorXd sh_vec = Eigen::VectorXd::Zero(counts.size());
+    Eigen::MatrixXd shifts = sh_vec;
+    BinnedHistogram hist(binning, counts, shifts);
+
+    VariableResult result;
+    result.binning_ = binning;
+    result.total_mc_hist_ = hist;
+    result.strat_hists_.emplace(ChannelKey{std::string{"10"}}, hist);
+
+    RegionAnalysis region(RegionKey{std::string{"reg"}}, "reg");
+
+    // Request uniform binning with two bins spanning [0,4]
+    StackedHistogramPlot plot("test_plot", result, region,
+                              "inclusive_strange_channels", "test_plots", true,
+                              {}, true, false, "Events", 2, 0.0, 4.0);
+    plot.drawAndSave("root");
+
+    TFile file("test_plots/test_plot.root");
+    auto canvas = dynamic_cast<TCanvas *>(file.Get("test_plot"));
+    assert(canvas);
+    auto stack = dynamic_cast<THStack *>(canvas->GetPrimitive("mc_stack"));
+    assert(stack);
+    TH1 *frame = stack->GetHistogram();
+    assert(frame);
+    auto axis = frame->GetXaxis();
+    assert(axis->GetNbins() == 2);
+    assert(std::abs(axis->GetXmin() - 0.0) < 1e-6);
+    assert(std::abs(axis->GetXmax() - 4.0) < 1e-6);
+    return 0;
+}


### PR DESCRIPTION
Allow `StackedHistogramPlot` to optionally use uniform binning when `n_bins`, `min`, and `max` are provided