### PR TITLE
Add plotting workflow activity diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ python scripts/generate_analysis_config.py
 ```
 `analyse` executes the analysis and optional plug-ins. `plot` renders figures using the produced ROOT file.
 
+## Plotting workflow
+
+The plotting stages are outlined in [docs/plot_activity_diagram.puml](docs/plot_activity_diagram.puml).
+
 ## Example plug-ins
 The configuration files contain analysis and plotting directives.
 

--- a/docs/plot_activity_diagram.puml
+++ b/docs/plot_activity_diagram.puml
@@ -1,0 +1,13 @@
+@startuml
+start
+
+:Load configs and result file;
+
+:Construct AnalysisDataLoader objects;
+
+:Invoke PlotPluginManager;
+
+:Run plugins;
+
+stop
+@enduml


### PR DESCRIPTION
## Summary
- add PlantUML activity diagram for plotting workflow
- reference diagram in project documentation

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b87af5fb00832eb03f8cb3aaa1d239