### PR TITLE
Use ROOT object for analysis results

### DIFF
--- a/libapp/AnalysisResult.h
+++ b/libapp/AnalysisResult.h
@@ -1,0 +1,41 @@
+#ifndef ANALYSIS_RESULT_H
+#define ANALYSIS_RESULT_H
+
+#include "TFile.h"
+#include "TObject.h"
+
+#include "AnalysisTypes.h"
+#include "RegionAnalysis.h"
+
+#include <memory>
+#include <string>
+
+namespace analysis {
+
+class AnalysisResult : public TObject {
+  public:
+    AnalysisResult() = default;
+    explicit AnalysisResult(RegionAnalysisMap regions) : regions_(std::move(regions)) {}
+
+    const RegionAnalysisMap &regions() const noexcept { return regions_; }
+    RegionAnalysisMap &regions() noexcept { return regions_; }
+
+    void saveToFile(const std::string &path) const {
+        TFile outfile(path.c_str(), "RECREATE");
+        outfile.WriteObject(this, "analysis_result");
+        outfile.Close();
+    }
+
+    static std::unique_ptr<AnalysisResult> loadFromFile(const std::string &path) {
+        TFile infile(path.c_str(), "READ");
+        auto *ptr = infile.Get<AnalysisResult>("analysis_result");
+        return ptr ? std::unique_ptr<AnalysisResult>(static_cast<AnalysisResult *>(ptr->Clone())) : nullptr;
+    }
+
+  private:
+    RegionAnalysisMap regions_;
+};
+
+} // namespace analysis
+
+#endif

--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -2,7 +2,6 @@
 #define ANALYSIS_RUNNER_H
 
 #include <algorithm>
-#include <filesystem>
 #include <map>
 #include <memory>
 #include <numeric>
@@ -10,13 +9,13 @@
 #include <string>
 #include <unordered_map>
 
-#include "TFile.h"
 #include <nlohmann/json.hpp>
 
 #include "AnalysisDataLoader.h"
 #include "AnalysisDefinition.h"
 #include "AnalysisLogger.h"
 #include "AnalysisPluginManager.h"
+#include "AnalysisResult.h"
 #include "AnalysisTypes.h"
 #include "DataProcessor.h"
 #include "DynamicBinning.h"
@@ -35,15 +34,13 @@ class AnalysisRunner {
   public:
     AnalysisRunner(AnalysisDataLoader &ldr, const SelectionRegistry &sel_reg, const EventVariableRegistry &var_reg,
                    std::unique_ptr<IHistogramBooker> booker, SystematicsProcessor &sys_proc,
-                   const nlohmann::json &plgn_cfg, bool serialise_results = false,
-                   std::string serialisation_dir = "variable_results")
+                   const nlohmann::json &plgn_cfg)
         : analysis_definition_(sel_reg, var_reg), data_loader_(ldr), selection_registry_(sel_reg),
-          systematics_processor_(sys_proc), histogram_booker_(std::move(booker)), serialise_results_(serialise_results),
-          serialisation_directory_(std::move(serialisation_dir)) {
+          systematics_processor_(sys_proc), histogram_booker_(std::move(booker)) {
         plugin_manager.loadPlugins(plgn_cfg, &data_loader_);
     }
 
-    RegionAnalysisMap run() {
+    AnalysisResult run() {
         log::info("AnalysisRunner::run", "Initiating orchestrated analysis run...");
         plugin_manager.notifyInitialisation(analysis_definition_, selection_registry_);
 
@@ -194,13 +191,6 @@ class AnalysisRunner {
 
                 result.printSummary();
 
-                if (serialise_results_) {
-                    serialiseVariableResult(region_handle.key_, var_key, result);
-                    result.raw_detvar_hists_.clear();
-                    result.variation_hists_.clear();
-                    result.universe_projected_hists_.clear();
-                }
-
                 region_analysis.addFinalVariable(var_key, std::move(result));
 
                 log::info("AnalysisRunner::run", "Variable pipeline concluded (", var_index, "/", var_total,
@@ -218,61 +208,18 @@ class AnalysisRunner {
         }
 
         plugin_manager.notifyFinalisation(analysis_regions);
-        return analysis_regions;
+        return AnalysisResult(std::move(analysis_regions));
     }
 
   private:
-    void serialiseVariableResult(const RegionKey &region, const VariableKey &variable,
-                                 const VariableResult &result) const {
-        namespace fs = std::filesystem;
-        fs::path region_dir = fs::path(serialisation_directory_) / region.str();
-        fs::create_directories(region_dir);
-        fs::path file_path = region_dir / (variable.str() + ".root");
-
-        TFile outfile(file_path.c_str(), "RECREATE");
-        auto write_hist = [&](const std::string &name, const BinnedHistogram &hist) {
-            if (const TH1D *h = hist.get()) {
-                h->Write(name.c_str());
-            }
-        };
-
-        write_hist("data", result.data_hist_);
-        write_hist("total_mc", result.total_mc_hist_);
-        for (const auto &[key, hist] : result.strat_hists_) {
-            write_hist("strat_" + key.str(), hist);
-        }
-        for (const auto &[sample_key, var_map] : result.raw_detvar_hists_) {
-            for (const auto &[variation, hist] : var_map) {
-                write_hist("detvar_" + sample_key.str() + "_" + variationToKey(variation), hist);
-            }
-        }
-        for (const auto &[key, hist] : result.variation_hists_) {
-            write_hist("variation_" + key.str(), hist);
-        }
-        for (const auto &[key, vec] : result.universe_projected_hists_) {
-            for (size_t i = 0; i < vec.size(); ++i) {
-                write_hist("universe_" + key.str() + "_" + std::to_string(i), vec[i]);
-            }
-        }
-        for (const auto &[key, mat] : result.covariance_matrices_) {
-            mat.Write(("covariance_" + key.str()).c_str());
-        }
-        result.total_covariance_.Write("total_covariance");
-        result.total_correlation_.Write("total_correlation");
-        write_hist("nominal_with_band", result.nominal_with_band_);
-        outfile.Close();
-    }
-
     AnalysisPluginManager plugin_manager;
     AnalysisDefinition analysis_definition_;
     AnalysisDataLoader &data_loader_;
     const SelectionRegistry &selection_registry_;
     SystematicsProcessor &systematics_processor_;
     std::unique_ptr<IHistogramBooker> histogram_booker_;
-    bool serialise_results_{false};
-    std::string serialisation_directory_{"variable_results"};
 };
 
-}
+} // namespace analysis
 
 #endif


### PR DESCRIPTION
## Summary
- Replace manual histogram serialisation with direct `AnalysisResult` output from `AnalysisRunner`
- Add `AnalysisResult` ROOT object with helpers to save and load results

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT"; repo not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeefeab18832eb99220e18754ec00