### PR TITLE
Refactor SystematicsProcessor covariance helpers

### DIFF
--- a/libsyst/SystematicsProcessor.h
+++ b/libsyst/SystematicsProcessor.h
@@ -54,53 +54,62 @@ class SystematicsProcessor {
 
     void processSystematics(VariableResult &result) {
         log::debug("SystematicsProcessor::processSystematics", "Commencing covariance calculations");
-        auto sanitize = [](TMatrixDSym &m) {
-            for (int i = 0; i < m.GetNrows(); ++i) {
-                for (int j = 0; j < m.GetNcols(); ++j) {
-                    if (!std::isfinite(m(i, j))) {
-                        m(i, j) = 0.0;
-                    }
-                }
-            }
-        };
         for (const auto &strategy : systematic_strategies_) {
             SystematicKey key{strategy->getName()};
             log::debug("SystematicsProcessor::processSystematics", "Computing covariance for", key.str());
             auto cov = strategy->computeCovariance(result, systematic_futures_);
-            sanitize(cov);
+            sanitizeMatrix(cov);
             log::debug("SystematicsProcessor::processSystematics", key.str(), "matrix size", cov.GetNrows(), "x",
                        cov.GetNcols());
             result.covariance_matrices_.insert_or_assign(key, cov);
         }
-
-        int n_bins = result.total_mc_hist_.getNumberOfBins();
-        if (n_bins > 0) {
-            result.total_covariance_.ResizeTo(n_bins, n_bins);
-            result.total_covariance_ = result.total_mc_hist_.hist.covariance();
-            log::debug("SystematicsProcessor::processSystematics", "Combining covariance matrices");
-            for (const auto &[name, cov_matrix] : result.covariance_matrices_) {
-                if (cov_matrix.GetNrows() == n_bins) {
-                    TMatrixDSym cov = cov_matrix;
-                    sanitize(cov);
-                    log::debug("SystematicsProcessor::processSystematics", "Adding matrix", name.str());
-                    result.total_covariance_ += cov;
-                } else {
-                    log::warn("SystematicsProcessor::processSystematics", "Skipping systematic", name.str(),
-                              "due to incompatible matrix size (", cov_matrix.GetNrows(), "x", cov_matrix.GetNcols(),
-                              "vs expected", n_bins, "x", n_bins, ")");
-                }
-            }
-            sanitize(result.total_covariance_);
-            result.nominal_with_band_ = result.total_mc_hist_;
-            result.nominal_with_band_.hist.shifts.resize(n_bins, 0);
-            result.nominal_with_band_.addCovariance(result.total_covariance_);
-        }
+        combineCovariances(result);
         log::debug("SystematicsProcessor::processSystematics", "Covariance calculation complete");
     }
 
     void clearFutures() { systematic_futures_.variations.clear(); }
 
   private:
+    static void sanitizeMatrix(TMatrixDSym &m) {
+        for (int i = 0; i < m.GetNrows(); ++i) {
+            for (int j = 0; j < m.GetNcols(); ++j) {
+                if (!std::isfinite(m(i, j))) m(i, j) = 0.0;
+            }
+        }
+    }
+
+    static void combineCovariances(VariableResult &result) {
+        int n_bins = result.total_mc_hist_.getNumberOfBins();
+
+        if (n_bins <= 0) return;
+
+        result.total_covariance_.ResizeTo(n_bins, n_bins);
+        result.total_covariance_ = result.total_mc_hist_.hist.covariance();
+
+        log::debug("SystematicsProcessor::combineCovariances", "Combining covariance matrices");
+
+        for (const auto &[name, cov_matrix] : result.covariance_matrices_) {
+            if (cov_matrix.GetNrows() == n_bins) {
+                TMatrixDSym cov = cov_matrix;
+                sanitizeMatrix(cov);
+
+                log::debug("SystematicsProcessor::combineCovariances", "Adding matrix", name.str());
+
+                result.total_covariance_ += cov;
+            } else {
+                log::warn("SystematicsProcessor::combineCovariances", "Skipping systematic", name.str(),
+                          "due to incompatible matrix size (", cov_matrix.GetNrows(), "x", cov_matrix.GetNcols(),
+                          "vs expected", n_bins, "x", n_bins, ")");
+            }
+        }
+
+        sanitizeMatrix(result.total_covariance_);
+
+        result.nominal_with_band_ = result.total_mc_hist_;
+        result.nominal_with_band_.hist.shifts.resize(n_bins, 0);
+        result.nominal_with_band_.addCovariance(result.total_covariance_);
+    }
+
     static std::vector<KnobDef> createKnobs(const VariableRegistry &registry) {
         std::vector<KnobDef> out;
         out.reserve(registry.knobVariations().size());


### PR DESCRIPTION
## Summary
- Extract helper to sanitize covariance matrices
- Add helper to combine individual covariances into totals
- Delegate orchestration to processSystematics for clarity

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*
- `ctest --output-on-failure` *(No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9cfab530832ea022fabfc1932857