### PR TITLE
Save event displays as PNG

### DIFF
--- a/libplot/EventDisplay.h
+++ b/libplot/EventDisplay.h
@@ -197,7 +197,7 @@ class EventDisplay {
         }
         legend.Draw();
 
-        auto out_file = (out_dir / (tag + ".pdf")).string();
+        auto out_file = (out_dir / (tag + ".png")).string();
         canvas.SaveAs(out_file.c_str());
 
         delete hist_det;


### PR DESCRIPTION
## Summary
- Output event display images as PNG instead of PDF for better compatibility

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*
- `apt-get update` *(fails: 403 Forbidden when fetching Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68adb9ece57c832e8d6c0c57884d9cf1