### PR TITLE
Add property-based tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake libeigen3-dev libtbb-dev nlohmann-json3-dev libtorch-dev root-system
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build -j$(nproc)
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,12 @@
+include(FetchContent)
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.4.0
+)
+FetchContent_MakeAvailable(Catch2)
+include(Catch)
+
 add_executable(histogram_uncertainty_tests histogram_uncertainty_tests.cpp)
 target_link_libraries(histogram_uncertainty_tests PRIVATE libapp libhist libutils Eigen3::Eigen ${ROOT_LIBRARIES})
 add_test(NAME histogram_uncertainty_tests COMMAND histogram_uncertainty_tests)
@@ -13,3 +22,7 @@ add_test(NAME stacked_histogram_uniform_binning COMMAND stacked_histogram_unifor
 add_executable(stacked_histogram_underflow_overflow stacked_histogram_underflow_overflow.cpp)
 target_link_libraries(stacked_histogram_underflow_overflow PRIVATE libapp libhist libplot libutils Eigen3::Eigen ${ROOT_LIBRARIES})
 add_test(NAME stacked_histogram_underflow_overflow COMMAND stacked_histogram_underflow_overflow)
+
+add_executable(histogram_property_tests histogram_property_tests.cpp)
+target_link_libraries(histogram_property_tests PRIVATE libapp libhist libutils Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
+catch_discover_tests(histogram_property_tests)

--- a/tests/histogram_property_tests.cpp
+++ b/tests/histogram_property_tests.cpp
@@ -1,0 +1,31 @@
+#include <catch2/catch_test_macros.hpp>
+#include <random>
+
+#include "HistogramUncertainty.h"
+
+using namespace analysis;
+
+TEST_CASE("HistogramUncertainty addition is commutative", "[property]") {
+    BinningDefinition bn({0.0, 1.0, 2.0}, "", "", {}, "");
+    std::mt19937 gen(std::random_device{}());
+    std::uniform_real_distribution<double> count_dist(0.0, 10.0);
+    std::uniform_real_distribution<double> err_dist(0.0, 1.0);
+
+    for (int i = 0; i < 100; ++i) {
+        std::vector<double> c1{count_dist(gen), count_dist(gen)};
+        Eigen::Vector2d e1(err_dist(gen), err_dist(gen));
+        HistogramUncertainty h1(bn, c1, e1);
+
+        std::vector<double> c2{count_dist(gen), count_dist(gen)};
+        Eigen::Vector2d e2(err_dist(gen), err_dist(gen));
+        HistogramUncertainty h2(bn, c2, e2);
+
+        auto sum1 = h1 + h2;
+        auto sum2 = h2 + h1;
+
+        REQUIRE(sum1.count(0) == Approx(sum2.count(0)));
+        REQUIRE(sum1.count(1) == Approx(sum2.count(1)));
+        REQUIRE(sum1.err(0) == Approx(sum2.err(0)));
+        REQUIRE(sum1.err(1) == Approx(sum2.err(1)));
+    }
+}


### PR DESCRIPTION
## Summary
- Add Catch2 property-based test for histogram addition commutativity
- Integrate Catch2 via CMake and discover tests
- Introduce GitHub Actions workflow to build and test project

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68aec5180c88832eb3e6416fcb55b510