### PR TITLE
Use neutrino energy in systematic breakdown

### DIFF
--- a/systematic_breakdown_plugin.json
+++ b/systematic_breakdown_plugin.json
@@ -16,7 +16,7 @@
       "path": "build/SystematicBreakdownPlugin.so",
       "plots": [
         {
-          "variable": "n_muons",
+          "variable": "neutrino energy",
           "region": "NUMU_CC_SEL",
           "output_directory": "plots",
           "fractional": true


### PR DESCRIPTION
## Summary
- Configure `SystematicBreakdownPlugin` to analyze the `neutrino energy` variable instead of `n_muons`.

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68add14c71e8832e999635b59b6544aa