### PR TITLE
Reintroduce two-stage analysis and plotting workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ add_subdirectory(tests)
 
 set(ANALYSIS_EXECUTABLES
     analyse
+    plot
 )
 
 foreach(exe ${ANALYSIS_EXECUTABLES})

--- a/analyse.cpp
+++ b/analyse.cpp
@@ -5,10 +5,8 @@
 #include <memory>
 #include <string>
 #include <vector>
-
 #include <ROOT/RDataFrame.hxx>
 #include <nlohmann/json.hpp>
-
 #include "AnalysisDataLoader.h"
 #include "AnalysisLogger.h"
 #include "AnalysisRunner.h"
@@ -19,10 +17,7 @@
 #include "SelectionRegistry.h"
 #include "StratifierRegistry.h"
 #include "SystematicsProcessor.h"
-
 namespace fs = std::filesystem;
-
-// Load and parse a JSON file, validating that it exists and is readable.
 static nlohmann::json loadJsonFile(const std::string &path) {
     if (!fs::exists(path) || !fs::is_regular_file(path)) {
         analysis::log::fatal("analyse::loadJsonFile", "File inaccessible:", path);
@@ -35,112 +30,66 @@ static nlohmann::json loadJsonFile(const std::string &path) {
     }
     return nlohmann::json::parse(file);
 }
-
-static analysis::SystematicsProcessor makeSystematicsProcessor(
-    const analysis::EventVariableRegistry &ev_reg) {
+static analysis::SystematicsProcessor makeSystematicsProcessor(const analysis::EventVariableRegistry &ev_reg) {
     std::vector<analysis::KnobDef> knob_defs;
     knob_defs.reserve(ev_reg.knobVariations().size());
-    std::transform(ev_reg.knobVariations().begin(), ev_reg.knobVariations().end(),
-                   std::back_inserter(knob_defs),
-                   [](const auto &kv) {
-                       return analysis::KnobDef{kv.first, kv.second.first, kv.second.second};
-                   });
-
+    std::transform(ev_reg.knobVariations().begin(), ev_reg.knobVariations().end(), std::back_inserter(knob_defs), [](const auto &kv) { return analysis::KnobDef{kv.first, kv.second.first, kv.second.second}; });
     std::vector<analysis::UniverseDef> universe_defs;
     universe_defs.reserve(ev_reg.multiUniverseVariations().size());
-    std::transform(ev_reg.multiUniverseVariations().begin(),
-                   ev_reg.multiUniverseVariations().end(),
-                   std::back_inserter(universe_defs),
-                   [](const auto &kv) {
-                       return analysis::UniverseDef{kv.first, kv.first, kv.second};
-                   });
-
+    std::transform(ev_reg.multiUniverseVariations().begin(), ev_reg.multiUniverseVariations().end(), std::back_inserter(universe_defs), [](const auto &kv) { return analysis::UniverseDef{kv.first, kv.first, kv.second}; });
     return analysis::SystematicsProcessor(knob_defs, universe_defs);
 }
-
 struct AnalysisComponents {
     analysis::EventVariableRegistry ev_reg;
     analysis::SelectionRegistry sel_reg;
     analysis::StratifierRegistry strat_reg;
     analysis::SystematicsProcessor sys_proc;
-
     AnalysisComponents() : sys_proc(makeSystematicsProcessor(ev_reg)) {}
 };
-
-static void runBeamline(const std::string &beam, const nlohmann::json &run_configs,
+static analysis::AnalysisResult runBeamline(const std::string &beam, const nlohmann::json &run_configs,
                         const std::string &ntuple_base_directory,
                         analysis::RunConfigRegistry &rc_reg,
                         const nlohmann::json &plugins_config) {
     std::vector<std::string> periods;
     periods.reserve(run_configs.size());
-    std::transform(run_configs.items().begin(), run_configs.items().end(),
-                   std::back_inserter(periods),
-                   [](const auto &item) { return item.key(); });
-
+    std::transform(run_configs.items().begin(), run_configs.items().end(), std::back_inserter(periods), [](const auto &item) { return item.key(); });
     AnalysisComponents components;
-
-    // Instantiate the data loader outside of the plugin infrastructure so that it
-    // remains alive for the entire duration of the analysis run. Plugins such as
-    // EventDisplay rely on this object during their finalisation stage, so
-    // destroying it earlier would leave them without access to the required event
-    // data.
-    analysis::AnalysisDataLoader data_loader(rc_reg, components.ev_reg, beam, periods,
-                                             ntuple_base_directory, true);
-
-    auto histogram_booker =
-        std::make_unique<analysis::HistogramBooker>(components.strat_reg);
-
-    analysis::AnalysisRunner runner(data_loader, components.sel_reg, components.ev_reg,
-                                    std::move(histogram_booker), components.sys_proc,
-                                    plugins_config);
-
-    runner.run();
+    analysis::AnalysisDataLoader data_loader(rc_reg, components.ev_reg, beam, periods, ntuple_base_directory, true);
+    auto histogram_booker = std::make_unique<analysis::HistogramBooker>(components.strat_reg);
+    analysis::AnalysisRunner runner(data_loader, components.sel_reg, components.ev_reg, std::move(histogram_booker), components.sys_proc, plugins_config);
+    return runner.run();
 }
-
-static void runAnalysis(const nlohmann::json &config_data,
+static analysis::AnalysisResult runAnalysis(const nlohmann::json &config_data,
                         const nlohmann::json &plugins_config,
                         const std::string &config_path) {
     ROOT::EnableImplicitMT();
-    analysis::log::info("analyse::main", "Implicit multithreading engaged across",
-                        ROOT::GetThreadPoolSize(), "threads.");
-
-    std::string ntuple_base_directory =
-        config_data.at("ntuple_base_directory").get<std::string>();
-
-    analysis::log::info("analyse::main", "Configuration loaded for",
-                        config_data.at("run_configurations").size(),
-                        "beamlines.");
-
+    analysis::log::info("analyse::main", "Implicit multithreading engaged across", ROOT::GetThreadPoolSize(), "threads.");
+    std::string ntuple_base_directory = config_data.at("ntuple_base_directory").get<std::string>();
+    analysis::log::info("analyse::main", "Configuration loaded for", config_data.at("run_configurations").size(), "beamlines.");
     analysis::RunConfigRegistry rc_reg;
     analysis::RunConfigLoader::loadRunConfigurations(config_path, rc_reg);
-
-    for (auto const &[beam, run_configs] :
-         config_data.at("run_configurations").items()) {
-        runBeamline(beam, run_configs, ntuple_base_directory, rc_reg,
-                    plugins_config);
+    analysis::AnalysisResult combined;
+    for (auto const &[beam, run_configs] : config_data.at("run_configurations").items()) {
+        auto res = runBeamline(beam, run_configs, ntuple_base_directory, rc_reg, plugins_config);
+        for (auto &kv : res.regions()) combined.regions().insert(kv);
     }
+    return combined;
 }
-
 int main(int argc, char *argv[]) {
     analysis::AnalysisLogger::getInstance().setLevel(analysis::LogLevel::DEBUG);
-
-    if (argc != 3) {
-        analysis::log::fatal("analyse::main", "Invocation error. Expected:",
-                            argv[0], "<path/to/analysis_config.json> <path/to/plugins.json>");
+    if (argc != 4) {
+        analysis::log::fatal("analyse::main", "Invocation error. Expected:", argv[0], "<path/to/analysis_config.json> <path/to/plugins.json> <output.root>");
         return 1;
     }
-
     try {
         nlohmann::json config_data = loadJsonFile(argv[1]);
         nlohmann::json plugins_config = loadJsonFile(argv[2]);
-
-        runAnalysis(config_data, plugins_config, argv[1]);
+        auto result = runAnalysis(config_data, plugins_config, argv[1]);
+        result.saveToFile(argv[3]);
     } catch (const std::exception &e) {
         analysis::log::fatal("analyse::main", "An error occurred:", e.what());
         return 1;
     }
-
-    analysis::log::info("analyse::main",
-                         "Global analysis routine terminated nominally.");
+    analysis::log::info("analyse::main", "Global analysis routine terminated nominally.");
     return 0;
 }

--- a/libplug/CMakeLists.txt
+++ b/libplug/CMakeLists.txt
@@ -32,5 +32,3 @@ function(add_plugin NAME SRC EXTRA_LIBS)
     POSITION_INDEPENDENT_CODE ON
   )
 endfunction()
-
-

--- a/plot.cpp
+++ b/plot.cpp
@@ -1,0 +1,72 @@
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+#include <map>
+#include <nlohmann/json.hpp>
+#include "AnalysisDataLoader.h"
+#include "AnalysisLogger.h"
+#include "AnalysisPluginManager.h"
+#include "AnalysisResult.h"
+#include "EventVariableRegistry.h"
+#include "RunConfigLoader.h"
+#include "RunConfigRegistry.h"
+using namespace analysis;
+namespace fs = std::filesystem;
+static nlohmann::json loadJsonFile(const std::string &path) {
+    if (!fs::exists(path) || !fs::is_regular_file(path)) throw std::runtime_error("File inaccessible");
+    std::ifstream file(path);
+    if (!file.is_open()) throw std::runtime_error("Unable to open file");
+    return nlohmann::json::parse(file);
+}
+int main(int argc, char *argv[]) {
+    AnalysisLogger::getInstance().setLevel(LogLevel::DEBUG);
+    if (argc != 3) {
+        log::fatal("plot::main", "Invocation error.");
+        return 1;
+    }
+    try {
+        auto result = AnalysisResult::loadFromFile(argv[1]);
+        if (!result) {
+            log::fatal("plot::main", "Failed to load analysis result");
+            return 1;
+        }
+        nlohmann::json plugins_config = loadJsonFile(argv[2]);
+        RunConfigRegistry rc_reg;
+        EventVariableRegistry ev_reg;
+        std::map<std::string, std::unique_ptr<AnalysisDataLoader>> loaders;
+        if (plugins_config.contains("analysis_config")) {
+            std::string cfg_path = plugins_config.at("analysis_config");
+            nlohmann::json config_data = loadJsonFile(cfg_path);
+            RunConfigLoader::loadRunConfigurations(cfg_path, rc_reg);
+            std::string ntuple_base_directory = config_data.at("ntuple_base_directory");
+            for (auto const &[beam, runs] : config_data.at("run_configurations").items()) {
+                std::vector<std::string> periods;
+                for (auto const &p : runs.items()) periods.push_back(p.key());
+                loaders.emplace(beam, std::make_unique<AnalysisDataLoader>(rc_reg, ev_reg, beam, periods, ntuple_base_directory, true));
+            }
+        }
+        std::map<std::string, AnalysisPluginManager::RegionAnalysisMap> beam_regions;
+        for (auto const &kv : result->regions()) {
+            beam_regions[kv.second.beamConfig()].insert(kv);
+        }
+        if (loaders.empty()) {
+            AnalysisPluginManager manager;
+            manager.loadPlugins(plugins_config, nullptr);
+            manager.notifyFinalisation(result->regions());
+        } else {
+            for (auto &kv : loaders) {
+                AnalysisPluginManager manager;
+                manager.loadPlugins(plugins_config, kv.second.get());
+                auto it = beam_regions.find(kv.first);
+                if (it != beam_regions.end()) manager.notifyFinalisation(it->second);
+            }
+        }
+    } catch (const std::exception &e) {
+        log::fatal("plot::main", "An error occurred:", e.what());
+        return 1;
+    }
+    log::info("plot::main", "Plotting routine terminated nominally.");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Save combined analysis results to file via new `analyse` CLI argument
- Add `plot` program to load saved results and execute configured plug-ins
- Remove `AutoPlotPlugin` and its build integration

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68af2bfffbb0832eb445154b0f1c2600