### PR TITLE
Add plugin class diagram and README reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ python scripts/generate_analysis_config.py
 ```
 `analyse` executes the analysis and optional plug-ins. `plot` renders figures using the produced ROOT file.
 
+## Plug-in architecture
+See [docs/plugin_class_diagram.puml](docs/plugin_class_diagram.puml) for the relationships between plug-in interfaces, managers, and example implementations.
+
 ## Example plug-ins
 The configuration files contain analysis and plotting directives.
 

--- a/docs/plugin_class_diagram.puml
+++ b/docs/plugin_class_diagram.puml
@@ -1,0 +1,47 @@
+@startuml
+left to right direction
+skinparam {
+  linetype ortho
+  packageStyle rectangle
+  classAttributeIconSize 0
+  shadowing false
+  dpi 150
+  pageMargin 10
+  pageWidth 8.27in
+  pageHeight 11.69in
+  roundCorner 15
+  classFontName Helvetica
+}
+
+hide empty members
+
+package plug #LightYellow {
+  top to bottom direction
+  interface IAnalysisPlugin {
+    +onInitialisation()
+    +onEvent()
+    +onFinalisation()
+  }
+
+  class AnalysisPluginManager {
+    +register()
+  }
+
+  interface IPlotPlugin {
+    +run()
+  }
+
+  class PlotPluginManager {
+    +register()
+  }
+
+  class RocCurvePlugin
+  class CutFlowPlotPlugin
+}
+
+IAnalysisPlugin <|-- RocCurvePlugin
+IPlotPlugin <|-- CutFlowPlotPlugin
+AnalysisPluginManager o--> IAnalysisPlugin : manages
+PlotPluginManager o--> IPlotPlugin : manages
+
+@enduml


### PR DESCRIPTION
## Summary
- Document plug-in interfaces and managers in a new PlantUML diagram
- Reference the plug-in architecture diagram in the README

## Testing
- `ctest --output-on-failure` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b87af2f73c832ea4501ca04dcc55b0