### PR TITLE
Fix covariance normalization and weight correlations

### DIFF
--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -96,8 +96,7 @@ class UniverseSystematicStrategy : public SystematicStrategy {
         double n_universes = static_cast<double>(processed_universes);
         for (int i = 0; i < n; ++i) {
             for (int j = 0; j <= i; ++j) {
-                double val =
-                    n_universes == 0 ? 0 : cov(i, j) / (n_universes * n_universes);
+                double val = n_universes == 0 ? 0 : cov(i, j) / n_universes;
                 cov(i, j) = val;
                 cov(j, i) = val;
             }

--- a/libsyst/WeightSystematicStrategy.h
+++ b/libsyst/WeightSystematicStrategy.h
@@ -78,9 +78,15 @@ class WeightSystematicStrategy : public SystematicStrategy {
         result.variation_hists_[up_key] = hu;
         result.variation_hists_[dn_key] = hd;
 
+        std::vector<double> diff(n);
+        for (int i = 0; i < n; ++i)
+            diff[i] = 0.5 * (hu.getBinContent(i) - hd.getBinContent(i));
         for (int i = 0; i < n; ++i) {
-            double d = 0.5 * (hu.getBinContent(i) - hd.getBinContent(i));
-            cov(i, i) = d * d;
+            for (int j = 0; j <= i; ++j) {
+                double val = diff[i] * diff[j];
+                cov(i, j) = val;
+                cov(j, i) = val;
+            }
         }
         log::debug("WeightSystematicStrategy::computeCovariance", identifier_,
                    "covariance calculated");


### PR DESCRIPTION
## Summary
- Normalize universe systematic covariance by number of processed universes
- Include bin-to-bin correlations when computing weight systematic covariance

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68af179f10b4832e9ec4939e3b9b41c5