### PR TITLE
Add dual-axis selection efficiency plot

### DIFF
--- a/config/plugins/selection_efficiency.json
+++ b/config/plugins/selection_efficiency.json
@@ -1,0 +1,24 @@
+{
+  "plugins": [
+    {
+      "path": "build/SelectionEfficiencyPlugin.so",
+      "efficiency_plots": [
+        {
+          "region": "CUSTOM",
+          "channel_column": "inclusive_strange_channels",
+          "signal_group": "inclusive_strange_channels",
+          "initial_label": "empty",
+          "log_purity": true,
+          "clauses": [
+            "in_reco_fiducial",
+            "num_slices == 1",
+            "optical_filter_pe_beam > 20",
+            "muon_score > 0.5",
+            "muon_length > 10",
+            "n_pfps_gen2 > 1"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/libplot/SelectionEfficiencyPlot.h
+++ b/libplot/SelectionEfficiencyPlot.h
@@ -9,6 +9,8 @@
 #include "TLatex.h"
 #include "TLegend.h"
 #include "TLegendEntry.h"
+#include "TPad.h"
+#include "TGaxis.h"
 
 #include "HistogramPlotterBase.h"
 
@@ -19,61 +21,74 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
     SelectionEfficiencyPlot(std::string plot_name, std::vector<std::string> stages, std::vector<double> efficiencies,
                             std::vector<double> efficiency_errors, std::vector<double> purities,
                             std::vector<double> purity_errors, std::string output_directory = "plots",
-                            bool use_log_y = false)
+                            bool log_purity = false)
         : HistogramPlotterBase(std::move(plot_name), std::move(output_directory)), stages_(std::move(stages)),
           efficiencies_(std::move(efficiencies)), efficiency_errors_(std::move(efficiency_errors)),
-          purities_(std::move(purities)), purity_errors_(std::move(purity_errors)), use_log_y_(use_log_y) {}
+          purities_(std::move(purities)), purity_errors_(std::move(purity_errors)), log_purity_(log_purity) {}
 
   private:
     void draw(TCanvas &canvas) override {
         canvas.cd();
-        if (use_log_y_)
-            canvas.SetLogy();
         int n = stages_.size();
-        TH1F frame("frame", "", n, 0, n);
-        double y_min = use_log_y_ ? 1e-3 : 0.0;
-        frame.GetYaxis()->SetRangeUser(y_min, 1.05);
-        frame.GetYaxis()->SetTitle("Fraction");
-        for (int i = 0; i < n; ++i) {
-            frame.GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
-        }
-        frame.DrawClone("AXIS");
-
+        TPad pad1("pad1", "", 0, 0, 1, 1);
+        pad1.SetRightMargin(0);
+        pad1.Draw();
+        pad1.cd();
+        TH1F frame1("frame1", "", n, 0, n);
+        frame1.GetYaxis()->SetRangeUser(0, 1.05);
+        frame1.GetYaxis()->SetTitle("Efficiency");
+        for (int i = 0; i < n; ++i)
+            frame1.GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
+        frame1.Draw("AXIS");
         TGraphErrors eff_graph(n);
-        TGraphErrors pur_graph(n);
         for (int i = 0; i < n; ++i) {
             double x = i + 0.5;
             eff_graph.SetPoint(i, x, efficiencies_[i]);
             eff_graph.SetPointError(i, 0.0, efficiency_errors_[i]);
-            pur_graph.SetPoint(i, x, purities_[i]);
-            pur_graph.SetPointError(i, 0.0, purity_errors_[i]);
         }
         eff_graph.SetLineColor(kBlue + 1);
         eff_graph.SetMarkerColor(kBlue + 1);
         eff_graph.SetMarkerStyle(20);
         eff_graph.SetLineWidth(2);
+        eff_graph.Draw("PL");
+        canvas.cd();
+        TPad pad2("pad2", "", 0, 0, 1, 1);
+        pad2.SetFillStyle(4000);
+        pad2.SetFrameFillStyle(4000);
+        pad2.SetLeftMargin(0);
+        pad2.SetRightMargin(0.15);
+        if (log_purity_)
+            pad2.SetLogy();
+        pad2.Draw();
+        pad2.cd();
+        double min_p = 1;
+        for (double v : purities_)
+            if (v > 0 && v < min_p)
+                min_p = v;
+        double y_min = log_purity_ ? (min_p > 0 ? min_p * 0.5 : 1e-3) : 0.0;
+        TH1F frame2("frame2", "", n, 0, n);
+        frame2.GetYaxis()->SetRangeUser(y_min, 1.05);
+        frame2.GetXaxis()->SetLabelSize(0);
+        frame2.GetXaxis()->SetTickLength(0);
+        frame2.Draw("AXIS");
+        TGraphErrors pur_graph(n);
+        for (int i = 0; i < n; ++i) {
+            double x = i + 0.5;
+            pur_graph.SetPoint(i, x, purities_[i]);
+            pur_graph.SetPointError(i, 0.0, purity_errors_[i]);
+        }
         pur_graph.SetLineColor(kRed + 1);
         pur_graph.SetMarkerColor(kRed + 1);
         pur_graph.SetMarkerStyle(21);
         pur_graph.SetLineWidth(2);
-
-        eff_graph.DrawClone("PL SAME");
-        pur_graph.DrawClone("PL SAME");
-
-        TLatex latex;
-        latex.SetTextAlign(23);
-        latex.SetTextFont(42);
-        latex.SetTextSize(0.035);
-        for (int i = 0; i < n; ++i) {
-            double x = i + 0.5;
-            double ye = efficiencies_[i];
-            double yp = purities_[i];
-            latex.SetTextColor(kBlue + 1);
-            latex.DrawLatex(x, ye + 0.02, Form("%.2f", ye));
-            latex.SetTextColor(kRed + 1);
-            latex.DrawLatex(x, yp + 0.02, Form("%.2f", yp));
-        }
-
+        pur_graph.Draw("PL");
+        TGaxis axis(n, y_min, n, 1.05, y_min, 1.05, 510, log_purity_ ? "L" : "");
+        axis.SetLabelColor(kRed + 1);
+        axis.SetTitleColor(kRed + 1);
+        axis.SetTitle("Purity");
+        axis.SetTitleOffset(1.2);
+        axis.Draw();
+        canvas.cd();
         TLegend legend(0.6, 0.75, 0.88, 0.88);
         legend.SetBorderSize(0);
         legend.SetFillStyle(0);
@@ -86,7 +101,21 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
         pur_entry->SetLineColor(kRed + 1);
         pur_entry->SetMarkerColor(kRed + 1);
         pur_entry->SetMarkerStyle(21);
-        legend.DrawClone();
+        legend.Draw();
+        TLatex latex;
+        latex.SetTextAlign(23);
+        latex.SetTextFont(42);
+        latex.SetTextSize(0.035);
+        for (int i = 0; i < n; ++i) {
+            double x = i + 0.5;
+            double ye = efficiencies_[i];
+            double yp = purities_[i];
+            latex.SetTextColor(kBlue + 1);
+            latex.DrawLatex(x, ye + 0.02, Form("%.2f", ye));
+            latex.SetTextColor(kRed + 1);
+            double yp_text = log_purity_ ? yp * 1.1 : yp + 0.02;
+            latex.DrawLatex(x, yp_text, Form("%.2f", yp));
+        }
     }
 
     std::vector<std::string> stages_;
@@ -94,7 +123,7 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
     std::vector<double> efficiency_errors_;
     std::vector<double> purities_;
     std::vector<double> purity_errors_;
-    bool use_log_y_;
+    bool log_purity_;
 };
 
 } // namespace analysis

--- a/libplug/SelectionEfficiencyPlugin.h
+++ b/libplug/SelectionEfficiencyPlugin.h
@@ -24,8 +24,9 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
         std::string signal_group;
         std::string output_directory{"plots"};
         std::string plot_name{"selection_efficiency"};
-        bool use_log_y{false};
+        bool log_purity{false};
         std::vector<std::string> clauses;
+        std::string initial_label{"All Events"};
     };
 
     explicit SelectionEfficiencyPlugin(const nlohmann::json &cfg) {
@@ -35,12 +36,16 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
         for (auto const &p : cfg.at("efficiency_plots")) {
             PlotConfig pc;
             pc.region = p.at("region").get<std::string>();
-            pc.selection_rule = p.at("selection_rule").get<std::string>();
+            pc.selection_rule = p.value("selection_rule", std::string{});
             pc.channel_column = p.at("channel_column").get<std::string>();
             pc.signal_group = p.at("signal_group").get<std::string>();
             pc.output_directory = p.value("output_directory", std::string{"plots"});
             pc.plot_name = p.value("plot_name", std::string{"selection_efficiency"});
-            pc.use_log_y = p.value("log_y", false);
+            pc.log_purity = p.value("log_purity", false);
+            pc.initial_label = p.value("initial_label", std::string{"All Events"});
+            if (p.contains("clauses") && p.at("clauses").is_array())
+                for (auto const &cl : p.at("clauses"))
+                    pc.clauses.push_back(cl.get<std::string>());
             plots_.push_back(std::move(pc));
         }
     }
@@ -48,8 +53,10 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
     void onInitialisation(AnalysisDefinition &def, const SelectionRegistry &sel_reg) override {
         for (auto &pc : plots_) {
             try {
-                auto rule = sel_reg.getRule(pc.selection_rule);
-                pc.clauses = rule.clauses;
+                if (pc.clauses.empty()) {
+                    auto rule = sel_reg.getRule(pc.selection_rule);
+                    pc.clauses = rule.clauses;
+                }
 
                 def.region(RegionKey{pc.region});
             } catch (const std::exception &e) {
@@ -90,7 +97,7 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
 
             std::string signal_expr = buildSignalExpr(signal_keys);
 
-            std::vector<std::string> stage_labels{"All Events"};
+            std::vector<std::string> stage_labels{pc.initial_label};
             stage_labels.insert(stage_labels.end(), pc.clauses.begin(), pc.clauses.end());
 
             std::vector<std::string> cumulative_filters{""};
@@ -164,7 +171,7 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
             }
 
             SelectionEfficiencyPlot plot(pc.plot_name + "_" + pc.region, stage_labels, efficiencies, eff_errors,
-                                         purities, pur_errors, pc.output_directory, pc.use_log_y);
+                                         purities, pur_errors, pc.output_directory, pc.log_purity);
             plot.drawAndSave("pdf");
         }
     }


### PR DESCRIPTION
## Summary
- Support log-scaled purity on secondary axis in SelectionEfficiencyPlot
- Configure SelectionEfficiencyPlugin with optional `log_purity` flag
- Enable log purity plotting in example plugin configuration

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68af643f4c34832eb27d6c608e0e0e96