### PR TITLE
Use VariableRegistry in SystematicsProcessor

### DIFF
--- a/analyse.cpp
+++ b/analyse.cpp
@@ -42,19 +42,8 @@ static analysis::AnalysisResult runAnalysis(const nlohmann::json &samples, const
         analysis::SelectionRegistry selection_registry;
         analysis::StratifierRegistry stratifier_registry;
 
-        std::vector<analysis::KnobDef> knob_defs;
-        knob_defs.reserve(variable_registry.knobVariations().size());
-        for (const auto &kv : variable_registry.knobVariations()) {
-            knob_defs.push_back({kv.first, kv.second.first, kv.second.second});
-        }
+        analysis::SystematicsProcessor systematics_processor(variable_registry);
 
-        std::vector<analysis::UniverseDef> universe_defs;
-        universe_defs.reserve(variable_registry.multiUniverseVariations().size());
-        for (const auto &kv : variable_registry.multiUniverseVariations()) {
-            universe_defs.push_back({kv.first, kv.first, kv.second});
-        }
-
-        analysis::SystematicsProcessor systematics_processor(knob_defs, universe_defs);
         analysis::AnalysisDataLoader data_loader(run_config_registry, variable_registry, beam, periods,
                                                  ntuple_directory, true);
         auto histogram_booker = std::make_unique<analysis::HistogramBooker>(stratifier_registry);

--- a/libsyst/SystematicsProcessor.h
+++ b/libsyst/SystematicsProcessor.h
@@ -15,53 +15,45 @@
 #include "DetectorSystematicStrategy.h"
 #include "SystematicStrategy.h"
 #include "UniverseSystematicStrategy.h"
+#include "VariableRegistry.h"
 #include "WeightSystematicStrategy.h"
 
 namespace analysis {
 
 class SystematicsProcessor {
   public:
-    SystematicsProcessor(std::vector<KnobDef> knob_definitions,
-                         std::vector<UniverseDef> universe_definitions,
+    SystematicsProcessor(const VariableRegistry &registry, bool store_universe_hists = false)
+        : SystematicsProcessor(createKnobs(registry), createUniverses(registry), store_universe_hists) {}
+
+    SystematicsProcessor(std::vector<KnobDef> knob_definitions, std::vector<UniverseDef> universe_definitions,
                          bool store_universe_hists = false)
-        : knob_definitions_(std::move(knob_definitions)),
-          universe_definitions_(std::move(universe_definitions)),
+        : knob_definitions_(std::move(knob_definitions)), universe_definitions_(std::move(universe_definitions)),
           store_universe_hists_(store_universe_hists) {
-        systematic_strategies_.emplace_back(
-            std::make_unique<DetectorSystematicStrategy>());
+        systematic_strategies_.emplace_back(std::make_unique<DetectorSystematicStrategy>());
         for (const auto &knob : knob_definitions_) {
-            systematic_strategies_.emplace_back(
-                std::make_unique<WeightSystematicStrategy>(knob));
+            systematic_strategies_.emplace_back(std::make_unique<WeightSystematicStrategy>(knob));
         }
         for (const auto &universe : universe_definitions_) {
             systematic_strategies_.emplace_back(
-                std::make_unique<UniverseSystematicStrategy>(universe,
-                                                             store_universe_hists_));
+                std::make_unique<UniverseSystematicStrategy>(universe, store_universe_hists_));
         }
 
-        log::debug("SystematicsProcessor", "Initialised with",
-                   knob_definitions_.size(), "weight knobs and",
+        log::debug("SystematicsProcessor", "Initialised with", knob_definitions_.size(), "weight knobs and",
                    universe_definitions_.size(), "universe variations");
     }
 
-    void bookSystematics(const SampleKey &sample_key, ROOT::RDF::RNode &rnode,
-                         const BinningDefinition &binning,
+    void bookSystematics(const SampleKey &sample_key, ROOT::RDF::RNode &rnode, const BinningDefinition &binning,
                          const ROOT::RDF::TH1DModel &model) {
-        log::debug("SystematicsProcessor::bookSystematics",
-                   "Booking variations for sample", sample_key.str());
+        log::debug("SystematicsProcessor::bookSystematics", "Booking variations for sample", sample_key.str());
         for (const auto &strategy : systematic_strategies_) {
-            log::debug("SystematicsProcessor::bookSystematics", "-> Strategy",
-                       strategy->getName());
-            strategy->bookVariations(sample_key, rnode, binning, model,
-                                     systematic_futures_);
+            log::debug("SystematicsProcessor::bookSystematics", "-> Strategy", strategy->getName());
+            strategy->bookVariations(sample_key, rnode, binning, model, systematic_futures_);
         }
-        log::debug("SystematicsProcessor::bookSystematics",
-                   "Completed booking for sample", sample_key.str());
+        log::debug("SystematicsProcessor::bookSystematics", "Completed booking for sample", sample_key.str());
     }
 
     void processSystematics(VariableResult &result) {
-        log::debug("SystematicsProcessor::processSystematics",
-                   "Commencing covariance calculations");
+        log::debug("SystematicsProcessor::processSystematics", "Commencing covariance calculations");
         auto sanitize = [](TMatrixDSym &m) {
             for (int i = 0; i < m.GetNrows(); ++i) {
                 for (int j = 0; j < m.GetNcols(); ++j) {
@@ -73,12 +65,11 @@ class SystematicsProcessor {
         };
         for (const auto &strategy : systematic_strategies_) {
             SystematicKey key{strategy->getName()};
-            log::debug("SystematicsProcessor::processSystematics",
-                       "Computing covariance for", key.str());
+            log::debug("SystematicsProcessor::processSystematics", "Computing covariance for", key.str());
             auto cov = strategy->computeCovariance(result, systematic_futures_);
             sanitize(cov);
-            log::debug("SystematicsProcessor::processSystematics", key.str(),
-                       "matrix size", cov.GetNrows(), "x", cov.GetNcols());
+            log::debug("SystematicsProcessor::processSystematics", key.str(), "matrix size", cov.GetNrows(), "x",
+                       cov.GetNcols());
             result.covariance_matrices_.insert_or_assign(key, cov);
         }
 
@@ -86,20 +77,16 @@ class SystematicsProcessor {
         if (n_bins > 0) {
             result.total_covariance_.ResizeTo(n_bins, n_bins);
             result.total_covariance_ = result.total_mc_hist_.hist.covariance();
-            log::debug("SystematicsProcessor::processSystematics",
-                       "Combining covariance matrices");
+            log::debug("SystematicsProcessor::processSystematics", "Combining covariance matrices");
             for (const auto &[name, cov_matrix] : result.covariance_matrices_) {
                 if (cov_matrix.GetNrows() == n_bins) {
                     TMatrixDSym cov = cov_matrix;
                     sanitize(cov);
-                    log::debug("SystematicsProcessor::processSystematics",
-                               "Adding matrix", name.str());
+                    log::debug("SystematicsProcessor::processSystematics", "Adding matrix", name.str());
                     result.total_covariance_ += cov;
                 } else {
-                    log::warn("SystematicsProcessor::processSystematics",
-                              "Skipping systematic", name.str(),
-                              "due to incompatible matrix size (",
-                              cov_matrix.GetNrows(), "x", cov_matrix.GetNcols(),
+                    log::warn("SystematicsProcessor::processSystematics", "Skipping systematic", name.str(),
+                              "due to incompatible matrix size (", cov_matrix.GetNrows(), "x", cov_matrix.GetNcols(),
                               "vs expected", n_bins, "x", n_bins, ")");
                 }
             }
@@ -108,13 +95,30 @@ class SystematicsProcessor {
             result.nominal_with_band_.hist.shifts.resize(n_bins, 0);
             result.nominal_with_band_.addCovariance(result.total_covariance_);
         }
-        log::debug("SystematicsProcessor::processSystematics",
-                   "Covariance calculation complete");
+        log::debug("SystematicsProcessor::processSystematics", "Covariance calculation complete");
     }
 
     void clearFutures() { systematic_futures_.variations.clear(); }
 
   private:
+    static std::vector<KnobDef> createKnobs(const VariableRegistry &registry) {
+        std::vector<KnobDef> out;
+        out.reserve(registry.knobVariations().size());
+        for (auto &kv : registry.knobVariations()) {
+            out.push_back({kv.first, kv.second.first, kv.second.second});
+        }
+        return out;
+    }
+
+    static std::vector<UniverseDef> createUniverses(const VariableRegistry &registry) {
+        std::vector<UniverseDef> out;
+        out.reserve(registry.multiUniverseVariations().size());
+        for (auto &kv : registry.multiUniverseVariations()) {
+            out.push_back({kv.first, kv.first, kv.second});
+        }
+        return out;
+    }
+
     std::vector<std::unique_ptr<SystematicStrategy>> systematic_strategies_;
     std::vector<KnobDef> knob_definitions_;
     std::vector<UniverseDef> universe_definitions_;
@@ -122,6 +126,6 @@ class SystematicsProcessor {
     SystematicFutures systematic_futures_;
 };
 
-}
+} // namespace analysis
 
 #endif


### PR DESCRIPTION
## Summary
- build SystematicsProcessor from VariableRegistry
- simplify analyse.cpp by passing registry directly to systematics processor

## Testing
- `cmake -S . -B build` *(fails: ROOT package missing)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc98486fe8832eb28dc2005d1ba6be