### PR TITLE
Tar larsoft local install and asset bundle after build

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -16,4 +16,14 @@ make -j"${NUM_CORES}" || { cd "${REPO_ROOT}"; return 1; }
 
 ctest || { ctest --rerun-failed --output-on-failure; cd "${REPO_ROOT}"; return 1; }
 
+if [ -n "${LARSOFT_INSTALL:-}" ] && [ -d "${LARSOFT_INSTALL}" ] && [ -n "${LARSOFT_TAR_DEST:-}" ]; then
+    tar -czf "${BUILD_DIR}/larsoft.tar.gz" -C "${LARSOFT_INSTALL}" . || { cd "${REPO_ROOT}"; return 1; }
+    mv "${BUILD_DIR}/larsoft.tar.gz" "${LARSOFT_TAR_DEST}" || { cd "${REPO_ROOT}"; return 1; }
+fi
+
+if [ -n "${ASSET_SOURCE:-}" ] && [ -d "${ASSET_SOURCE}" ] && [ -n "${ASSET_TAR_DEST:-}" ]; then
+    tar -czf "${BUILD_DIR}/asset.tar.gz" -C "${ASSET_SOURCE}" . || { cd "${REPO_ROOT}"; return 1; }
+    mv "${BUILD_DIR}/asset.tar.gz" "${ASSET_TAR_DEST}" || { cd "${REPO_ROOT}"; return 1; }
+fi
+
 cd "${REPO_ROOT}" || { return 0; }


### PR DESCRIPTION
## Summary
- Package the local larsoft install and asset directory into tarballs after a successful build
- Move the tarballs to locations specified by environment variables

## Testing
- `source .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b84693a7c8832ebda2280dcebd99f5