### PR TITLE
Correct canvas parameter handling in event display draws

### DIFF
--- a/libplot/IEventDisplay.h
+++ b/libplot/IEventDisplay.h
@@ -71,7 +71,7 @@ class SemanticDisplay:public IEventDisplay {
       : IEventDisplay(std::move(tag),image_size,std::move(output_directory)),data_(std::move(data)) {}
 
  protected:
-  void draw(TCanvas &canvas) override {
+  void draw(TCanvas &) override {
     TH2F hist(tag_.c_str(),tag_.c_str(),image_size_,0,image_size_,image_size_,0,image_size_);
 
     int palette[10];


### PR DESCRIPTION
## Summary
- restore named canvas parameter in `DetectorDisplay::draw` to use log scale settings
- leave `SemanticDisplay::draw` parameter unnamed to avoid unused variable warnings

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68b180dd3fb4832e8319e104420101ec