### PR TITLE
Standardize PlantUML diagram styling

### DIFF
--- a/docs/analysis_activity_diagram.puml
+++ b/docs/analysis_activity_diagram.puml
@@ -1,4 +1,20 @@
 @startuml
+left to right direction
+skinparam {
+  linetype ortho
+  packageStyle rectangle
+  classAttributeIconSize 0
+  shadowing false
+  dpi 150
+  pageMargin 10
+  pageWidth 8.27in
+  pageHeight 11.69in
+  roundCorner 15
+  classFontName Helvetica
+}
+
+hide empty members
+
 start
 :Load JSON configs;
 :Initialize registries;

--- a/docs/component_diagram.puml
+++ b/docs/component_diagram.puml
@@ -1,4 +1,20 @@
 @startuml
+left to right direction
+skinparam {
+  linetype ortho
+  packageStyle rectangle
+  classAttributeIconSize 0
+  shadowing false
+  dpi 150
+  pageMargin 10
+  pageWidth 8.27in
+  pageHeight 11.69in
+  roundCorner 15
+  classFontName Helvetica
+}
+
+hide empty members
+
 component Analysis
 component Plot
 

--- a/docs/deployment_diagram.puml
+++ b/docs/deployment_diagram.puml
@@ -1,4 +1,20 @@
 @startuml
+left to right direction
+skinparam {
+  linetype ortho
+  packageStyle rectangle
+  classAttributeIconSize 0
+  shadowing false
+  dpi 150
+  pageMargin 10
+  pageWidth 8.27in
+  pageHeight 11.69in
+  roundCorner 15
+  classFontName Helvetica
+}
+
+hide empty members
+
 node analyse
 node plot
 

--- a/docs/plot_activity_diagram.puml
+++ b/docs/plot_activity_diagram.puml
@@ -1,4 +1,20 @@
 @startuml
+left to right direction
+skinparam {
+  linetype ortho
+  packageStyle rectangle
+  classAttributeIconSize 0
+  shadowing false
+  dpi 150
+  pageMargin 10
+  pageWidth 8.27in
+  pageHeight 11.69in
+  roundCorner 15
+  classFontName Helvetica
+}
+
+hide empty members
+
 start
 
 :Load configs and result file;

--- a/docs/sequence_diagram.puml
+++ b/docs/sequence_diagram.puml
@@ -1,4 +1,20 @@
 @startuml
+left to right direction
+skinparam {
+  linetype ortho
+  packageStyle rectangle
+  classAttributeIconSize 0
+  shadowing false
+  dpi 150
+  pageMargin 10
+  pageWidth 8.27in
+  pageHeight 11.69in
+  roundCorner 15
+  classFontName Helvetica
+}
+
+hide empty members
+
 participant Analysis
 participant Plugin
 


### PR DESCRIPTION
## Summary
- Apply unified left-to-right orientation and skin parameters across all PlantUML diagrams

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68b880152f94832e83c5215b948b3b7d