### PR TITLE
Use RAII in SystematicBreakdownPlot and modularize draw

### DIFF
--- a/libplot/SystematicBreakdownPlot.cpp
+++ b/libplot/SystematicBreakdownPlot.cpp
@@ -1,6 +1,5 @@
 #include "SystematicBreakdownPlot.h"
 
-#include <algorithm>
 #include <cmath>
 
 #include "TCanvas.h"
@@ -9,26 +8,16 @@
 namespace analysis {
 
 SystematicBreakdownPlot::SystematicBreakdownPlot(
-    std::string plot_name, const VariableResult &var_result, bool normalise,
+    std::string plot_name,
+    const VariableResult &var_result,
+    bool normalise,
     std::string output_directory)
     : HistogramPlotterBase(std::move(plot_name), std::move(output_directory)),
-      variable_result_(var_result), normalise_(normalise), stack_(nullptr),
-      legend_(nullptr) {}
+      variable_result_(var_result),
+      normalise_(normalise) {}
 
-SystematicBreakdownPlot::~SystematicBreakdownPlot() {
-    delete stack_;
-    delete legend_;
-    for (auto *h : histograms_) {
-        delete h;
-    }
-}
-
-void SystematicBreakdownPlot::draw(TCanvas &canvas) {
-    canvas.cd();
-
-    const auto &edges = variable_result_.binning_.getEdges();
+std::vector<double> SystematicBreakdownPlot::calculateTotals() const {
     const int nbins = variable_result_.binning_.getBinNumber();
-
     std::vector<double> bin_totals(nbins, 0.0);
     for (const auto &[key, cov] : variable_result_.covariance_matrices_) {
         const int n = cov.GetNrows();
@@ -40,21 +29,32 @@ void SystematicBreakdownPlot::draw(TCanvas &canvas) {
         }
     }
 
-    stack_ = new THStack("syst_stack", "");
-    legend_ = new TLegend(0.65, 0.7, 0.9, 0.9);
+    return bin_totals;
+}
+
+void SystematicBreakdownPlot::fillHistograms(
+    const std::vector<double> &totals) {
+    const auto &edges = variable_result_.binning_.getEdges();
+    const int nbins = variable_result_.binning_.getBinNumber();
+
+    stack_ = std::make_unique<THStack>("syst_stack", "");
+    legend_ = std::make_unique<TLegend>(0.65, 0.7, 0.9, 0.9);
     legend_->SetBorderSize(0);
     legend_->SetFillStyle(0);
     legend_->SetTextFont(42);
 
+    histograms_.clear();
+
     int colour = kRed + 1;
     for (const auto &[key, cov] : variable_result_.covariance_matrices_) {
-        TH1D *hist = new TH1D(key.str().c_str(), "", nbins, edges.data());
+        auto hist =
+            std::make_unique<TH1D>(key.str().c_str(), "", nbins, edges.data());
         const int n = cov.GetNrows();
         for (int i = 0; i < nbins && i < n; ++i) {
             double val = cov(i, i);
             if (std::isfinite(val)) {
-                if (normalise_ && bin_totals[i] > 0.0) {
-                    val /= bin_totals[i];
+                if (normalise_ && totals[i] > 0.0) {
+                    val /= totals[i];
                 }
                 hist->SetBinContent(i + 1, val);
             } else {
@@ -63,18 +63,30 @@ void SystematicBreakdownPlot::draw(TCanvas &canvas) {
         }
         hist->SetFillColor(colour);
         hist->SetLineColor(kBlack);
-        stack_->Add(hist);
-        legend_->AddEntry(hist, key.str().c_str(), "f");
-        histograms_.push_back(hist);
+        stack_->Add(hist.get());
+        legend_->AddEntry(hist.get(), key.str().c_str(), "f");
+        histograms_.push_back(std::move(hist));
         ++colour;
     }
+}
 
+void SystematicBreakdownPlot::renderStackLegend() {
     stack_->Draw("hist");
     stack_->GetXaxis()->SetTitle(
         variable_result_.binning_.getTexLabel().c_str());
-    stack_->GetYaxis()->SetTitle(normalise_ ? "Fractional Contribution"
-                                            : "Variance");
+    stack_->GetYaxis()->SetTitle(
+        normalise_ ? "Fractional Contribution" : "Variance");
+
     legend_->Draw();
 }
 
+void SystematicBreakdownPlot::draw(TCanvas &canvas) {
+    canvas.cd();
+
+    auto totals = calculateTotals();
+    fillHistograms(totals);
+    renderStackLegend();
 }
+
+}
+

--- a/libplot/SystematicBreakdownPlot.h
+++ b/libplot/SystematicBreakdownPlot.h
@@ -1,6 +1,7 @@
 #ifndef SYSTEMATIC_BREAKDOWN_PLOT_H
 #define SYSTEMATIC_BREAKDOWN_PLOT_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -19,16 +20,19 @@ class SystematicBreakdownPlot : public HistogramPlotterBase {
                             const VariableResult &var_result,
                             bool normalise = false,
                             std::string output_directory = "plots");
-    ~SystematicBreakdownPlot() override;
 
   private:
     void draw(TCanvas &canvas) override;
 
+    std::vector<double> calculateTotals() const;
+    void fillHistograms(const std::vector<double> &totals);
+    void renderStackLegend();
+
     const VariableResult &variable_result_;
     bool normalise_;
-    THStack *stack_;
-    std::vector<TH1D *> histograms_;
-    TLegend *legend_;
+    std::unique_ptr<THStack> stack_;
+    std::vector<std::unique_ptr<TH1D>> histograms_;
+    std::unique_ptr<TLegend> legend_;
 };
 
 } 


### PR DESCRIPTION
## Summary
- Replace raw ROOT pointers with `std::unique_ptr` and drop manual deletes
- Introduce helpers for bin totals, histogram creation, and stack/legend rendering
- Simplify `draw` to orchestrate the helper calls

## Testing
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bc9cf697cc832e9d4700a7629659d9