### PR TITLE
Fix tests CMakeLists formatting

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,33 +1,15 @@
 add_executable(histogram_uncertainty_tests histogram_uncertainty_tests.cpp)
-    target_link_libraries(
-        histogram_uncertainty_tests PRIVATE libapp libhist libutils
-            Eigen3::Eigen ${
-                ROOT_LIBRARIES}) add_test(NAME histogram_uncertainty_tests
-                                              COMMAND
-                                                  histogram_uncertainty_tests)
+target_link_libraries(histogram_uncertainty_tests PRIVATE libapp libhist libutils Eigen3::Eigen ${ROOT_LIBRARIES})
+add_test(NAME histogram_uncertainty_tests COMMAND histogram_uncertainty_tests)
 
-        add_executable(test_systematics test_systematics.cpp) target_link_libraries(
-            test_systematics PRIVATE libapp libhist libutils libsyst
-                Eigen3::Eigen ${
-                    ROOT_LIBRARIES}) add_test(NAME test_systematics COMMAND
-                                                  test_systematics)
+add_executable(test_systematics test_systematics.cpp)
+target_link_libraries(test_systematics PRIVATE libapp libhist libutils libsyst Eigen3::Eigen ${ROOT_LIBRARIES})
+add_test(NAME test_systematics COMMAND test_systematics)
 
-            add_executable(stacked_histogram_uniform_binning
-                               stacked_histogram_uniform_binning.cpp)
-                target_link_libraries(
-                    stacked_histogram_uniform_binning PRIVATE libapp libhist
-                        libplot libutils Eigen3::Eigen ${ROOT_LIBRARIES})
-                    add_test(NAME stacked_histogram_uniform_binning COMMAND
-                                 stacked_histogram_uniform_binning)
+add_executable(stacked_histogram_uniform_binning stacked_histogram_uniform_binning.cpp)
+target_link_libraries(stacked_histogram_uniform_binning PRIVATE libapp libhist libplot libutils Eigen3::Eigen ${ROOT_LIBRARIES})
+add_test(NAME stacked_histogram_uniform_binning COMMAND stacked_histogram_uniform_binning)
 
-                        add_executable(
-                            stacked_histogram_underflow_overflow
-                                stacked_histogram_underflow_overflow.cpp)
-                            target_link_libraries(
-                                stacked_histogram_underflow_overflow PRIVATE
-                                    libapp libhist libplot libutils
-                                        Eigen3::Eigen ${ROOT_LIBRARIES})
-                                add_test(
-                                    NAME stacked_histogram_underflow_overflow
-                                        COMMAND
-                                            stacked_histogram_underflow_overflow)
+add_executable(stacked_histogram_underflow_overflow stacked_histogram_underflow_overflow.cpp)
+target_link_libraries(stacked_histogram_underflow_overflow PRIVATE libapp libhist libplot libutils Eigen3::Eigen ${ROOT_LIBRARIES})
+add_test(NAME stacked_histogram_underflow_overflow COMMAND stacked_histogram_underflow_overflow)


### PR DESCRIPTION
Split commands in tests/CMakeLists.txt across lines so CMake can parse and register tests