### PR TITLE
Add PlantUML diagrams

### DIFF
--- a/docs/component_diagram.puml
+++ b/docs/component_diagram.puml
@@ -1,0 +1,6 @@
+@startuml
+component Analysis
+component Plot
+
+Analysis --> Plot
+@enduml

--- a/docs/sequence_diagram.puml
+++ b/docs/sequence_diagram.puml
@@ -1,0 +1,7 @@
+@startuml
+participant Analysis
+participant Plugin
+
+Analysis -> Plugin: load
+Plugin --> Analysis: result
+@enduml


### PR DESCRIPTION
## Summary
- add component and sequence PlantUML diagrams to docs

## Testing
- `source .container.sh` (fails: /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh not found)
- `source .setup.sh` (fails: /cvmfs/uboone.opensciencegrid.org/products/setup_uboone_mcc9.sh not found)
- `source .build.sh` (fails: Could not find package ROOT)
- `ctest --output-on-failure` (fails: No tests were found)

------
https://chatgpt.com/codex/tasks/task_e_68b879b261b8832e8cbb7167903a1c36