### PR TITLE
Suppress unused canvas warning in SemanticDisplay draw

### DIFF
--- a/libplot/IEventDisplay.h
+++ b/libplot/IEventDisplay.h
@@ -43,7 +43,7 @@ class DetectorDisplay:public IEventDisplay {
       : IEventDisplay(std::move(tag),image_size,std::move(output_directory)),data_(std::move(data)) {}
 
  protected:
-  void draw(TCanvas &canvas) override {
+  void draw(TCanvas &) override {
     TH2F hist(tag_.c_str(),tag_.c_str(),image_size_,0,image_size_,image_size_,0,image_size_);
 
     for(int r=0;r<image_size_;++r){
@@ -71,7 +71,7 @@ class SemanticDisplay:public IEventDisplay {
       : IEventDisplay(std::move(tag),image_size,std::move(output_directory)),data_(std::move(data)) {}
 
  protected:
-  void draw(TCanvas &canvas) override {
+  void draw(TCanvas &) override {
     TH2F hist(tag_.c_str(),tag_.c_str(),image_size_,0,image_size_,image_size_,0,image_size_);
 
     int palette[10];


### PR DESCRIPTION
Eliminate unused canvas parameter in SemanticDisplay::draw to prevent compilation failure