### PR TITLE
Internalize stratifier registry

### DIFF
--- a/analyse.cpp
+++ b/analyse.cpp
@@ -14,7 +14,6 @@
 #include "RunConfigLoader.h"
 #include "RunConfigRegistry.h"
 #include "SelectionRegistry.h"
-#include "StratifierRegistry.h"
 #include "SystematicsProcessor.h"
 #include "VariableRegistry.h"
 
@@ -40,7 +39,6 @@ static analysis::AnalysisResult runAnalysis(const nlohmann::json &samples, const
 
         analysis::VariableRegistry variable_registry;
         analysis::SelectionRegistry selection_registry;
-        analysis::StratifierRegistry stratifier_registry;
 
         std::vector<analysis::KnobDef> knob_defs;
         knob_defs.reserve(variable_registry.knobVariations().size());
@@ -57,7 +55,7 @@ static analysis::AnalysisResult runAnalysis(const nlohmann::json &samples, const
         analysis::SystematicsProcessor systematics_processor(knob_defs, universe_defs);
         analysis::AnalysisDataLoader data_loader(run_config_registry, variable_registry, beam, periods,
                                                  ntuple_directory, true);
-        auto histogram_booker = std::make_unique<analysis::HistogramBooker>(stratifier_registry);
+        auto histogram_booker = std::make_unique<analysis::HistogramBooker>();
 
         analysis::AnalysisRunner runner(data_loader, selection_registry, variable_registry, std::move(histogram_booker),
                                         systematics_processor, analysis);

--- a/libhist/HistogramBooker.h
+++ b/libhist/HistogramBooker.h
@@ -11,8 +11,8 @@ namespace analysis {
 
 class HistogramBooker : public IHistogramBooker {
   public:
-    HistogramBooker(StratifierRegistry &strat_reg)
-        : stratifier_manager_(strat_reg) {
+    HistogramBooker()
+        : stratifier_manager_(stratifier_registry_) {
         log::debug("HistogramBooker::HistogramBooker",
                    "Constructor called, StratifierManager has been created.");
     }
@@ -45,6 +45,7 @@ class HistogramBooker : public IHistogramBooker {
     }
 
   private:
+    StratifierRegistry stratifier_registry_;
     StratifierManager stratifier_manager_;
 };
 


### PR DESCRIPTION
## Summary
- Create StratifierRegistry inside HistogramBooker
- Instantiate HistogramBooker without external registry in analyse.cpp

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc97f451bc832e828b5c72a48de71d