### PR TITLE
Run tests after build

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -14,4 +14,6 @@ cmake "${REPO_ROOT}" || { cd "${REPO_ROOT}"; return 1; }
 
 make -j"${NUM_CORES}" || { cd "${REPO_ROOT}"; return 1; }
 
+ctest || { ctest --rerun-failed --output-on-failure; cd "${REPO_ROOT}"; return 1; }
+
 cd "${REPO_ROOT}" || { return 0; }


### PR DESCRIPTION
## Summary
- Run tests at the end of the build and rerun failures with `--rerun-failed --output-on-failure`

## Testing
- `source .build.sh` *(fails: Could not find a package configuration file provided by "ROOT" with names: ROOTConfig.cmake, root-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68af06f5857c832e92595ca8b50eb281