### PR TITLE
Enable strategy selection in 2D dynamic binning

### DIFF
--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -9,6 +9,7 @@
 #include "AnalysisDataLoader.h"
 #include "AnalysisResult.h"
 #include "HistogramCut.h"
+#include "DynamicBinning2D.h"
 #include "OccupancyMatrixPlot.h"
 #include "Selection.h"
 #include "StackedHistogramPlot.h"
@@ -85,6 +86,16 @@ class PlotCatalog {
 
         auto x_edges = x_res.binning_.getEdges();
         auto y_edges = y_res.binning_.getEdges();
+
+        std::vector<ROOT::RDF::RNode> mc_nodes;
+        for (auto &[key, sample] : loader_.getSampleFrames())
+            if (sample.isMc())
+                mc_nodes.emplace_back(sample.nominal_node_);
+        if (!mc_nodes.empty()) {
+            auto bins = DynamicBinning2D::calculate(mc_nodes, x_res.binning_, y_res.binning_);
+            x_edges = bins.first.getEdges();
+            y_edges = bins.second.getEdges();
+        }
 
         TH2F *hist = new TH2F(name.c_str(), name.c_str(), x_edges.size() - 1, x_edges.data(), y_edges.size() - 1,
                               y_edges.data());

--- a/libutils/DynamicBinning2D.h
+++ b/libutils/DynamicBinning2D.h
@@ -1,0 +1,27 @@
+#ifndef DYNAMIC_BINNING_2D_H
+#define DYNAMIC_BINNING_2D_H
+
+#include "DynamicBinning.h"
+
+namespace analysis {
+
+class DynamicBinning2D {
+ public:
+  static std::pair<BinningDefinition, BinningDefinition> calculate(std::vector<ROOT::RDF::RNode> nodes,
+                                                                   const BinningDefinition &xb,
+                                                                   const BinningDefinition &yb,
+                                                                   const std::string &weight_col = "nominal_event_weight",
+                                                                   double min_neff_per_bin = 400.0,
+                                                                   bool include_out_of_range_bins = false,
+                                                                   DynamicBinningStrategy strategy = DynamicBinningStrategy::EqualWeight) {
+    auto bxnew = DynamicBinning::calculate(nodes, xb, weight_col, min_neff_per_bin, include_out_of_range_bins, strategy);
+
+    auto bynew = DynamicBinning::calculate(nodes, yb, weight_col, min_neff_per_bin, include_out_of_range_bins, strategy);
+
+    return {bxnew, bynew};
+  }
+};
+
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,3 +13,7 @@ catch_discover_tests(test_systematics)
 add_executable(test_dynamic_binning test_dynamic_binning.cpp)
 target_link_libraries(test_dynamic_binning PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
 catch_discover_tests(test_dynamic_binning)
+
+add_executable(test_dynamic_binning_2d test_dynamic_binning_2d.cpp)
+target_link_libraries(test_dynamic_binning_2d PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
+catch_discover_tests(test_dynamic_binning_2d)

--- a/tests/test_dynamic_binning_2d.cpp
+++ b/tests/test_dynamic_binning_2d.cpp
@@ -1,0 +1,35 @@
+#include "BinningDefinition.h"
+#include "DynamicBinning2D.h"
+#include "ROOT/RDataFrame.hxx"
+#include "TFile.h"
+#include "TTree.h"
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+using namespace analysis;
+
+TEST_CASE("dynamic_binning_2d_equal_weight") {
+    TFile f("d2.root", "RECREATE");
+    TTree t("t", "");
+    double x;
+    double y;
+    t.Branch("x", &x);
+    t.Branch("y", &y);
+    for (int ix = 0; ix < 10; ++ix) {
+        for (int iy = 0; iy < 10; ++iy) {
+            x = ix;
+            y = iy;
+            t.Fill();
+        }
+    }
+    t.Write();
+    ROOT::RDataFrame df("t", "d2.root");
+    std::vector<ROOT::RDF::RNode> nodes{df};
+    BinningDefinition bx({0.0, 10.0}, "x", "x", std::vector<SelectionKey>{});
+    BinningDefinition by({0.0, 10.0}, "y", "y", std::vector<SelectionKey>{});
+    auto bins = DynamicBinning2D::calculate(nodes, bx, by, "nominal_event_weight", 10.0, false);
+    auto ex = bins.first.getEdges();
+    auto ey = bins.second.getEdges();
+    REQUIRE(ex.size() == 11);
+    REQUIRE(ey.size() == 11);
+}


### PR DESCRIPTION
## Summary
- Rework DynamicBinning2D to delegate to 1D dynamic binning with a configurable strategy
- Update 2D binning unit test for new behaviour

## Testing
- `source .container.sh` (fails: No such file or directory)
- `source .setup.sh` (fails: setup scripts missing)
- `source .build.sh` (fails: Could not find a package configuration file provided by "ROOT")
- `ctest --output-on-failure` (fails: No tests were found)


------
https://chatgpt.com/codex/tasks/task_e_68b502128454832e9d83744be7885a5a