### PR TITLE
Add deployment diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Modular framework for precision rare cross-section measurements.
 
+## Diagrams
+- `docs/deployment_diagram.puml` illustrates the deployment architecture.
+
 ## Building
 ```bash
 source .container.sh

--- a/docs/deployment_diagram.puml
+++ b/docs/deployment_diagram.puml
@@ -1,0 +1,19 @@
+@startuml
+node analyse
+node plot
+
+node ROOT
+node "JSON configs"
+
+node "plugin libraries"
+
+node "output data files"
+
+analyse --> ROOT
+analyse --> "JSON configs"
+analyse --> "plugin libraries"
+analyse --> "output data files"
+plot --> ROOT
+plot --> "JSON configs"
+plot --> "output data files"
+@enduml


### PR DESCRIPTION
## Summary
- add deployment diagram illustrating executables, dependencies, plugins, and outputs
- reference the new diagram in documentation

## Testing
- `ctest --output-on-failure` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b87af6f660832eaca665ac9d25b1a1