### PR TITLE
Fix signed comparison warnings in selection efficiency plot

### DIFF
--- a/libplot/SelectionEfficiencyPlot.h
+++ b/libplot/SelectionEfficiencyPlot.h
@@ -50,7 +50,7 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
         double y_min = use_log_y_ ? 1e-3 : 0.0;
         frame.GetYaxis()->SetRangeUser(y_min, 1.05);
         frame.GetYaxis()->SetTitle("Fraction");
-        for (int i = 0; i < stages_.size(); ++i)
+        for (size_t i = 0; i < stages_.size(); ++i)
             frame.GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
         frame.DrawClone("AXIS");
     }
@@ -82,7 +82,7 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
         latex.SetTextAlign(23);
         latex.SetTextFont(42);
         latex.SetTextSize(0.035);
-        for (int i = 0; i < stages_.size(); ++i) {
+        for (size_t i = 0; i < stages_.size(); ++i) {
             double x = i + 0.5;
             double ye = efficiencies_[i];
             double yp = purities_[i];


### PR DESCRIPTION
## Summary
- Use `size_t` indices when looping over selection stages

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*
- `sudo apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bca01630ac832e91f792729ea01568