### PR TITLE
build: pull latest changes before building

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -1,4 +1,7 @@
 REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+if git -C "${REPO_ROOT}" remote get-url origin >/dev/null 2>&1; then
+    git -C "${REPO_ROOT}" pull --ff-only || { return 1; }
+fi
 
 BUILD_DIR="${REPO_ROOT}/build"
 


### PR DESCRIPTION
## Summary
- ensure `.build.sh` runs `git pull --ff-only` if an `origin` remote exists

## Testing
- `. ./.build.sh` *(fails: Could not find a package configuration file provided by `ROOT`)*

------
https://chatgpt.com/codex/tasks/task_e_68adda4c2f88832e8a98f1f3230bbdbe