### PR TITLE
docs: clarify vertical spacing rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 - Do not add comments in any code files.
 - Avoid docstrings or inline comments; keep code comment-free.
 - These instructions apply to the entire repository.
+- Use vertical space to separate distinct groups of statements for readability, such as between variable declarations, loops, and return statements.


### PR DESCRIPTION
Specify in AGENTS guidelines to insert vertical whitespace between logical code sections for readability