### PR TITLE
Fix under/overflow axis misalignment in StackedHistogramPlot

### DIFF
--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -27,22 +27,15 @@
 namespace analysis {
 class StackedHistogramPlot : public HistogramPlotterBase {
   public:
-    StackedHistogramPlot(
-        std::string plot_name, const VariableResult &var_result,
-        const RegionAnalysis &region_info, std::string category_column,
-        std::string output_directory = "plots", bool overlay_signal = true,
-        std::vector<Cut> cut_list = {}, bool annotate_numbers = true,
-        bool use_log_y = false, std::string y_axis_label = "Events",
-        int uniform_bins = -1, double uniform_min = 0.0,
-        double uniform_max = 0.0)
-        : HistogramPlotterBase(std::move(plot_name),
-                               std::move(output_directory)),
-          variable_result_(var_result), region_analysis_(region_info),
-          category_column_(std::move(category_column)),
-          overlay_signal_(overlay_signal), cuts_(cut_list),
-          annotate_numbers_(annotate_numbers), use_log_y_(use_log_y),
-          y_axis_label_(std::move(y_axis_label)),
-          use_uniform_binning_(uniform_bins > 0), uniform_bins_(uniform_bins),
+    StackedHistogramPlot(std::string plot_name, const VariableResult &var_result, const RegionAnalysis &region_info,
+                         std::string category_column, std::string output_directory = "plots",
+                         bool overlay_signal = true, std::vector<Cut> cut_list = {}, bool annotate_numbers = true,
+                         bool use_log_y = false, std::string y_axis_label = "Events", int uniform_bins = -1,
+                         double uniform_min = 0.0, double uniform_max = 0.0)
+        : HistogramPlotterBase(std::move(plot_name), std::move(output_directory)), variable_result_(var_result),
+          region_analysis_(region_info), category_column_(std::move(category_column)), overlay_signal_(overlay_signal),
+          cuts_(cut_list), annotate_numbers_(annotate_numbers), use_log_y_(use_log_y),
+          y_axis_label_(std::move(y_axis_label)), use_uniform_binning_(uniform_bins > 0), uniform_bins_(uniform_bins),
           uniform_min_(uniform_min), uniform_max_(uniform_max) {}
 
     ~StackedHistogramPlot() override {
@@ -65,8 +58,7 @@ class StackedHistogramPlot : public HistogramPlotterBase {
         stream << val;
         std::string s = stream.str();
         std::size_t pos = s.find('.');
-        for (int i = (pos == std::string::npos ? s.size() : pos) - 3; i > 0;
-             i -= 3) {
+        for (int i = (pos == std::string::npos ? s.size() : pos) - 3; i > 0; i -= 3) {
             s.insert(i, ",");
         }
         return s;
@@ -78,8 +70,7 @@ class StackedHistogramPlot : public HistogramPlotterBase {
         std::string line1 = "#bf{#muBooNE Simulation, Preliminary}";
 
         std::stringstream pot_stream;
-        pot_stream << std::scientific << std::setprecision(2)
-                   << region_analysis_.protonsOnTarget();
+        pot_stream << std::scientific << std::setprecision(2) << region_analysis_.protonsOnTarget();
         std::string pot_str = pot_stream.str();
         size_t e_pos = pot_str.find('e');
         if (e_pos != std::string::npos) {
@@ -88,8 +79,7 @@ class StackedHistogramPlot : public HistogramPlotterBase {
             pot_str += " #times 10^{" + std::to_string(exponent) + "}";
         }
 
-        std::map<std::string, std::string> beam_map = {
-            {"numi_fhc", "NuMI FHC"}, {"numi_rhc", "NuMI RHC"}};
+        std::map<std::string, std::string> beam_map = {{"numi_fhc", "NuMI FHC"}, {"numi_rhc", "NuMI RHC"}};
 
         std::string beam_name = region_analysis_.beamConfig();
         if (beam_map.count(beam_name)) {
@@ -107,9 +97,7 @@ class StackedHistogramPlot : public HistogramPlotterBase {
                     run_label = formatWithCommas(std::stod(run_label), 0);
                 } catch (...) {
                 }
-                runs_str +=
-                    run_label +
-                    (i < region_analysis_.runNumbers().size() - 1 ? ", " : "");
+                runs_str += run_label + (i < region_analysis_.runNumbers().size() - 1 ? ", " : "");
             }
         } else {
             runs_str = "N/A";
@@ -117,40 +105,31 @@ class StackedHistogramPlot : public HistogramPlotterBase {
 
         std::string line2 = "Beam: " + beam_name + ", Runs: " + runs_str;
         std::string line3 = "POT: " + pot_str;
-        std::string line4 =
-            "#it{Analysis Region}: " + region_analysis_.regionLabel();
-        std::string line5 =
-            "#it{Total Entries}: " + formatWithCommas(total_mc_events, 2);
+        std::string line4 = "#it{Analysis Region}: " + region_analysis_.regionLabel();
+        std::string line5 = "#it{Total Entries}: " + formatWithCommas(total_mc_events, 2);
 
         TLatex watermark;
         watermark.SetNDC();
         watermark.SetTextAlign(33);
         watermark.SetTextFont(62);
         watermark.SetTextSize(0.05);
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.03, line1.c_str());
+        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.03, line1.c_str());
         watermark.SetTextFont(42);
         watermark.SetTextSize(0.05 * 0.8);
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.09, line2.c_str());
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.15, line3.c_str());
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.21, line4.c_str());
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.27, line5.c_str());
+        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.09, line2.c_str());
+        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.15, line3.c_str());
+        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.21, line4.c_str());
+        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.27, line5.c_str());
     }
 
   protected:
     void draw(TCanvas &canvas) override {
-        log::info("StackedHistogramPlot::draw", "X-axis label from result:",
-                  variable_result_.binning_.getTexLabel().c_str());
+        log::info("StackedHistogramPlot::draw",
+                  "X-axis label from result:", variable_result_.binning_.getTexLabel().c_str());
         const double PLOT_LEGEND_SPLIT = 0.85;
         canvas.cd();
-        TPad *p_main =
-            new TPad("main_pad", "main_pad", 0.0, 0.0, 1.0, PLOT_LEGEND_SPLIT);
-        TPad *p_legend = new TPad("legend_pad", "legend_pad", 0.0,
-                                  PLOT_LEGEND_SPLIT, 1.0, 1.0);
+        TPad *p_main = new TPad("main_pad", "main_pad", 0.0, 0.0, 1.0, PLOT_LEGEND_SPLIT);
+        TPad *p_legend = new TPad("legend_pad", "legend_pad", 0.0, PLOT_LEGEND_SPLIT, 1.0, 1.0);
         p_main->SetTopMargin(0.01);
         p_main->SetBottomMargin(0.12);
         p_main->SetLeftMargin(0.12);
@@ -177,8 +156,7 @@ class StackedHistogramPlot : public HistogramPlotterBase {
         }
 
         double left_edge = orig_edges.empty() ? 0.0 : orig_edges.front();
-        double right_edge =
-            orig_edges.empty() ? 0.0 : orig_edges[orig_edges.size() - 1];
+        double right_edge = orig_edges.empty() ? 0.0 : orig_edges[orig_edges.size() - 1];
         double min_edge = left_edge;
         double max_edge = right_edge;
         if (orig_edges.size() >= 2) {
@@ -196,9 +174,7 @@ class StackedHistogramPlot : public HistogramPlotterBase {
         }
 
         std::sort(mc_hists.begin(), mc_hists.end(),
-                  [](const auto &a, const auto &b) {
-                      return a.second.getSum() < b.second.getSum();
-                  });
+                  [](const auto &a, const auto &b) { return a.second.getSum() < b.second.getSum(); });
         std::reverse(mc_hists.begin(), mc_hists.end());
 
         double total_mc_events = 0.0;
@@ -217,8 +193,7 @@ class StackedHistogramPlot : public HistogramPlotterBase {
 
         for (const auto &[key, hist] : mc_hists) {
             TH1D *h_leg = new TH1D();
-            const auto &stratum = registry.getStratumProperties(
-                category_column_, std::stoi(key.str()));
+            const auto &stratum = registry.getStratumProperties(category_column_, std::stoi(key.str()));
             h_leg->SetFillColor(stratum.fill_colour);
             h_leg->SetFillStyle(stratum.fill_style);
             h_leg->SetLineColor(kBlack);
@@ -230,9 +205,7 @@ class StackedHistogramPlot : public HistogramPlotterBase {
             }
 
             std::string legend_label =
-                annotate_numbers_
-                    ? tex_label + " : " + formatWithCommas(hist.getSum(), 2)
-                    : tex_label;
+                annotate_numbers_ ? tex_label + " : " + formatWithCommas(hist.getSum(), 2) : tex_label;
             legend_->AddEntry(h_leg, legend_label.c_str(), "f");
         }
 
@@ -252,15 +225,12 @@ class StackedHistogramPlot : public HistogramPlotterBase {
         for (const auto &[key, hist] : mc_hists) {
             TH1D *h = (TH1D *)hist.get()->Clone();
             if (use_uniform_binning_ && uniform_max_ > uniform_min_) {
-                TH1D *h_tmp = (TH1D *)h->Rebin(
-                    orig_edges.size() - 1,
-                    (std::string(h->GetName()) + "_rebin").c_str(),
-                    orig_edges.data());
+                TH1D *h_tmp = (TH1D *)h->Rebin(orig_edges.size() - 1, (std::string(h->GetName()) + "_rebin").c_str(),
+                                               orig_edges.data());
                 delete h;
                 h = h_tmp;
             }
-            const auto &stratum = registry.getStratumProperties(
-                category_column_, std::stoi(key.str()));
+            const auto &stratum = registry.getStratumProperties(category_column_, std::stoi(key.str()));
             h->SetFillColor(stratum.fill_colour);
             h->SetFillStyle(stratum.fill_style);
             h->SetLineColor(kBlack);
@@ -274,10 +244,9 @@ class StackedHistogramPlot : public HistogramPlotterBase {
             }
         }
 
-        double max_y = total_mc_hist_ ? total_mc_hist_->GetMaximum() +
-                                            total_mc_hist_->GetBinError(
-                                                total_mc_hist_->GetMaximumBin())
-                                      : 1.0;
+        double max_y = total_mc_hist_
+                           ? total_mc_hist_->GetMaximum() + total_mc_hist_->GetBinError(total_mc_hist_->GetMaximumBin())
+                           : 1.0;
         mc_stack_->Draw("HIST");
         mc_stack_->SetMaximum(max_y * (use_log_y_ ? 10 : 1.3));
         mc_stack_->SetMinimum(use_log_y_ ? 0.1 : 0.0);
@@ -287,13 +256,9 @@ class StackedHistogramPlot : public HistogramPlotterBase {
 
             for (int i = 1; i <= total_mc_hist_->GetNbinsX(); ++i) {
                 double stat_err = total_mc_hist_->GetBinError(i);
-                double syst_err = (i - 1 < total_syst_cov.GetNrows())
-                                      ? std::sqrt(total_syst_cov(i - 1, i - 1))
-                                      : 0.0;
-                double total_err =
-                    std::sqrt(stat_err * stat_err + syst_err * syst_err);
-                log::info("StackedHistogramPlot::draw", "Bin", i,
-                          "stat_err =", stat_err, "syst_err =", syst_err,
+                double syst_err = (i - 1 < total_syst_cov.GetNrows()) ? std::sqrt(total_syst_cov(i - 1, i - 1)) : 0.0;
+                double total_err = std::sqrt(stat_err * stat_err + syst_err * syst_err);
+                log::info("StackedHistogramPlot::draw", "Bin", i, "stat_err =", stat_err, "syst_err =", syst_err,
                           "total_err =", total_err);
                 total_mc_hist_->SetBinError(i, total_err);
             }
@@ -309,12 +274,10 @@ class StackedHistogramPlot : public HistogramPlotterBase {
 
         for (const auto &cut : cuts_) {
             double y_arrow_pos = max_y * 0.85;
-            double x_range = mc_stack_->GetXaxis()->GetXmax() -
-                             mc_stack_->GetXaxis()->GetXmin();
+            double x_range = mc_stack_->GetXaxis()->GetXmax() - mc_stack_->GetXaxis()->GetXmin();
             double arrow_length = x_range * 0.04;
 
-            TLine *line =
-                new TLine(cut.threshold, 0, cut.threshold, max_y * 1.3);
+            TLine *line = new TLine(cut.threshold, 0, cut.threshold, max_y * 1.3);
             line->SetLineColor(kRed);
             line->SetLineWidth(2);
             line->SetLineStyle(kDashed);
@@ -329,8 +292,7 @@ class StackedHistogramPlot : public HistogramPlotterBase {
                 x_start = cut.threshold;
                 x_end = cut.threshold - arrow_length;
             }
-            TArrow *arrow = new TArrow(x_start, y_arrow_pos, x_end, y_arrow_pos,
-                                       0.025, ">");
+            TArrow *arrow = new TArrow(x_start, y_arrow_pos, x_end, y_arrow_pos, 0.025, ">");
             arrow->SetLineColor(kRed);
             arrow->SetFillColor(kRed);
             arrow->SetLineWidth(2);
@@ -339,35 +301,34 @@ class StackedHistogramPlot : public HistogramPlotterBase {
         }
 
         TH1 *frame = mc_stack_->GetHistogram();
-        frame->GetXaxis()->SetTitle(
-            variable_result_.binning_.getTexLabel().c_str());
+        frame->GetXaxis()->SetTitle(variable_result_.binning_.getTexLabel().c_str());
         frame->GetYaxis()->SetTitle(y_axis_label_.c_str());
         frame->GetXaxis()->SetTitleOffset(1.0);
         frame->GetYaxis()->SetTitleOffset(1.0);
 
-        mc_stack_->GetXaxis()->SetLimits(min_edge, max_edge);
+        // Extend the axis range by directly modifying the frame histogram.
+        // Calling SetLimits on the THStack axis can distort the positions of
+        // the bins when variable-width binning is used.  Adjusting the frame
+        // histogram instead keeps the bins in their original locations while
+        // allowing underflow and overflow bins to remain visible.
+        frame->GetXaxis()->SetLimits(min_edge, max_edge);
         frame->GetXaxis()->SetNdivisions(520);
         frame->GetXaxis()->SetTickLength(0.02);
         if (orig_edges.size() >= 2) {
             std::ostringstream uf_label, of_label;
             uf_label << "<" << formatWithCommas(left_edge);
             of_label << ">" << formatWithCommas(right_edge);
-            frame->GetXaxis()->ChangeLabel(1, -1, -1, -1, -1, -1,
-                                           uf_label.str().c_str());
-            frame->GetXaxis()->ChangeLabel(frame->GetXaxis()->GetNbins(), -1,
-                                           -1, -1, -1, -1,
-                                           of_label.str().c_str());
+            frame->GetXaxis()->ChangeLabel(1, -1, -1, -1, -1, -1, uf_label.str().c_str());
+            frame->GetXaxis()->ChangeLabel(frame->GetXaxis()->GetNbins(), -1, -1, -1, -1, -1, of_label.str().c_str());
             double line_min = use_log_y_ ? 0.1 : 0.0;
             double line_max = max_y * (use_log_y_ ? 10 : 1.3);
             double tick_max = line_min + (line_max - line_min) * 0.05;
-            TLine *uf_edge =
-                new TLine(left_edge, line_min, left_edge, tick_max);
+            TLine *uf_edge = new TLine(left_edge, line_min, left_edge, tick_max);
             uf_edge->SetLineColorAlpha(kGray + 2, 0.4);
             uf_edge->SetLineWidth(2);
             uf_edge->Draw("same");
             cut_visuals_.push_back(uf_edge);
-            TLine *of_edge =
-                new TLine(right_edge, line_min, right_edge, tick_max);
+            TLine *of_edge = new TLine(right_edge, line_min, right_edge, tick_max);
             of_edge->SetLineColorAlpha(kGray + 2, 0.4);
             of_edge->SetLineWidth(2);
             of_edge->Draw("same");


### PR DESCRIPTION
Avoid distorting bin positions when extending x-axis range in `StackedHistogramPlot`