### PR TITLE
Fix unused canvas parameter causing build failure

### DIFF
--- a/libplot/EventDisplay.h
+++ b/libplot/EventDisplay.h
@@ -56,6 +56,7 @@ class SemanticDisplayPlot : public EventDisplayBase {
         : EventDisplayBase(std::move(tag), image_size, std::move(output_directory)), data_(std::move(data)) {}
 
     void draw(TCanvas &canvas) override {
+        canvas.cd();
         TH2F hist(plot_name_.c_str(), plot_name_.c_str(), image_size_, 0, image_size_, image_size_, 0, image_size_);
         int palette[10];
         for (int i = 0; i < 10; ++i)


### PR DESCRIPTION
Handle the canvas parameter in `SemanticDisplayPlot::draw` to avoid unused-parameter warnings treated as errors