### PR TITLE
Add flash and image analysis variables to registry

### DIFF
--- a/libdata/VariableRegistry.h
+++ b/libdata/VariableRegistry.h
@@ -49,6 +49,7 @@ class VariableRegistry {
         vars.insert(processedEventVariables().begin(), processedEventVariables().end());
         vars.insert(blipVariables().begin(), blipVariables().end());
         vars.insert(imageVariables().begin(), imageVariables().end());
+        vars.insert(flashVariables().begin(), flashVariables().end());
 
         if (type == SampleOrigin::kMonteCarlo) {
             vars.insert(truthVariables().begin(), truthVariables().end());
@@ -191,7 +192,23 @@ class VariableRegistry {
                                                    "event_semantic_counts_w",
                                                    "is_vtx_in_image_u",
                                                    "is_vtx_in_image_v",
-                                                   "is_vtx_in_image_w"};
+                                                   "is_vtx_in_image_w",
+                                                   "inference_score"};
+        return v;
+    }
+
+    static const std::vector<std::string> &flashVariables() {
+        static const std::vector<std::string> v = {"t0",
+                                                   "flash_match_score",
+                                                   "flash_total_pe",
+                                                   "flash_time",
+                                                   "flash_z_center",
+                                                   "flash_z_width",
+                                                   "slice_charge",
+                                                   "slice_z_center",
+                                                   "charge_light_ratio",
+                                                   "flash_slice_z_dist",
+                                                   "flash_pe_per_charge"};
         return v;
     }
 


### PR DESCRIPTION
## Summary
- include flash analysis variables in event registry
- add image inference variable to image group

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b83fad48f0832e947287c3cd50c119