### PR TITLE
Remove unused variable from systematic breakdown plugin

### DIFF
--- a/libplug/SystematicBreakdownPlugin.h
+++ b/libplug/SystematicBreakdownPlugin.h
@@ -52,7 +52,6 @@ class SystematicBreakdownPlugin : public IAnalysisPlugin {
                 continue;
             }
 
-            const auto &region_analysis = result.region(rkey);
             const auto &variable_result = result.result(rkey, vkey);
 
             SystematicBreakdownPlot plot("syst_breakdown_" + pc.variable + "_" + pc.region, variable_result,


### PR DESCRIPTION
## Summary
- drop unused region_analysis variable in SystematicBreakdownPlugin

## Testing
- `bash .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68af85310de0832ea429f4bdbca04c89