### PR TITLE
Add workflow for PlantUML diagrams

### DIFF
--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -1,0 +1,30 @@
+name: plantuml
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'docs/**/*.puml'
+      - '.github/workflows/plantuml.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - run: sudo apt-get update
+
+      - run: sudo apt-get install -y graphviz plantuml
+
+      - run: plantuml -o diagrams docs/*.puml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: diagrams
+          path: docs/diagrams

--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@ The `strategy` field accepts `equal_weight`, `freedman_diaconis`, `scott`, `stur
 ```bash
 ctest --output-on-failure
 ```
+
+## Diagrams
+PlantUML diagrams are rendered by a GitHub Actions workflow
+Generated images are available as build artifacts

--- a/docs/class_diagram.puml
+++ b/docs/class_diagram.puml
@@ -1,0 +1,66 @@
+@startuml
+
+package app {
+  class ISampleProcessor
+  class DataProcessor
+  class MonteCarloProcessor
+  class AnalysisRunner
+}
+
+ISampleProcessor <|-- DataProcessor
+ISampleProcessor <|-- MonteCarloProcessor
+
+package data {
+  class IEventProcessor
+  class MuonSelectionProcessor
+  class ReconstructionProcessor
+  class TruthChannelProcessor
+  class WeightProcessor
+  class BlipProcessor
+}
+
+IEventProcessor <|-- MuonSelectionProcessor
+IEventProcessor <|-- ReconstructionProcessor
+IEventProcessor <|-- TruthChannelProcessor
+IEventProcessor <|-- WeightProcessor
+IEventProcessor <|-- BlipProcessor
+
+package plot {
+  class HistogramPlotterBase
+  class StackedHistogramPlot
+  class UnstackedHistogramPlot
+  class OccupancyMatrixPlot
+  class SelectionEfficiencyPlot
+  class SystematicBreakdownPlot
+  class RocCurvePlot
+}
+
+HistogramPlotterBase <|-- StackedHistogramPlot
+HistogramPlotterBase <|-- UnstackedHistogramPlot
+HistogramPlotterBase <|-- OccupancyMatrixPlot
+HistogramPlotterBase <|-- SelectionEfficiencyPlot
+HistogramPlotterBase <|-- SystematicBreakdownPlot
+HistogramPlotterBase <|-- RocCurvePlot
+
+package plug {
+  class IAnalysisPlugin
+  class AnalysisPluginManager
+  class IPlotPlugin
+  class PlotPluginManager
+}
+
+AnalysisPluginManager o--> IAnalysisPlugin
+PlotPluginManager o--> IPlotPlugin
+
+package syst {
+  class SystematicStrategy
+  class UniverseSystematicStrategy
+  class DetectorSystematicStrategy
+  class WeightSystematicStrategy
+}
+
+SystematicStrategy <|-- UniverseSystematicStrategy
+SystematicStrategy <|-- DetectorSystematicStrategy
+SystematicStrategy <|-- WeightSystematicStrategy
+
+@enduml


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to render PlantUML diagrams and upload artifacts
- document diagram generation workflow in README

## Testing
- `ctest --output-on-failure` (no tests found)
- `plantuml docs/class_diagram.puml` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_68b858f5f374832e94ddb0246c18d4c7