### PR TITLE
Refactor UnstackedHistogramPlot draw into modular helpers

### DIFF
--- a/libplot/UnstackedHistogramPlot.h
+++ b/libplot/UnstackedHistogramPlot.h
@@ -8,6 +8,7 @@
 #include <numeric>
 #include <sstream>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "TArrow.h"
@@ -111,48 +112,56 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
         watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.27, line5.c_str());
     }
 
-  protected:
-    void draw(TCanvas &canvas) override {
-        log::info("UnstackedHistogramPlot::draw",
-                  "X-axis label from result:", variable_result_.binning_.getTexLabel().c_str());
+    std::pair<TPad *, TPad *> setupPads(TCanvas &canvas) const {
         const double PLOT_LEGEND_SPLIT = 0.85;
+
         canvas.cd();
         TPad *p_main = new TPad("main_pad", "main_pad", 0.0, 0.0, 1.0, PLOT_LEGEND_SPLIT);
         TPad *p_legend = new TPad("legend_pad", "legend_pad", 0.0, PLOT_LEGEND_SPLIT, 1.0, 1.0);
+
         p_main->SetTopMargin(0.01);
         p_main->SetBottomMargin(0.12);
         p_main->SetLeftMargin(0.12);
         p_main->SetRightMargin(0.05);
+
         if (use_log_y_)
             p_main->SetLogy();
+
         p_legend->SetTopMargin(0.05);
         p_legend->SetBottomMargin(0.01);
         p_legend->Draw();
         p_main->Draw();
 
-        StratifierRegistry registry;
+        return {p_main, p_legend};
+    }
 
+    std::pair<std::vector<std::pair<ChannelKey, BinnedHistogram>>, double> collectHistograms() const {
         std::vector<std::pair<ChannelKey, BinnedHistogram>> mc_hists;
-        for (auto const &[key, hist] : variable_result_.strat_hists_) {
-            if (hist.getSum() > 0) {
+
+        for (auto const &[key, hist] : variable_result_.strat_hists_)
+            if (hist.getSum() > 0)
                 mc_hists.emplace_back(key, hist);
-            }
-        }
 
         std::sort(mc_hists.begin(), mc_hists.end(),
                   [](const auto &a, const auto &b) { return a.second.getSum() < b.second.getSum(); });
         std::reverse(mc_hists.begin(), mc_hists.end());
 
         double total_mc_events = 0.0;
-        for (const auto &[key, hist] : mc_hists) {
-            total_mc_events += hist.getSum();
-        }
 
+        for (const auto &[key, hist] : mc_hists)
+            total_mc_events += hist.getSum();
+
+        return {mc_hists, total_mc_events};
+    }
+
+    void buildLegend(TPad *p_legend, const std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists) {
         p_legend->cd();
+
         legend_ = new TLegend(0.12, 0.0, 0.95, 1.0);
         legend_->SetBorderSize(0);
         legend_->SetFillStyle(0);
         legend_->SetTextFont(42);
+
         const int n_entries = mc_hists.size();
         int n_cols = (n_entries > 4) ? 3 : 2;
         legend_->SetNColumns(n_cols);
@@ -164,44 +173,64 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
             return stream.str();
         };
 
-        p_main->cd();
-        double max_y = use_log_y_ ? 0.1 : 0.0;
-        bool first_drawn = false;
+        StratifierRegistry registry;
 
         for (const auto &[key, hist] : mc_hists) {
-            TH1D *h = (TH1D *)hist.get()->Clone();
-            h->SetDirectory(0);
-            const auto &stratum = registry.getStratumProperties(category_column_, std::stoi(key.str()));
-            h->SetLineColor(stratum.fill_colour);
-            h->SetLineWidth(2);
-            h->SetFillStyle(0);
-            if (area_normalise_ && h->Integral() > 0)
-                h->Scale(1.0 / h->Integral());
-            max_y = std::max(max_y, h->GetMaximum());
-            if (!first_drawn) {
-                h->Draw("HIST");
-                first_drawn = true;
-            } else {
-                h->Draw("HIST SAME");
-            }
-            hists_.push_back(h);
-
             TH1D *h_leg = new TH1D();
+
+            const auto &stratum = registry.getStratumProperties(category_column_, std::stoi(key.str()));
             h_leg->SetLineColor(stratum.fill_colour);
             h_leg->SetLineWidth(2);
             h_leg->SetFillStyle(0);
 
             std::string tex_label = stratum.tex_label;
-            if (tex_label == "#emptyset") {
+
+            if (tex_label == "#emptyset")
                 tex_label = "\xE2\x88\x85";
-            }
+
             std::string legend_label =
                 annotate_numbers_ ? tex_label + " : " + format_double(hist.getSum(), 2) : tex_label;
             legend_->AddEntry(h_leg, legend_label.c_str(), "l");
         }
 
         legend_->Draw();
+    }
 
+    double drawHistograms(TPad *p_main, const std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists) {
+        p_main->cd();
+
+        StratifierRegistry registry;
+
+        double max_y = use_log_y_ ? 0.1 : 0.0;
+        bool first_drawn = false;
+
+        for (const auto &[key, hist] : mc_hists) {
+            TH1D *h = (TH1D *)hist.get()->Clone();
+            h->SetDirectory(0);
+
+            const auto &stratum = registry.getStratumProperties(category_column_, std::stoi(key.str()));
+            h->SetLineColor(stratum.fill_colour);
+            h->SetLineWidth(2);
+            h->SetFillStyle(0);
+
+            if (area_normalise_ && h->Integral() > 0)
+                h->Scale(1.0 / h->Integral());
+
+            max_y = std::max(max_y, h->GetMaximum());
+
+            if (!first_drawn) {
+                h->Draw("HIST");
+                first_drawn = true;
+            } else
+                h->Draw("HIST SAME");
+
+            hists_.push_back(h);
+        }
+
+        return max_y;
+    }
+
+    void renderCuts(double max_y) {
         for (const auto &cut : cuts_) {
             double y_arrow_pos = max_y * 0.85;
             double x_range = hists_.empty() ? 0.0 : hists_[0]->GetXaxis()->GetXmax() - hists_[0]->GetXaxis()->GetXmin();
@@ -215,6 +244,7 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
             cut_visuals_.push_back(line);
 
             double x_start, x_end;
+
             if (cut.direction == CutDirection::GreaterThan) {
                 x_start = cut.threshold;
                 x_end = cut.threshold + arrow_length;
@@ -222,6 +252,7 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
                 x_start = cut.threshold;
                 x_end = cut.threshold - arrow_length;
             }
+
             TArrow *arrow = new TArrow(x_start, y_arrow_pos, x_end, y_arrow_pos, 0.025, ">");
             arrow->SetLineColor(kRed);
             arrow->SetFillColor(kRed);
@@ -229,26 +260,48 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
             arrow->Draw("same");
             cut_visuals_.push_back(arrow);
         }
+    }
 
-        if (!hists_.empty()) {
-            hists_[0]->GetXaxis()->SetTitle(variable_result_.binning_.getTexLabel().c_str());
-            hists_[0]->GetYaxis()->SetTitle(y_axis_label_.c_str());
-            hists_[0]->GetXaxis()->SetTitleOffset(1.0);
-            hists_[0]->GetYaxis()->SetTitleOffset(1.0);
+    void configureAxes() {
+        if (hists_.empty())
+            return;
 
-            const auto &edges = variable_result_.binning_.getEdges();
-            hists_[0]->GetXaxis()->SetLimits(edges.front(), edges.back());
-            hists_[0]->GetXaxis()->SetNdivisions(520);
-            hists_[0]->GetXaxis()->SetTickLength(0.02);
-            if (edges.size() >= 3) {
-                std::ostringstream uf_label, of_label;
-                uf_label << "<" << edges[1];
-                of_label << ">" << edges[edges.size() - 2];
-                hists_[0]->GetXaxis()->ChangeLabel(1, -1, -1, -1, -1, -1, uf_label.str().c_str());
-                hists_[0]->GetXaxis()->ChangeLabel(hists_[0]->GetXaxis()->GetNbins(), -1, -1, -1, -1, -1,
-                                                   of_label.str().c_str());
-            }
+        hists_[0]->GetXaxis()->SetTitle(variable_result_.binning_.getTexLabel().c_str());
+        hists_[0]->GetYaxis()->SetTitle(y_axis_label_.c_str());
+        hists_[0]->GetXaxis()->SetTitleOffset(1.0);
+        hists_[0]->GetYaxis()->SetTitleOffset(1.0);
+
+        const auto &edges = variable_result_.binning_.getEdges();
+        hists_[0]->GetXaxis()->SetLimits(edges.front(), edges.back());
+        hists_[0]->GetXaxis()->SetNdivisions(520);
+        hists_[0]->GetXaxis()->SetTickLength(0.02);
+
+        if (edges.size() >= 3) {
+            std::ostringstream uf_label, of_label;
+            uf_label << "<" << edges[1];
+            of_label << ">" << edges[edges.size() - 2];
+            hists_[0]->GetXaxis()->ChangeLabel(1, -1, -1, -1, -1, -1, uf_label.str().c_str());
+            hists_[0]->GetXaxis()->ChangeLabel(hists_[0]->GetXaxis()->GetNbins(), -1, -1, -1, -1, -1,
+                                               of_label.str().c_str());
         }
+    }
+
+  protected:
+    void draw(TCanvas &canvas) override {
+        log::info("UnstackedHistogramPlot::draw",
+                  "X-axis label from result:", variable_result_.binning_.getTexLabel().c_str());
+
+        auto [p_main, p_legend] = setupPads(canvas);
+
+        auto [mc_hists, total_mc_events] = collectHistograms();
+
+        buildLegend(p_legend, mc_hists);
+
+        double max_y = drawHistograms(p_main, mc_hists);
+
+        renderCuts(max_y);
+
+        configureAxes();
 
         drawWatermark(p_main, total_mc_events);
 


### PR DESCRIPTION
## Summary
- Refactor `UnstackedHistogramPlot::draw` by decomposing responsibilities into dedicated helpers
- Introduce setupPads, collectHistograms, buildLegend, drawHistograms, renderCuts, and configureAxes to improve readability
- Preserve watermark placement as the final drawing step

## Testing
- ⚠️ `source .container.sh` *(missing /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh)*
- ⚠️ `source .setup.sh` *(missing /cvmfs/uboone.opensciencegrid.org/products/setup_uboone_mcc9.sh and setup commands)*
- ⚠️ `source .build.sh` *(CMake failed: Could not find package configuration file provided by "ROOT")*
- ⚠️ `ctest --output-on-failure` *(No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9dc0e4c4832ea5699f0e22fcf35b