### PR TITLE
docs: add analysis activity diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ The `strategy` field accepts `equal_weight`, `freedman_diaconis`, `scott`, `stur
 ```bash
 ctest --output-on-failure
 ```
+
+## Analysis activity diagram
+
+See [analysis activity diagram](docs/analysis_activity_diagram.puml).

--- a/docs/analysis_activity_diagram.puml
+++ b/docs/analysis_activity_diagram.puml
@@ -1,0 +1,9 @@
+@startuml
+start
+:Load JSON configs;
+:Initialize registries;
+:Process beamlines;
+:Run AnalysisRunner;
+:Save results;
+stop
+@enduml


### PR DESCRIPTION
## Summary
- add analysis activity diagram
- reference analysis activity diagram in README

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b87af412c8832e9cf46168e5ddf2a9