### PR TITLE
Enable log scale for selection efficiency plots

### DIFF
--- a/selection_efficiency_plugin.json
+++ b/selection_efficiency_plugin.json
@@ -24,7 +24,7 @@
           "signal_group": "inclusive_strange_channels",
           "output_directory": "plots",
           "plot_name": "selection_efficiency_inclusive",
-          "log_y": false
+          "log_y": true
         },
         {
           "region": "QUALITY_NUMU_CC_SEL",
@@ -33,7 +33,7 @@
           "signal_group": "exclusive_strange_channels",
           "output_directory": "plots",
           "plot_name": "selection_efficiency_exclusive",
-          "log_y": false
+          "log_y": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- enable logarithmic y-axis for inclusive selection efficiency plots
- enable logarithmic y-axis for exclusive selection efficiency plots

## Testing
- `cmake ..` (fails: Could not find package configuration file provided by "ROOT")

------
https://chatgpt.com/codex/tasks/task_e_68adcbc7f404832e96b2cbc29fdc15d3