### PR TITLE
Fix bin edge calculation in dynamic binning

### DIFF
--- a/libutils/DynamicBinning.h
+++ b/libutils/DynamicBinning.h
@@ -341,7 +341,7 @@ class DynamicBinning {
                 size_t idx = 0;
                 for (int k = 1; k < target_bins; ++k) {
                     double thresh = (static_cast<double>(k) / static_cast<double>(target_bins)) * W;
-                    while (idx < in_range.size() && cum + in_range[idx].second < thresh) {
+                    while (idx < in_range.size() && cum + in_range[idx].second <= thresh) {
                         cum += in_range[idx].second;
                         ++idx;
                     }


### PR DESCRIPTION
## Summary
- ensure equal-weight strategy advances past threshold when computing bin edges

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: repository not signed; 403 Forbidden)*
- `cd build && ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68b564d96034832e8c77fe385bed08d5