### PR TITLE
Ensure AnalysisDataLoader persists for EventDisplay

### DIFF
--- a/analyse.cpp
+++ b/analyse.cpp
@@ -85,6 +85,11 @@ int main(int argc, char *argv[]) {
 
             analysis::SystematicsProcessor sys_proc(knob_defs, universe_defs);
 
+            // Instantiate the data loader outside of the plugin infrastructure
+            // so that it remains alive for the entire duration of the analysis
+            // run.  Plugins such as EventDisplay rely on this object during
+            // their finalisation stage, so destroying it earlier would leave
+            // them without access to the required event data.
             analysis::AnalysisDataLoader data_loader(
                 rc_reg, ev_reg, beam, periods, ntuple_base_directory, true);
 

--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -29,6 +29,9 @@ namespace analysis {
 
 class AnalysisRunner {
   public:
+    // Receive a pre-existing AnalysisDataLoader by reference so that the loader
+    // can outlive this runner.  Plugins may retain pointers to the loader for
+    // use during finalisation.
     AnalysisRunner(AnalysisDataLoader &ldr, const SelectionRegistry &sel_reg,
                    const EventVariableRegistry &var_reg,
                    std::unique_ptr<IHistogramBooker> booker,

--- a/libplug/EventDisplayPlugin.cpp
+++ b/libplug/EventDisplayPlugin.cpp
@@ -1,10 +1,15 @@
 #include "EventDisplayPlugin.h"
 #include <nlohmann/json.hpp>
 
+// Factory function invoked by the plugin manager to create an instance of the
+// EventDisplayPlugin.
 extern "C" analysis::IAnalysisPlugin *createPlugin(const nlohmann::json &cfg) {
     return new analysis::EventDisplayPlugin(cfg);
 }
 
+// Optional context hook.  If present, AnalysisPluginManager calls this with a
+// pointer to the long-lived AnalysisDataLoader so that the plugin can fetch
+// event data during its finalisation step.
 extern "C" void setPluginContext(analysis::AnalysisDataLoader *loader) {
     analysis::EventDisplayPlugin::setLoader(loader);
 }


### PR DESCRIPTION
Pass AnalysisDataLoader by reference through AnalysisRunner to preserve plugin access