### PR TITLE
Fix underflow/overflow bin handling in stacked histogram plots

### DIFF
--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -246,10 +246,8 @@ class StackedHistogramPlot : public HistogramPlotterBase {
         for (const auto &[key, hist] : mc_hists) {
             TH1D *h = (TH1D *)hist.get()->Clone();
             if (adjusted_edges.size() == orig_edges.size()) {
-                TH1D *rebinned = (TH1D *)h->Rebin(adjusted_edges.size() - 1, "",
-                                                  adjusted_edges.data());
-                delete h;
-                h = rebinned;
+                h->GetXaxis()->Set(adjusted_edges.size() - 1,
+                                   adjusted_edges.data());
             }
             const auto &stratum = registry.getStratumProperties(
                 category_column_, std::stoi(key.str()));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,9 +14,9 @@ add_executable(histogram_uncertainty_tests histogram_uncertainty_tests.cpp)
 
                     add_test(NAME test_systematics COMMAND test_systematics)
 
-                        add_executable(
-                            stacked_histogram_uniform_binning
-                                stacked_histogram_uniform_binning.cpp)
+        add_executable(
+            stacked_histogram_uniform_binning
+                stacked_histogram_uniform_binning.cpp)
 
                             target_link_libraries(
                                 stacked_histogram_uniform_binning PRIVATE libapp
@@ -27,3 +27,15 @@ add_executable(histogram_uncertainty_tests histogram_uncertainty_tests.cpp)
                                     NAME stacked_histogram_uniform_binning
                                         COMMAND
                                             stacked_histogram_uniform_binning)
+
+add_executable(
+    stacked_histogram_underflow_overflow
+    stacked_histogram_underflow_overflow.cpp)
+
+target_link_libraries(
+    stacked_histogram_underflow_overflow PRIVATE libapp libhist libplot
+                                               libutils Eigen3::Eigen
+                                               ${ROOT_LIBRARIES})
+
+add_test(NAME stacked_histogram_underflow_overflow
+         COMMAND stacked_histogram_underflow_overflow)

--- a/tests/stacked_histogram_underflow_overflow.cpp
+++ b/tests/stacked_histogram_underflow_overflow.cpp
@@ -1,0 +1,51 @@
+#include <cassert>
+#include <vector>
+
+#include "Eigen/Dense"
+#include "TCanvas.h"
+#include "TFile.h"
+#include "TH1.h"
+#include "THStack.h"
+
+#include "AnalysisTypes.h"
+#include "BinningDefinition.h"
+#include "RegionAnalysis.h"
+#include "StackedHistogramPlot.h"
+
+using namespace analysis;
+
+int main() {
+    // Binning with explicit underflow and overflow bins
+    std::vector<double> edges{-1.0, 0.0, 1.0, 2.0, 3.0, 4.0};
+    BinningDefinition binning(edges, "x", "x", {});
+
+    // Include counts for underflow and overflow
+    std::vector<double> counts{5.0, 1.0, 2.0, 3.0, 6.0};
+    Eigen::VectorXd sh_vec = Eigen::VectorXd::Zero(counts.size());
+    Eigen::MatrixXd shifts = sh_vec;
+    BinnedHistogram hist(binning, counts, shifts);
+
+    VariableResult result;
+    result.binning_ = binning;
+    result.total_mc_hist_ = hist;
+    result.strat_hists_.emplace(ChannelKey{std::string{"10"}}, hist);
+
+    RegionAnalysis region(RegionKey{std::string{"reg"}}, "reg");
+
+    StackedHistogramPlot plot("under_over_test", result, region,
+                              "inclusive_strange_channels", "test_plots", true,
+                              {}, true, false, "Events");
+    plot.drawAndSave("root");
+
+    TFile file("test_plots/under_over_test.root");
+    auto canvas = dynamic_cast<TCanvas *>(file.Get("under_over_test"));
+    assert(canvas);
+    auto stack = dynamic_cast<THStack *>(canvas->GetPrimitive("mc_stack"));
+    assert(stack);
+    TH1 *frame = stack->GetHistogram();
+    assert(frame);
+    assert(frame->GetNbinsX() == 5);
+    assert(std::abs(frame->GetBinContent(1) - 5.0) < 1e-6);
+    assert(std::abs(frame->GetBinContent(5) - 6.0) < 1e-6);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Preserve underflow/overflow bin contents by resizing axes rather than rebinnig in StackedHistogramPlot
- Add regression test ensuring underflow/overflow bins retain data

## Testing
- `cmake ..` *(fails: Could not find ROOT package)*
- `apt-get update` *(fails: repository InRelease files not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8bf8acb0832e9ebe0855e9833481