### PR TITLE
Include Catch2 Approx header for dynamic binning tests

### DIFF
--- a/tests/test_dynamic_binning.cpp
+++ b/tests/test_dynamic_binning.cpp
@@ -4,6 +4,7 @@
 #include "TFile.h"
 #include "TTree.h"
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <vector>
 
 using namespace analysis;


### PR DESCRIPTION
## Summary
- include Catch2 Approx header to enable Approx usage in dynamic binning test

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*
- `ctest --output-on-failure` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19806fb3c832e9f2e60be251528ad