### PR TITLE
Refactor analysis results interface for plotting plugins

### DIFF
--- a/libapp/AnalysisResult.h
+++ b/libapp/AnalysisResult.h
@@ -9,16 +9,45 @@
 
 #include <memory>
 #include <string>
+#include <map>
 
 namespace analysis {
 
 class AnalysisResult : public TObject {
   public:
+    struct VariableResults {
+        std::map<VariableKey, VariableResult> variables;
+        bool has(const VariableKey &k) const { return variables.find(k) != variables.end(); }
+        const VariableResult &get(const VariableKey &k) const { return variables.at(k); }
+    };
+
     AnalysisResult() = default;
-    explicit AnalysisResult(RegionAnalysisMap regions) : regions_(std::move(regions)) {}
+    explicit AnalysisResult(RegionAnalysisMap regions) : regions_(std::move(regions)) { build(); }
 
     const RegionAnalysisMap &regions() const noexcept { return regions_; }
     RegionAnalysisMap &regions() noexcept { return regions_; }
+
+    const RegionAnalysis &region(const RegionKey &r) const { return regions_.at(r); }
+
+    const VariableResult &result(const RegionKey &r, const VariableKey &v) const {
+        return variable_results_.at(r).get(v);
+    }
+
+    bool hasResult(const RegionKey &r, const VariableKey &v) const {
+        auto it = variable_results_.find(r);
+        return it != variable_results_.end() && it->second.has(v);
+    }
+
+    void build() {
+        variable_results_.clear();
+        for (auto &rk : regions_) {
+            VariableResults vr;
+            for (auto &kv : rk.second.finalVariables()) {
+                vr.variables.insert_or_assign(kv.first, kv.second);
+            }
+            variable_results_.insert_or_assign(rk.first, std::move(vr));
+        }
+    }
 
     void saveToFile(const std::string &path) const {
         TFile outfile(path.c_str(), "RECREATE");
@@ -34,6 +63,7 @@ class AnalysisResult : public TObject {
 
   private:
     RegionAnalysisMap regions_;
+    std::map<RegionKey, VariableResults> variable_results_;
 };
 
 } // namespace analysis

--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -181,8 +181,9 @@ class AnalysisRunner {
                       "):", region_handle.key_.str());
         }
 
-        plugin_manager.notifyFinalisation(analysis_regions);
-        return AnalysisResult(std::move(analysis_regions));
+        AnalysisResult result(std::move(analysis_regions));
+        plugin_manager.notifyFinalisation(result);
+        return result;
     }
 
   private:

--- a/libplug/AnalysisPluginManager.h
+++ b/libplug/AnalysisPluginManager.h
@@ -13,6 +13,7 @@
 #include "AnalysisDataLoader.h"
 #include "AnalysisLogger.h"
 #include "IAnalysisPlugin.h"
+#include "AnalysisResult.h"
 
 namespace analysis {
 
@@ -66,7 +67,7 @@ class AnalysisPluginManager {
             pl->onPostSampleProcessing(skey, rkey, res);
     }
 
-    void notifyFinalisation(const RegionAnalysisMap &res) {
+    void notifyFinalisation(const AnalysisResult &res) {
         for (auto &pl : plugins_)
             pl->onFinalisation(res);
     }

--- a/libplug/EventDisplayPlugin.h
+++ b/libplug/EventDisplayPlugin.h
@@ -61,7 +61,7 @@ class EventDisplayPlugin : public IAnalysisPlugin {
     inline void onPreSampleProcessing(const SampleKey &, const RegionKey &, const RunConfig &) override {}
     inline void onPostSampleProcessing(const SampleKey &, const RegionKey &, const RegionAnalysisMap &) override {}
 
-    inline void onFinalisation(const RegionAnalysisMap &) override {
+    inline void onFinalisation(const AnalysisResult &) override {
         if (!loader_) {
             log::error("EventDisplayPlugin::onFinalisation", "No AnalysisDataLoader context provided");
             return;

--- a/libplug/IAnalysisPlugin.h
+++ b/libplug/IAnalysisPlugin.h
@@ -8,6 +8,7 @@
 #include "AnalysisTypes.h"
 #include "RunConfig.h"
 #include "SelectionRegistry.h"
+#include "AnalysisResult.h"
 
 namespace analysis {
 
@@ -26,7 +27,7 @@ class IAnalysisPlugin {
                                         const RegionKey &region_key,
                                         const RegionAnalysisMap &results) = 0;
 
-    virtual void onFinalisation(const RegionAnalysisMap &results) = 0;
+    virtual void onFinalisation(const AnalysisResult &results) = 0;
 };
 
 }

--- a/libplug/OccupancyMatrixPlugin.h
+++ b/libplug/OccupancyMatrixPlugin.h
@@ -78,7 +78,7 @@ class OccupancyMatrixPlugin : public IAnalysisPlugin {
     void onPostSampleProcessing(const SampleKey &, const RegionKey &,
                                 const RegionAnalysisMap &) override {}
 
-    void onFinalisation(const RegionAnalysisMap &region_map) override {
+    void onFinalisation(const AnalysisResult &result) override {
         if (!loader_) {
             log::error("OccupancyMatrixPlugin::onFinalisation",
                        "No AnalysisDataLoader context provided");
@@ -86,24 +86,16 @@ class OccupancyMatrixPlugin : public IAnalysisPlugin {
         }
         for (auto const &pc : plots_) {
             RegionKey rkey{pc.region};
-            auto it = region_map.find(rkey);
-            if (it == region_map.end()) {
-                log::error(
-                    "OccupancyMatrixPlugin::onFinalisation",
-                    "Could not find analysis region for key:", rkey.str());
-                continue;
-            }
             VariableKey x_key{pc.x_variable};
             VariableKey y_key{pc.y_variable};
-            if (!it->second.hasFinalVariable(x_key) ||
-                !it->second.hasFinalVariable(y_key)) {
+            if (!result.hasResult(rkey, x_key) || !result.hasResult(rkey, y_key)) {
                 log::error("OccupancyMatrixPlugin::onFinalisation",
                            "Missing variables for region", rkey.str());
                 continue;
             }
             PlotCatalog catalog(*loader_, 800, pc.output_directory);
             catalog.generateOccupancyMatrixPlot(
-                region_map, pc.x_variable, pc.y_variable, pc.region,
+                result, pc.x_variable, pc.y_variable, pc.region,
                 pc.selection, pc.x_cuts, pc.y_cuts);
         }
     }

--- a/libplug/RegionsPlugin.h
+++ b/libplug/RegionsPlugin.h
@@ -50,7 +50,7 @@ class RegionsPlugin : public IAnalysisPlugin {
                                const RunConfig &) override {}
     void onPostSampleProcessing(const SampleKey &, const RegionKey &,
                                 const RegionAnalysisMap &) override {}
-    void onFinalisation(const RegionAnalysisMap &) override {}
+    void onFinalisation(const AnalysisResult &) override {}
 
   private:
     nlohmann::json config_;

--- a/libplug/RocCurvePlugin.h
+++ b/libplug/RocCurvePlugin.h
@@ -80,7 +80,7 @@ class RocCurvePlugin : public IAnalysisPlugin {
     void onPostSampleProcessing(const SampleKey &, const RegionKey &,
                                 const RegionAnalysisMap &) override {}
 
-    void onFinalisation(const RegionAnalysisMap &) override {
+    void onFinalisation(const AnalysisResult &) override {
         if (!loader_) {
             log::error("RocCurvePlugin::onFinalisation",
                        "No AnalysisDataLoader context provided");

--- a/libplug/SelectionEfficiencyPlugin.h
+++ b/libplug/SelectionEfficiencyPlugin.h
@@ -61,7 +61,7 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
     void onPreSampleProcessing(const SampleKey &, const RegionKey &, const RunConfig &) override {}
     void onPostSampleProcessing(const SampleKey &, const RegionKey &, const RegionAnalysisMap &) override {}
 
-    void onFinalisation(const RegionAnalysisMap &) override {
+    void onFinalisation(const AnalysisResult &) override {
         if (!loader_) {
             log::error("SelectionEfficiencyPlugin::onFinalisation", "No AnalysisDataLoader context provided");
             return;

--- a/libplug/SnapshotPlugin.h
+++ b/libplug/SnapshotPlugin.h
@@ -51,7 +51,7 @@ class SnapshotPlugin : public IAnalysisPlugin {
     void onPreSampleProcessing(const SampleKey &, const RegionKey &, const RunConfig &) override {}
     void onPostSampleProcessing(const SampleKey &, const RegionKey &, const RegionAnalysisMap &) override {}
 
-    void onFinalisation(const RegionAnalysisMap &) override {
+    void onFinalisation(const AnalysisResult &) override {
         if (!loader_) {
             log::error("SnapshotPlugin::onFinalisation", "No AnalysisDataLoader context provided");
             return;

--- a/libplug/StackedHistogramPlugin.h
+++ b/libplug/StackedHistogramPlugin.h
@@ -90,30 +90,19 @@ class StackedHistogramPlugin : public IAnalysisPlugin {
     void onPostSampleProcessing(const SampleKey &, const RegionKey &,
                                 const RegionAnalysisMap &) override {}
 
-    void onFinalisation(const RegionAnalysisMap &region_map) override {
+    void onFinalisation(const AnalysisResult &result) override {
         gSystem->mkdir("plots", true);
         for (auto const &pc : plots_) {
             RegionKey rkey{pc.region};
-            auto it = region_map.find(rkey);
-
-            if (it == region_map.end()) {
-                log::error(
-                    "StackedHistogramPlugin::onFinalisation",
-                    "Could not find analysis region for key:", rkey.str());
-                continue;
-            }
-
             VariableKey vkey{pc.variable};
-            if (!it->second.hasFinalVariable(vkey)) {
+            if (!result.hasResult(rkey, vkey)) {
                 log::error("StackedHistogramPlugin::onFinalisation",
                            "Could not find variable", vkey.str(), "in region",
                            rkey.str());
                 continue;
             }
-
-            const auto &region_analysis = it->second;
-            const auto &variable_result =
-                region_analysis.getFinalVariable(vkey);
+            const auto &region_analysis = result.region(rkey);
+            const auto &variable_result = result.result(rkey, vkey);
 
             std::vector<Cut> cuts = pc.cut_list;
             if (pc.selection_cuts) {

--- a/libplug/SystematicBreakdownPlugin.h
+++ b/libplug/SystematicBreakdownPlugin.h
@@ -41,27 +41,19 @@ class SystematicBreakdownPlugin : public IAnalysisPlugin {
     void onPreSampleProcessing(const SampleKey &, const RegionKey &, const RunConfig &) override {}
     void onPostSampleProcessing(const SampleKey &, const RegionKey &, const RegionAnalysisMap &) override {}
 
-    void onFinalisation(const RegionAnalysisMap &region_map) override {
+    void onFinalisation(const AnalysisResult &result) override {
         gSystem->mkdir("plots", true);
         for (auto const &pc : plots_) {
             RegionKey rkey{pc.region};
-            auto it = region_map.find(rkey);
-
-            if (it == region_map.end()) {
-                log::error("SystematicBreakdownPlugin::onFinalisation",
-                           "Could not find analysis region for key:", rkey.str());
-                continue;
-            }
-
             VariableKey vkey{pc.variable};
-            if (!it->second.hasFinalVariable(vkey)) {
+            if (!result.hasResult(rkey, vkey)) {
                 log::error("SystematicBreakdownPlugin::onFinalisation", "Could not find variable", vkey.str(),
                            "in region", rkey.str());
                 continue;
             }
 
-            const auto &region_analysis = it->second;
-            const auto &variable_result = region_analysis.getFinalVariable(vkey);
+            const auto &region_analysis = result.region(rkey);
+            const auto &variable_result = result.result(rkey, vkey);
 
             SystematicBreakdownPlot plot("syst_breakdown_" + pc.variable + "_" + pc.region, variable_result,
                                          pc.fractional, pc.output_directory);

--- a/libplug/UnstackedHistogramPlugin.h
+++ b/libplug/UnstackedHistogramPlugin.h
@@ -84,30 +84,20 @@ class UnstackedHistogramPlugin : public IAnalysisPlugin {
     void onPostSampleProcessing(const SampleKey &, const RegionKey &,
                                 const RegionAnalysisMap &) override {}
 
-    void onFinalisation(const RegionAnalysisMap &region_map) override {
+    void onFinalisation(const AnalysisResult &result) override {
         gSystem->mkdir("plots", true);
         for (auto const &pc : plots_) {
             RegionKey rkey{pc.region};
-            auto it = region_map.find(rkey);
-
-            if (it == region_map.end()) {
-                log::error(
-                    "UnstackedHistogramPlugin::onFinalisation",
-                    "Could not find analysis region for key:", rkey.str());
-                continue;
-            }
-
             VariableKey vkey{pc.variable};
-            if (!it->second.hasFinalVariable(vkey)) {
+            if (!result.hasResult(rkey, vkey)) {
                 log::error("UnstackedHistogramPlugin::onFinalisation",
                            "Could not find variable", vkey.str(), "in region",
                            rkey.str());
                 continue;
             }
 
-            const auto &region_analysis = it->second;
-            const auto &variable_result =
-                region_analysis.getFinalVariable(vkey);
+            const auto &region_analysis = result.region(rkey);
+            const auto &variable_result = result.result(rkey, vkey);
 
             std::vector<Cut> cuts = pc.cut_list;
             if (pc.selection_cuts) {

--- a/libplug/VariablesPlugin.h
+++ b/libplug/VariablesPlugin.h
@@ -81,7 +81,7 @@ class VariablesPlugin : public IAnalysisPlugin {
 
     void onPreSampleProcessing(const SampleKey &, const RegionKey &, const RunConfig &) override {}
     void onPostSampleProcessing(const SampleKey &, const RegionKey &, const RegionAnalysisMap &) override {}
-    void onFinalisation(const RegionAnalysisMap &) override {}
+    void onFinalisation(const AnalysisResult &) override {}
 
   private:
     nlohmann::json config_;

--- a/plot.cpp
+++ b/plot.cpp
@@ -45,15 +45,18 @@ int main(int argc, char *argv[]) {
             for (auto const &p : runs.items()) periods.push_back(p.key());
             loaders.emplace(beam, std::make_unique<AnalysisDataLoader>(rc_reg, ev_reg, beam, periods, ntuple_base_directory, true));
         }
-        std::map<std::string, AnalysisPluginManager::RegionAnalysisMap> beam_regions;
+        std::map<std::string, AnalysisResult> beam_results;
         for (auto const &kv : result->regions()) {
-            beam_regions[kv.second.beamConfig()].insert(kv);
+            beam_results[kv.second.beamConfig()].regions().insert(kv);
+        }
+        for (auto &kv : beam_results) {
+            kv.second.build();
         }
         for (auto &kv : loaders) {
             AnalysisPluginManager manager;
             manager.loadPlugins(plot_cfg, kv.second.get());
-            auto it = beam_regions.find(kv.first);
-            if (it != beam_regions.end()) manager.notifyFinalisation(it->second);
+            auto it = beam_results.find(kv.first);
+            if (it != beam_results.end()) manager.notifyFinalisation(it->second);
         }
     } catch (const std::exception &e) {
         log::fatal("plot::main", "An error occurred:", e.what());


### PR DESCRIPTION
## Summary
- Embed variable-level results into `AnalysisResult` with helper methods to access them
- Update plugin API and plot catalog to consume `AnalysisResult` directly
- Adjust plotting plugins and utilities to use the new accessors

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: command not found)*
- `source .build.sh` *(fails: could not find ROOT)*
- `ctest --output-on-failure` *(fails: no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68af32c6c9cc832eb4d586246ecc3b6c