### PR TITLE
feat: add log-scale option to selection efficiency plots

### DIFF
--- a/libplot/SelectionEfficiencyPlot.h
+++ b/libplot/SelectionEfficiencyPlot.h
@@ -15,26 +15,27 @@ namespace analysis {
 
 class SelectionEfficiencyPlot : public HistogramPlotterBase {
   public:
-    SelectionEfficiencyPlot(std::string plot_name,
-                            std::vector<std::string> stages,
-                            std::vector<double> efficiencies,
-                            std::vector<double> efficiency_errors,
-                            std::vector<double> purities,
-                            std::vector<double> purity_errors,
-                            std::string output_directory = "plots")
+    SelectionEfficiencyPlot(
+        std::string plot_name, std::vector<std::string> stages,
+        std::vector<double> efficiencies, std::vector<double> efficiency_errors,
+        std::vector<double> purities, std::vector<double> purity_errors,
+        std::string output_directory = "plots", bool use_log_y = false)
         : HistogramPlotterBase(std::move(plot_name),
                                std::move(output_directory)),
           stages_(std::move(stages)), efficiencies_(std::move(efficiencies)),
           efficiency_errors_(std::move(efficiency_errors)),
           purities_(std::move(purities)),
-          purity_errors_(std::move(purity_errors)) {}
+          purity_errors_(std::move(purity_errors)), use_log_y_(use_log_y) {}
 
   private:
     void draw(TCanvas &canvas) override {
         canvas.cd();
+        if (use_log_y_)
+            canvas.SetLogy();
         int n = stages_.size();
         TH1F frame("frame", "", n, 0, n);
-        frame.GetYaxis()->SetRangeUser(0.0, 1.05);
+        double y_min = use_log_y_ ? 1e-3 : 0.0;
+        frame.GetYaxis()->SetRangeUser(y_min, 1.05);
         frame.GetYaxis()->SetTitle("Fraction");
         for (int i = 0; i < n; ++i) {
             frame.GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
@@ -53,12 +54,14 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
         eff_graph.SetLineColor(kBlue + 1);
         eff_graph.SetMarkerColor(kBlue + 1);
         eff_graph.SetMarkerStyle(20);
+        eff_graph.SetLineWidth(2);
         pur_graph.SetLineColor(kRed + 1);
         pur_graph.SetMarkerColor(kRed + 1);
         pur_graph.SetMarkerStyle(21);
+        pur_graph.SetLineWidth(2);
 
-        eff_graph.DrawClone("P SAME");
-        pur_graph.DrawClone("P SAME");
+        eff_graph.DrawClone("PL SAME");
+        pur_graph.DrawClone("PL SAME");
 
         TLegend legend(0.6, 0.75, 0.88, 0.88);
         legend.SetBorderSize(0);
@@ -82,6 +85,7 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
     std::vector<double> efficiency_errors_;
     std::vector<double> purities_;
     std::vector<double> purity_errors_;
+    bool use_log_y_;
 };
 
 } // namespace analysis

--- a/libplug/SelectionEfficiencyPlugin.h
+++ b/libplug/SelectionEfficiencyPlugin.h
@@ -24,6 +24,7 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
         std::string signal_group;
         std::string output_directory{"plots"};
         std::string plot_name{"selection_efficiency"};
+        bool use_log_y{false};
         std::vector<std::string> clauses;
     };
 
@@ -43,6 +44,7 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
                 p.value("output_directory", std::string{"plots"});
             pc.plot_name =
                 p.value("plot_name", std::string{"selection_efficiency"});
+            pc.use_log_y = p.value("log_y", false);
             plots_.push_back(std::move(pc));
         }
     }
@@ -162,9 +164,10 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
                 pur_errors.push_back(pur_err);
             }
 
-            SelectionEfficiencyPlot plot(
-                pc.plot_name + "_" + pc.region, stage_labels, efficiencies,
-                eff_errors, purities, pur_errors, pc.output_directory);
+            SelectionEfficiencyPlot plot(pc.plot_name + "_" + pc.region,
+                                         stage_labels, efficiencies, eff_errors,
+                                         purities, pur_errors,
+                                         pc.output_directory, pc.use_log_y);
             plot.drawAndSave("pdf");
         }
     }

--- a/numu_plugins.json
+++ b/numu_plugins.json
@@ -97,7 +97,8 @@
           "channel_column": "incl_channel",
           "signal_group": "inclusive_strange_channels",
           "output_directory": "plots",
-          "plot_name": "selection_efficiency"
+          "plot_name": "selection_efficiency",
+          "log_y": false
         }
       ]
     },


### PR DESCRIPTION
## Summary
- add optional log-y axis for selection efficiency plots and connect graph points
- allow SelectionEfficiencyPlugin to toggle log scale via `log_y` config
- document `log_y` usage in sample plugin config

## Testing
- `bash ./.build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*
- `cd build && ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad859874e4832e8cbc289eadccfec7