### PR TITLE
Allow updating scheme tallies

### DIFF
--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -166,7 +166,7 @@ class AnalysisRunner {
         return filters;
     }
 
-    void updateSchemeTallies(const ROOT::RDF::RNode &df, const std::vector<std::string> &schemes,
+    void updateSchemeTallies(ROOT::RDF::RNode df, const std::vector<std::string> &schemes,
                              const std::unordered_map<std::string, std::vector<int>> &scheme_keys,
                              RegionAnalysis::StageCount &stage_count) {
         for (auto &s : schemes)


### PR DESCRIPTION
## Summary
- allow updating scheme tallies by letting the function take RNode by value

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9eeeee70832e8799a94dcccabc42