### PR TITLE
Refine class diagram orientation

### DIFF
--- a/docs/class_diagram.puml
+++ b/docs/class_diagram.puml
@@ -1,5 +1,5 @@
 @startuml
-top to bottom direction
+left to right direction
 skinparam {
   linetype ortho
   packageStyle rectangle
@@ -9,11 +9,14 @@ skinparam {
   pageMargin 10
   pageWidth 8.27in
   pageHeight 11.69in
+  roundCorner 15
+  classFontName Helvetica
 }
 
 hide empty members
 
 package app #LightGray {
+  top to bottom direction
   interface ISampleProcessor {
     +processSample()
   }
@@ -41,6 +44,7 @@ AnalysisRunner --> IPlotPlugin : loads
 AnalysisRunner --> SystematicStrategy : configures
 
 package data #LightBlue {
+  top to bottom direction
   interface IEventProcessor {
     +processEvent()
   }
@@ -73,6 +77,7 @@ IEventProcessor <|-- WeightProcessor
 IEventProcessor <|-- BlipProcessor
 
 package plug #LightYellow {
+  top to bottom direction
   interface IAnalysisPlugin {
     +execute()
   }
@@ -94,6 +99,7 @@ AnalysisPluginManager o--> IAnalysisPlugin : manages
 PlotPluginManager o--> IPlotPlugin : manages
 
 package plot #LightGreen {
+  top to bottom direction
   class HistogramPlotterBase {
     +plot()
   }
@@ -114,6 +120,7 @@ HistogramPlotterBase <|-- SystematicBreakdownPlot
 HistogramPlotterBase <|-- RocCurvePlot
 
 package syst #LightPink {
+  top to bottom direction
   class SystematicStrategy {
     +apply()
   }


### PR DESCRIPTION
## Summary
- orient class diagram left-to-right for a more horizontal layout
- style diagram with rounded corners and Helvetica font
- organize package contents with top-to-bottom flow

## Testing
- `plantuml docs/class_diagram.puml` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository access forbidden)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b8740eebb8832ea29bba839aab2410