### PR TITLE
Remove comments and adopt British spelling

### DIFF
--- a/analyse.cpp
+++ b/analyse.cpp
@@ -78,12 +78,6 @@ int main(int argc, char *argv[]) {
             }
 
             analysis::SystematicsProcessor sys_proc(knob_defs, universe_defs);
-
-            // Instantiate the data loader outside of the plugin infrastructure
-            // so that it remains alive for the entire duration of the analysis
-            // run.  Plugins such as EventDisplay rely on this object during
-            // their finalisation stage, so destroying it earlier would leave
-            // them without access to the required event data.
             analysis::AnalysisDataLoader data_loader(rc_reg, ev_reg, beam, periods, ntuple_base_directory, true);
 
             auto histogram_booker = std::make_unique<analysis::HistogramBooker>(strat_reg);

--- a/libapp/AnalysisDefinition.h
+++ b/libapp/AnalysisDefinition.h
@@ -334,6 +334,6 @@ class AnalysisDefinition {
     friend class RegionIterator;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -273,6 +273,6 @@ class AnalysisRunner {
     std::string serialisation_directory_{"variable_results"};
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/BinnedHistogram.h
+++ b/libapp/BinnedHistogram.h
@@ -113,6 +113,6 @@ class BinnedHistogram : public TNamed, private TH1DRenderer {
 
 using BinnedHistogramD = BinnedHistogram;
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/DataProcessor.h
+++ b/libapp/DataProcessor.h
@@ -28,6 +28,6 @@ class DataProcessor : public ISampleProcessor {
     ROOT::RDF::RResultPtr<TH1D> data_future_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/HistogramPolicy.h
+++ b/libapp/HistogramPolicy.h
@@ -13,12 +13,12 @@ namespace analysis {
 
 struct TH1DRenderer {
     mutable TH1D *hist = nullptr;
-    Color_t color = kBlack;
+    Color_t colour = kBlack;
     int hatch = 0;
     TString tex;
 
     void style(Color_t c, int h, const TString &t) {
-        color = c;
+        colour = c;
         hatch = h;
         tex = t;
     }
@@ -38,11 +38,11 @@ struct TH1DRenderer {
             hist->SetBinContent(i + 1, s.counts[i]);
             hist->SetBinError(i + 1, s.err(i));
         }
-        hist->SetLineColor(color);
-        hist->SetMarkerColor(color);
+        hist->SetLineColor(colour);
+        hist->SetMarkerColor(colour);
         hist->SetFillStyle(hatch);
         if (hatch)
-            hist->SetFillColor(color);
+            hist->SetFillColor(colour);
     }
 
     const TH1D *get(const HistogramUncertainty &s) const {
@@ -51,6 +51,6 @@ struct TH1DRenderer {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/HistogramUncertainty.h
+++ b/libapp/HistogramUncertainty.h
@@ -133,10 +133,6 @@ inline void HistogramUncertainty::addCovariance(const TMatrixDSym &cov_to_add) {
     Eigen::MatrixXd cov = base_cov + cov_e;
     Eigen::LLT<Eigen::MatrixXd> llt(cov);
     if (llt.info() == Eigen::NumericalIssue) {
-        // The covariance matrix is not positive definite. Project it to the
-        // nearest positive semidefinite matrix by removing negative
-        // eigenvalues before performing the decomposition. This prevents NaN
-        // entries in the resulting uncertainty shifts.
         Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(cov);
         Eigen::VectorXd evals = es.eigenvalues().cwiseMax(0.0);
         Eigen::MatrixXd cov_psd = es.eigenvectors() * evals.asDiagonal() *
@@ -286,6 +282,6 @@ HistogramUncertainty::operator/(const HistogramUncertainty &o) const {
     return tmp;
 }
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/ISampleProcessor.h
+++ b/libapp/ISampleProcessor.h
@@ -17,6 +17,6 @@ class ISampleProcessor {
     virtual void contributeTo(VariableResult &result) = 0;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -54,6 +54,6 @@ class MonteCarloProcessor : public ISampleProcessor {
     std::unordered_map<SampleVariation, ROOT::RDF::RResultPtr<TH1D>> variation_futures_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/RegionAnalysis.h
+++ b/libapp/RegionAnalysis.h
@@ -66,4 +66,4 @@ class RegionAnalysis {
     std::map<VariableKey, VariableResult> final_variables_;
 };
 
-  } // namespace analysis
+  }

--- a/libapp/Selection.h
+++ b/libapp/Selection.h
@@ -42,6 +42,6 @@ class Selection {
     std::string expr_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/SelectionRegistry.h
+++ b/libapp/SelectionRegistry.h
@@ -70,6 +70,6 @@ class SelectionRegistry {
     std::unordered_map<std::string, SelectionRule> rules_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/AnalysisDataLoader.h
+++ b/libdata/AnalysisDataLoader.h
@@ -128,6 +128,6 @@ class AnalysisDataLoader {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/BlipProcessor.h
+++ b/libdata/BlipProcessor.h
@@ -70,6 +70,6 @@ class BlipProcessor : public IEventProcessor {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/EventVariableRegistry.h
+++ b/libdata/EventVariableRegistry.h
@@ -216,6 +216,6 @@ class EventVariableRegistry {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/IEventProcessor.h
+++ b/libdata/IEventProcessor.h
@@ -24,6 +24,6 @@ class IEventProcessor {
     std::unique_ptr<IEventProcessor> next_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/MuonSelectionProcessor.h
+++ b/libdata/MuonSelectionProcessor.h
@@ -90,6 +90,6 @@ class MuonSelectionProcessor : public IEventProcessor {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/ReconstructionProcessor.h
+++ b/libdata/ReconstructionProcessor.h
@@ -39,6 +39,6 @@ class ReconstructionProcessor : public IEventProcessor {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/RunConfig.h
+++ b/libdata/RunConfig.h
@@ -48,6 +48,6 @@ struct RunConfig {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/RunConfigLoader.h
+++ b/libdata/RunConfigLoader.h
@@ -34,6 +34,6 @@ class RunConfigLoader {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/RunConfigRegistry.h
+++ b/libdata/RunConfigRegistry.h
@@ -37,6 +37,6 @@ class RunConfigRegistry {
     std::map<std::string, RunConfig> configs_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/SampleDefinition.h
+++ b/libdata/SampleDefinition.h
@@ -177,6 +177,6 @@ class SampleDefinition {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/WeightProcessor.h
+++ b/libdata/WeightProcessor.h
@@ -66,6 +66,6 @@ class WeightProcessor : public IEventProcessor {
     double total_run_pot_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/BinningDefinition.h
+++ b/libhist/BinningDefinition.h
@@ -57,6 +57,6 @@ class BinningDefinition {
     StratifierKey strat_key_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/HistogramBooker.h
+++ b/libhist/HistogramBooker.h
@@ -48,6 +48,6 @@ class HistogramBooker : public IHistogramBooker {
     StratifierManager stratifier_manager_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/IHistogramBooker.h
+++ b/libhist/IHistogramBooker.h
@@ -21,6 +21,6 @@ class IHistogramBooker {
                         const ROOT::RDF::TH1DModel &model) = 0;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/IHistogramStratifier.h
+++ b/libhist/IHistogramStratifier.h
@@ -63,6 +63,6 @@ class IHistogramStratifier {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/ScalarStratifier.h
+++ b/libhist/ScalarStratifier.h
@@ -37,6 +37,6 @@ class ScalarStratifier : public IHistogramStratifier {
     StratifierRegistry &stratifier_registry_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/StratifierManager.h
+++ b/libhist/StratifierManager.h
@@ -57,6 +57,6 @@ class StratifierManager {
         cache_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/StratifierRegistry.h
+++ b/libhist/StratifierRegistry.h
@@ -313,6 +313,6 @@ class StratifierRegistry {
     std::map<std::string, std::vector<int>> signal_channel_groups_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/VectorStratifier.h
+++ b/libhist/VectorStratifier.h
@@ -46,6 +46,6 @@ class VectorStratifier : public IHistogramStratifier {
     StratifierRegistry &strat_registry_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/EventDisplay.h
+++ b/libplot/EventDisplay.h
@@ -77,6 +77,6 @@ class SemanticDisplayPlot : public EventDisplayBase {
     std::vector<int> data_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/HistogramCut.h
+++ b/libplot/HistogramCut.h
@@ -10,6 +10,6 @@ struct Cut {
     CutDirection direction;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/HistogramPlotterBase.h
+++ b/libplot/HistogramPlotterBase.h
@@ -76,6 +76,6 @@ class HistogramPlotterBase {
     std::string output_directory_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/OccupancyMatrixPlot.h
+++ b/libplot/OccupancyMatrixPlot.h
@@ -41,6 +41,6 @@ class OccupancyMatrixPlot : public HistogramPlotterBase {
     TH2F *hist_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -227,6 +227,6 @@ class PlotCatalog {
     std::filesystem::path output_directory_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/RocCurvePlot.h
+++ b/libplot/RocCurvePlot.h
@@ -44,6 +44,6 @@ class RocCurvePlot : public HistogramPlotterBase {
     std::vector<double> background_rej_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/SelectionEfficiencyPlot.h
+++ b/libplot/SelectionEfficiencyPlot.h
@@ -88,6 +88,6 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
     bool use_log_y_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -305,12 +305,6 @@ class StackedHistogramPlot : public HistogramPlotterBase {
         frame->GetYaxis()->SetTitle(y_axis_label_.c_str());
         frame->GetXaxis()->SetTitleOffset(1.0);
         frame->GetYaxis()->SetTitleOffset(1.0);
-
-        // Extend the axis range by directly modifying the frame histogram.
-        // Calling SetLimits on the THStack axis can distort the positions of
-        // the bins when variable-width binning is used.  Adjusting the frame
-        // histogram instead keeps the bins in their original locations while
-        // allowing underflow and overflow bins to remain visible.
         frame->GetXaxis()->SetLimits(min_edge, max_edge);
         frame->GetXaxis()->SetNdivisions(520);
         frame->GetXaxis()->SetTickLength(0.02);
@@ -374,6 +368,6 @@ class StackedHistogramPlot : public HistogramPlotterBase {
     std::vector<TObject *> cut_visuals_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/SystematicBreakdownPlot.cpp
+++ b/libplot/SystematicBreakdownPlot.cpp
@@ -46,7 +46,7 @@ void SystematicBreakdownPlot::draw(TCanvas &canvas) {
     legend_->SetFillStyle(0);
     legend_->SetTextFont(42);
 
-    int color = kRed + 1;
+    int colour = kRed + 1;
     for (const auto &[key, cov] : variable_result_.covariance_matrices_) {
         TH1D *hist = new TH1D(key.str().c_str(), "", nbins, edges.data());
         const int n = cov.GetNrows();
@@ -61,12 +61,12 @@ void SystematicBreakdownPlot::draw(TCanvas &canvas) {
                 hist->SetBinContent(i + 1, 0.0);
             }
         }
-        hist->SetFillColor(color);
+        hist->SetFillColor(colour);
         hist->SetLineColor(kBlack);
         stack_->Add(hist);
         legend_->AddEntry(hist, key.str().c_str(), "f");
         histograms_.push_back(hist);
-        ++color;
+        ++colour;
     }
 
     stack_->Draw("hist");
@@ -77,4 +77,4 @@ void SystematicBreakdownPlot::draw(TCanvas &canvas) {
     legend_->Draw();
 }
 
-} // namespace analysis
+}

--- a/libplot/UnstackedHistogramPlot.h
+++ b/libplot/UnstackedHistogramPlot.h
@@ -301,6 +301,6 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
     std::vector<TObject *> cut_visuals_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/AnalysisPluginManager.h
+++ b/libplug/AnalysisPluginManager.h
@@ -78,5 +78,5 @@ class AnalysisPluginManager {
     std::vector<void *> handles_;
 };
 
-} // namespace analysis
+}
 #endif

--- a/libplug/EventDisplayPlugin.cpp
+++ b/libplug/EventDisplayPlugin.cpp
@@ -1,15 +1,8 @@
 #include "EventDisplayPlugin.h"
 #include <nlohmann/json.hpp>
-
-// Factory function invoked by the plugin manager to create an instance of the
-// EventDisplayPlugin.
 extern "C" analysis::IAnalysisPlugin *createPlugin(const nlohmann::json &cfg) {
     return new analysis::EventDisplayPlugin(cfg);
 }
-
-// Optional context hook.  If present, AnalysisPluginManager calls this with a
-// pointer to the long-lived AnalysisDataLoader so that the plugin can fetch
-// event data during its finalisation step.
 extern "C" void setPluginContext(analysis::AnalysisDataLoader *loader) {
     analysis::EventDisplayPlugin::setLoader(loader);
 }

--- a/libplug/EventDisplayPlugin.h
+++ b/libplug/EventDisplayPlugin.h
@@ -129,6 +129,6 @@ class EventDisplayPlugin : public IAnalysisPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/IAnalysisPlugin.h
+++ b/libplug/IAnalysisPlugin.h
@@ -29,5 +29,5 @@ class IAnalysisPlugin {
     virtual void onFinalisation(const RegionAnalysisMap &results) = 0;
 };
 
-} // namespace analysis
+}
 #endif

--- a/libplug/OccupancyMatrixPlugin.h
+++ b/libplug/OccupancyMatrixPlugin.h
@@ -115,6 +115,6 @@ class OccupancyMatrixPlugin : public IAnalysisPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/RegionsPlugin.h
+++ b/libplug/RegionsPlugin.h
@@ -56,6 +56,6 @@ class RegionsPlugin : public IAnalysisPlugin {
     nlohmann::json config_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/RocCurvePlugin.h
+++ b/libplug/RocCurvePlugin.h
@@ -180,6 +180,6 @@ class RocCurvePlugin : public IAnalysisPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/SelectionEfficiencyPlugin.h
+++ b/libplug/SelectionEfficiencyPlugin.h
@@ -160,6 +160,6 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/SnapshotPlugin.h
+++ b/libplug/SnapshotPlugin.h
@@ -17,10 +17,10 @@ namespace analysis {
 class SnapshotPlugin : public IAnalysisPlugin {
   public:
     struct SnapshotConfig {
-        std::string selection_rule; // key in SelectionRegistry
-        Selection selection;        // resolved selection
+        std::string selection_rule;
+        Selection selection;
         std::string output_directory{"snapshots"};
-        std::vector<std::string> columns; // columns to persist
+        std::vector<std::string> columns;
     };
 
     explicit SnapshotPlugin(const nlohmann::json &cfg) {
@@ -80,6 +80,6 @@ class SnapshotPlugin : public IAnalysisPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/StackedHistogramPlugin.h
+++ b/libplug/StackedHistogramPlugin.h
@@ -156,6 +156,6 @@ class StackedHistogramPlugin : public IAnalysisPlugin {
     std::map<RegionKey, std::map<std::string, std::vector<Cut>>> region_cuts_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/SystematicBreakdownPlugin.h
+++ b/libplug/SystematicBreakdownPlugin.h
@@ -73,6 +73,6 @@ class SystematicBreakdownPlugin : public IAnalysisPlugin {
     std::vector<PlotConfig> plots_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/UnstackedHistogramPlugin.h
+++ b/libplug/UnstackedHistogramPlugin.h
@@ -150,6 +150,6 @@ class UnstackedHistogramPlugin : public IAnalysisPlugin {
     std::map<RegionKey, std::map<std::string, std::vector<Cut>>> region_cuts_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/VariablesPlugin.h
+++ b/libplug/VariablesPlugin.h
@@ -87,6 +87,6 @@ class VariablesPlugin : public IAnalysisPlugin {
     nlohmann::json config_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libsyst/DetectorSystematicStrategy.h
+++ b/libsyst/DetectorSystematicStrategy.h
@@ -115,6 +115,6 @@ class DetectorSystematicStrategy : public SystematicStrategy {
     std::string identifier_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libsyst/SystematicStrategy.h
+++ b/libsyst/SystematicStrategy.h
@@ -57,6 +57,6 @@ class SystematicStrategy {
                         SystematicFutures &futures) = 0;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libsyst/SystematicsProcessor.h
+++ b/libsyst/SystematicsProcessor.h
@@ -122,6 +122,6 @@ class SystematicsProcessor {
     SystematicFutures systematic_futures_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -39,12 +39,6 @@ class UniverseSystematicStrategy : public SystematicStrategy {
                 return 1.0;
             };
 
-            // ROOT's RDataFrame does not provide an overload of Histo1D that
-            // takes a custom weight functor together with a branch name for the
-            // variable to be histogrammed.  Instead we first "Define" a new
-            // temporary column holding the weight for this universe and then
-            // pass the name of that column to Histo1D as the weight.
-
             auto uni_weight_name = "_uni_w_" + std::to_string(u);
             auto node = rnode.Define(uni_weight_name, weight, {vector_name_});
 
@@ -134,6 +128,6 @@ class UniverseSystematicStrategy : public SystematicStrategy {
     bool store_universe_hists_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libsyst/WeightSystematicStrategy.h
+++ b/libsyst/WeightSystematicStrategy.h
@@ -100,6 +100,6 @@ class WeightSystematicStrategy : public SystematicStrategy {
     std::string dn_column_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/AnalysisKey.h
+++ b/libutils/AnalysisKey.h
@@ -29,7 +29,7 @@ template <class Tag> class AnalysisKey {
     std::string v_;
 };
 
-} // namespace analysis
+}
 
 namespace std {
 template <class Tag> struct hash<analysis::AnalysisKey<Tag>> {
@@ -37,4 +37,4 @@ template <class Tag> struct hash<analysis::AnalysisKey<Tag>> {
         return std::hash<std::string>()(k.str());
     }
 };
-} // namespace std
+}

--- a/libutils/AnalysisLogger.h
+++ b/libutils/AnalysisLogger.h
@@ -144,8 +144,8 @@ template <typename... Args>
 inline void fatal(const std::string &ctx, const Args &...args) {
     AnalysisLogger::getInstance().fatal(ctx, args...);
 }
-} // namespace log
+}
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/AnalysisTypes.h
+++ b/libutils/AnalysisTypes.h
@@ -79,6 +79,6 @@ struct SampleDatasetGroup {
 
 using SampleDatasetGroupMap = std::unordered_map<SampleKey, SampleDatasetGroup>;
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/DynamicBinning.h
+++ b/libutils/DynamicBinning.h
@@ -406,6 +406,6 @@ class DynamicBinning {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/KeyTypes.h
+++ b/libutils/KeyTypes.h
@@ -25,6 +25,6 @@ using StratifierKey = AnalysisKey<StratifierKeyTag>;
 using StratumKey = AnalysisKey<StratumKeyTag>;
 using SelectionKey = AnalysisKey<SelectionKeyTag>;
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/SampleTypes.h
+++ b/libutils/SampleTypes.h
@@ -56,6 +56,6 @@ inline std::string variationToKey(SampleVariation var) {
     }
 }
 
-} // namespace analysis
+}
 
 #endif

--- a/tests/histogram_uncertainty_tests.cpp
+++ b/tests/histogram_uncertainty_tests.cpp
@@ -47,12 +47,8 @@ int main() {
     auto corr2 = h3.corrMat();
     double expected_corr = 0.02 / std::sqrt((0.01 + 0.01) * (0.04 + 0.04));
     assert(std::abs(corr2(0, 1) - expected_corr) < 1e-12);
-
-    // Verify default-constructed binning behaves sensibly
     BinningDefinition empty_bn;
     assert(empty_bn.getBinNumber() == 0);
-
-    // Ensure adding a populated histogram to an empty one works
     HistogramUncertainty empty_hist;
     auto h_sum2 = empty_hist + h1;
     assert(h_sum2.size() == h1.size());

--- a/tests/stacked_histogram_underflow_overflow.cpp
+++ b/tests/stacked_histogram_underflow_overflow.cpp
@@ -15,11 +15,8 @@
 using namespace analysis;
 
 int main() {
-    // Binning with explicit underflow and overflow bins
     std::vector<double> edges{-1.0, 0.0, 1.0, 2.0, 3.0, 4.0};
     BinningDefinition binning(edges, "x", "x", {});
-
-    // Include counts for underflow and overflow
     std::vector<double> counts{5.0, 1.0, 2.0, 3.0, 6.0};
     Eigen::VectorXd sh_vec = Eigen::VectorXd::Zero(counts.size());
     Eigen::MatrixXd shifts = sh_vec;

--- a/tests/stacked_histogram_uniform_binning.cpp
+++ b/tests/stacked_histogram_uniform_binning.cpp
@@ -16,11 +16,8 @@
 using namespace analysis;
 
 int main() {
-    // Original variable binning with four bins
     std::vector<double> edges{0.0, 1.0, 2.0, 3.0, 4.0};
     BinningDefinition binning(edges, "x", "x", {});
-
-    // Create a simple histogram with counts in each bin
     std::vector<double> counts{1.0, 2.0, 3.0, 4.0};
     Eigen::VectorXd sh_vec = Eigen::VectorXd::Zero(counts.size());
     Eigen::MatrixXd shifts = sh_vec;
@@ -32,8 +29,6 @@ int main() {
     result.strat_hists_.emplace(ChannelKey{std::string{"10"}}, hist);
 
     RegionAnalysis region(RegionKey{std::string{"reg"}}, "reg");
-
-    // Request uniform binning with two bins spanning [0,4]
     StackedHistogramPlot plot("test_plot", result, region,
                               "inclusive_strange_channels", "test_plots", true,
                               {}, true, false, "Events", 2, 0.0, 4.0);

--- a/tests/test_systematics.cpp
+++ b/tests/test_systematics.cpp
@@ -19,10 +19,6 @@ int main() {
     std::vector<double> x{0.5, 1.5};
     std::vector<double> knob_up{1.2, 0.8};
     std::vector<double> knob_dn{0.8, 1.2};
-    // Two toy universes that migrate events between bins. The first universe
-    // doubles the weight in the lower bin while removing it from the upper bin
-    // and the second does the opposite. This setup should yield a covariance
-    // matrix with anti-correlated bins.
     std::vector<ROOT::RVec<unsigned short>> uni_w{
         ROOT::RVec<unsigned short>{2, 0}, ROOT::RVec<unsigned short>{0, 2}};
 
@@ -83,8 +79,6 @@ int main() {
                     std::sqrt(1.55)) < 1e-6);
     assert(std::abs(result.nominal_with_band_.getBinError(1) -
                     std::sqrt(1.55)) < 1e-6);
-
-    // By default no per-universe histograms should be stored
     assert(result.universe_projected_hists_.empty());
 
     return 0;


### PR DESCRIPTION
Strip all comments across the codebase, including redundant namespace annotations