### PR TITLE
Avoid crash when efficiency plots are absent

### DIFF
--- a/libplug/SelectionEfficiencyPlugin.h
+++ b/libplug/SelectionEfficiencyPlugin.h
@@ -3,7 +3,6 @@
 
 #include <cmath>
 #include <nlohmann/json.hpp>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -31,9 +30,8 @@ class SelectionEfficiencyPlugin : public IAnalysisPlugin {
     };
 
     explicit SelectionEfficiencyPlugin(const nlohmann::json &cfg) {
-        if (!cfg.contains("efficiency_plots") || !cfg.at("efficiency_plots").is_array()) {
-            throw std::runtime_error("SelectionEfficiencyPlugin missing efficiency_plots");
-        }
+        if (!cfg.contains("efficiency_plots") || !cfg.at("efficiency_plots").is_array())
+            return;
         for (auto const &p : cfg.at("efficiency_plots")) {
             PlotConfig pc;
             pc.region = p.at("region").get<std::string>();


### PR DESCRIPTION
## Summary
- Gracefully handle SelectionEfficiencyPlugin with no `efficiency_plots`

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68af8636c538832eb64322e69a986e85