### PR TITLE
Introduce quadtree-based 2D binning

### DIFF
--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -9,6 +9,7 @@
 #include "AnalysisDataLoader.h"
 #include "AnalysisResult.h"
 #include "HistogramCut.h"
+#include "QuadTreeBinning2D.h"
 #include "OccupancyMatrixPlot.h"
 #include "Selection.h"
 #include "StackedHistogramPlot.h"
@@ -85,6 +86,16 @@ class PlotCatalog {
 
         auto x_edges = x_res.binning_.getEdges();
         auto y_edges = y_res.binning_.getEdges();
+
+        std::vector<ROOT::RDF::RNode> mc_nodes;
+        for (auto &[key, sample] : loader_.getSampleFrames())
+            if (sample.isMc())
+                mc_nodes.emplace_back(sample.nominal_node_);
+        if (!mc_nodes.empty()) {
+            auto bins = QuadTreeBinning2D::calculate(mc_nodes, x_res.binning_, y_res.binning_);
+            x_edges = bins.first.getEdges();
+            y_edges = bins.second.getEdges();
+        }
 
         TH2F *hist = new TH2F(name.c_str(), name.c_str(), x_edges.size() - 1, x_edges.data(), y_edges.size() - 1,
                               y_edges.data());

--- a/libutils/DynamicBinning2D.h
+++ b/libutils/DynamicBinning2D.h
@@ -1,0 +1,27 @@
+#ifndef DYNAMIC_BINNING_2D_H
+#define DYNAMIC_BINNING_2D_H
+
+#include "DynamicBinning.h"
+
+namespace analysis {
+
+class DynamicBinning2D {
+ public:
+  static std::pair<BinningDefinition, BinningDefinition> calculate(std::vector<ROOT::RDF::RNode> nodes,
+                                                                   const BinningDefinition &xb,
+                                                                   const BinningDefinition &yb,
+                                                                   const std::string &weight_col = "nominal_event_weight",
+                                                                   double min_neff_per_bin = 400.0,
+                                                                   bool include_out_of_range_bins = false,
+                                                                   DynamicBinningStrategy strategy = DynamicBinningStrategy::EqualWeight) {
+    auto bxnew = DynamicBinning::calculate(nodes, xb, weight_col, min_neff_per_bin, include_out_of_range_bins, strategy);
+
+    auto bynew = DynamicBinning::calculate(nodes, yb, weight_col, min_neff_per_bin, include_out_of_range_bins, strategy);
+
+    return {bxnew, bynew};
+  }
+};
+
+}
+
+#endif

--- a/libutils/QuadTreeBinning2D.h
+++ b/libutils/QuadTreeBinning2D.h
@@ -1,0 +1,138 @@
+#ifndef QUADTREE_BINNING_2D_H
+#define QUADTREE_BINNING_2D_H
+
+#include <set>
+#include <vector>
+#include <string>
+#include <limits>
+#include <cmath>
+
+#include "ROOT/RDataFrame.hxx"
+
+#include "BinningDefinition.h"
+
+namespace analysis {
+
+class QuadTreeBinning2D {
+ public:
+  static std::pair<BinningDefinition,BinningDefinition> calculate(std::vector<ROOT::RDF::RNode> nodes,
+                                                                  const BinningDefinition &xb,
+                                                                  const BinningDefinition &yb,
+                                                                  const std::string &weight_col = "nominal_event_weight",
+                                                                  double min_neff_per_bin = 400.0,
+                                                                  bool include_out_of_range_bins = false) {
+    struct Point { double x; double y; double w; };
+
+    std::vector<Point> pts;
+    pts.reserve(262144);
+
+    double xmin = xb.getEdges().front();
+    double xmax = xb.getEdges().back();
+    double ymin = yb.getEdges().front();
+    double ymax = yb.getEdges().back();
+
+    for (auto &n : nodes) {
+      bool has_w = n.HasColumn(weight_col);
+      auto xv = n.Take<double>(xb.getVariable());
+      auto yv = n.Take<double>(yb.getVariable());
+      if (has_w) {
+        auto wv = n.Take<double>(weight_col);
+        for (size_t i = 0; i < xv->size(); ++i) {
+          double x = (*xv)[i];
+          double y = (*yv)[i];
+          double w = (*wv)[i];
+          if (std::isfinite(x) && std::isfinite(y) && std::isfinite(w) && w > 0.0 && x >= xmin && x <= xmax && y >= ymin && y <= ymax) pts.push_back({x,y,w});
+        }
+      } else {
+        for (size_t i = 0; i < xv->size(); ++i) {
+          double x = (*xv)[i];
+          double y = (*yv)[i];
+          if (std::isfinite(x) && std::isfinite(y) && x >= xmin && x <= xmax && y >= ymin && y <= ymax) pts.push_back({x,y,1.0});
+        }
+      }
+    }
+
+    std::set<double> xset;
+    std::set<double> yset;
+
+    auto subdivide = [&](auto &&self, std::vector<Point> &v, double x0, double x1, double y0, double y1) -> void {
+      double sw = 0.0;
+      double sw2 = 0.0;
+      for (auto &p : v) {
+        sw += p.w;
+        sw2 += p.w * p.w;
+      }
+      double neff = (sw * sw) / std::max(sw2, std::numeric_limits<double>::min());
+      if (neff <= min_neff_per_bin || v.size() <= 1) return;
+
+      double xm = 0.5 * (x0 + x1);
+      double ym = 0.5 * (y0 + y1);
+
+      xset.insert(xm);
+      yset.insert(ym);
+
+      std::vector<Point> q1;
+      std::vector<Point> q2;
+      std::vector<Point> q3;
+      std::vector<Point> q4;
+
+      q1.reserve(v.size());
+      q2.reserve(v.size());
+      q3.reserve(v.size());
+      q4.reserve(v.size());
+
+      for (auto &p : v) {
+        bool left = p.x < xm;
+        bool bottom = p.y < ym;
+        if (left) {
+          if (bottom) q1.push_back(p);
+          else q2.push_back(p);
+        } else {
+          if (bottom) q3.push_back(p);
+          else q4.push_back(p);
+        }
+      }
+
+      self(self, q1, x0, xm, y0, ym);
+      self(self, q2, x0, xm, ym, y1);
+      self(self, q3, xm, x1, y0, ym);
+      self(self, q4, xm, x1, ym, y1);
+    };
+
+    subdivide(subdivide, pts, xmin, xmax, ymin, ymax);
+
+    std::vector<double> xedges;
+    std::vector<double> yedges;
+
+    xedges.reserve(xset.size() + 2);
+    yedges.reserve(yset.size() + 2);
+
+    xedges.push_back(xmin);
+    xedges.insert(xedges.end(), xset.begin(), xset.end());
+    xedges.push_back(xmax);
+
+    yedges.push_back(ymin);
+    yedges.insert(yedges.end(), yset.begin(), yset.end());
+    yedges.push_back(ymax);
+
+    if (include_out_of_range_bins && xedges.size() > 1 && yedges.size() > 1) {
+      double first_w = xedges[1] - xedges[0];
+      double last_w = xedges[xedges.size() - 1] - xedges[xedges.size() - 2];
+      xedges.insert(xedges.begin(), xedges.front() - 0.5 * first_w);
+      xedges.push_back(xedges.back() + 0.5 * last_w);
+
+      first_w = yedges[1] - yedges[0];
+      last_w = yedges[yedges.size() - 1] - yedges[yedges.size() - 2];
+      yedges.insert(yedges.begin(), yedges.front() - 0.5 * first_w);
+      yedges.push_back(yedges.back() + 0.5 * last_w);
+    }
+
+    return {BinningDefinition(xedges, xb.getVariable(), xb.getTexLabel(), {}, xb.getStratifierKey().str()),
+            BinningDefinition(yedges, yb.getVariable(), yb.getTexLabel(), {}, yb.getStratifierKey().str())};
+  }
+};
+
+}
+
+#endif
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,3 +13,11 @@ catch_discover_tests(test_systematics)
 add_executable(test_dynamic_binning test_dynamic_binning.cpp)
 target_link_libraries(test_dynamic_binning PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
 catch_discover_tests(test_dynamic_binning)
+
+add_executable(test_dynamic_binning_2d test_dynamic_binning_2d.cpp)
+target_link_libraries(test_dynamic_binning_2d PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
+catch_discover_tests(test_dynamic_binning_2d)
+
+add_executable(test_quadtree_binning_2d test_quadtree_binning_2d.cpp)
+target_link_libraries(test_quadtree_binning_2d PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
+catch_discover_tests(test_quadtree_binning_2d)

--- a/tests/test_dynamic_binning_2d.cpp
+++ b/tests/test_dynamic_binning_2d.cpp
@@ -1,0 +1,35 @@
+#include "BinningDefinition.h"
+#include "DynamicBinning2D.h"
+#include "ROOT/RDataFrame.hxx"
+#include "TFile.h"
+#include "TTree.h"
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+using namespace analysis;
+
+TEST_CASE("dynamic_binning_2d_equal_weight") {
+    TFile f("d2.root", "RECREATE");
+    TTree t("t", "");
+    double x;
+    double y;
+    t.Branch("x", &x);
+    t.Branch("y", &y);
+    for (int ix = 0; ix < 10; ++ix) {
+        for (int iy = 0; iy < 10; ++iy) {
+            x = ix;
+            y = iy;
+            t.Fill();
+        }
+    }
+    t.Write();
+    ROOT::RDataFrame df("t", "d2.root");
+    std::vector<ROOT::RDF::RNode> nodes{df};
+    BinningDefinition bx({0.0, 10.0}, "x", "x", std::vector<SelectionKey>{});
+    BinningDefinition by({0.0, 10.0}, "y", "y", std::vector<SelectionKey>{});
+    auto bins = DynamicBinning2D::calculate(nodes, bx, by, "nominal_event_weight", 10.0, false);
+    auto ex = bins.first.getEdges();
+    auto ey = bins.second.getEdges();
+    REQUIRE(ex.size() == 11);
+    REQUIRE(ey.size() == 11);
+}

--- a/tests/test_quadtree_binning_2d.cpp
+++ b/tests/test_quadtree_binning_2d.cpp
@@ -1,0 +1,36 @@
+#include "BinningDefinition.h"
+#include "QuadTreeBinning2D.h"
+#include "ROOT/RDataFrame.hxx"
+#include "TFile.h"
+#include "TTree.h"
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+using namespace analysis;
+
+TEST_CASE("quadtree_binning_2d") {
+    TFile f("qt.root", "RECREATE");
+    TTree t("t", "");
+    double x;
+    double y;
+    t.Branch("x", &x);
+    t.Branch("y", &y);
+    for (int ix = 0; ix < 10; ++ix) {
+        for (int iy = 0; iy < 10; ++iy) {
+            x = ix / 10.0;
+            y = iy / 10.0;
+            t.Fill();
+        }
+    }
+    t.Write();
+    ROOT::RDataFrame df("t", "qt.root");
+    std::vector<ROOT::RDF::RNode> nodes{df};
+    BinningDefinition bx({0.0, 1.0}, "x", "x", std::vector<SelectionKey>{});
+    BinningDefinition by({0.0, 1.0}, "y", "y", std::vector<SelectionKey>{});
+    auto bins = QuadTreeBinning2D::calculate(nodes, bx, by, "nominal_event_weight", 30.0, false);
+    auto ex = bins.first.getEdges();
+    auto ey = bins.second.getEdges();
+    REQUIRE(ex.size() == 3);
+    REQUIRE(ey.size() == 3);
+}
+


### PR DESCRIPTION
## Summary
- Implement quadtree-based 2D bin edge calculation and expose it through `QuadTreeBinning2D`
- Use quadtree binning in occupancy matrix plots
- Add unit test for quadtree 2D binning

## Testing
- `source .container.sh` (fails: No such file or directory)
- `source .setup.sh` (fails: No such file or directory)
- `source .build.sh` (fails: Could not find a package configuration file provided by "ROOT")
- `ctest --output-on-failure` (fails: No tests were found!!!)


------
https://chatgpt.com/codex/tasks/task_e_68b502128454832e9d83744be7885a5a