### PR TITLE
Update dynamic binning tests for new interface

### DIFF
--- a/tests/test_dynamic_binning.cpp
+++ b/tests/test_dynamic_binning.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 using namespace analysis;
+using Catch::Approx;
 
 TEST_CASE("bayesian_blocks_unweighted") {
     TFile f("unw.root", "RECREATE");
@@ -24,7 +25,7 @@ TEST_CASE("bayesian_blocks_unweighted") {
     t.Write();
     ROOT::RDataFrame df("t", "unw.root");
     std::vector<ROOT::RDF::RNode> nodes{df};
-    BinningDefinition b({0.0, 14.9}, "x", "x");
+    BinningDefinition b({0.0, 14.9}, "x", "x", std::vector<SelectionKey>{});
     auto res = DynamicBinning::calculate(nodes, b);
     auto e = res.getEdges();
     REQUIRE(e.size() == 4);
@@ -54,7 +55,7 @@ TEST_CASE("bayesian_blocks_weighted") {
     t.Write();
     ROOT::RDataFrame df("t", "wei.root");
     std::vector<ROOT::RDF::RNode> nodes{df};
-    BinningDefinition b({0.0, 14.9}, "x", "x");
+    BinningDefinition b({0.0, 14.9}, "x", "x", std::vector<SelectionKey>{});
     auto res = DynamicBinning::calculate(nodes, b, "w");
     auto e = res.getEdges();
     REQUIRE(e.size() == 4);


### PR DESCRIPTION
## Summary
- Import `Catch::Approx` for compatibility with Catch2
- Pass empty selection key vector to `BinningDefinition` in dynamic binning tests

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68b19737f098832ea28477adcc701566