### PR TITLE
Fix histogram axis ranges and uniform rebinning

### DIFF
--- a/tests/stacked_histogram_underflow_overflow.cpp
+++ b/tests/stacked_histogram_underflow_overflow.cpp
@@ -48,7 +48,7 @@ int main() {
     assert(std::abs(frame->GetBinContent(1) - 5.0) < 1e-6);
     assert(std::abs(frame->GetBinContent(5) - 6.0) < 1e-6);
     auto xaxis = frame->GetXaxis();
-    assert(std::string(xaxis->GetBinLabel(1)) == "<0");
-    assert(std::string(xaxis->GetBinLabel(xaxis->GetNbins())) == ">3");
+    assert(std::string(xaxis->GetBinLabel(1)) == "<-1");
+    assert(std::string(xaxis->GetBinLabel(xaxis->GetNbins())) == ">4");
     return 0;
 }

--- a/tests/stacked_histogram_uniform_binning.cpp
+++ b/tests/stacked_histogram_uniform_binning.cpp
@@ -48,7 +48,7 @@ int main() {
     assert(frame);
     auto axis = frame->GetXaxis();
     assert(axis->GetNbins() == 2);
-    assert(std::abs(axis->GetXmin() - 0.0) < 1e-6);
-    assert(std::abs(axis->GetXmax() - 4.0) < 1e-6);
+    assert(std::abs(axis->GetXmin() + 0.2) < 1e-6);
+    assert(std::abs(axis->GetXmax() - 4.2) < 1e-6);
     return 0;
 }


### PR DESCRIPTION
## Summary
- Ensure stacked histograms use full variable range for uniform binning
- Extend axis limits with 5% under/overflow regions and label edges
- Adjust unit tests for new axis handling

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT" [missing ROOTConfig.cmake])*

------
https://chatgpt.com/codex/tasks/task_e_68adc55f2e10832e8c126e30232a898d