### PR TITLE
Refactor detector covariance computation

### DIFF
--- a/libsyst/DetectorSystematicStrategy.h
+++ b/libsyst/DetectorSystematicStrategy.h
@@ -5,6 +5,7 @@
 #include "BinnedHistogram.h"
 #include "SystematicStrategy.h"
 #include <cmath>
+#include <optional>
 
 namespace analysis {
 
@@ -19,81 +20,39 @@ class DetectorSystematicStrategy : public SystematicStrategy {
 
     TMatrixDSym computeCovariance(VariableResult &result, SystematicFutures &) override {
         const auto &nominal_hist = result.total_mc_hist_;
+
         int n_bins = nominal_hist.getNumberOfBins();
+
         TMatrixDSym total_detvar_cov(n_bins);
+
         total_detvar_cov.Zero();
 
         log::debug("DetectorSystematicStrategy::computeCovariance",
                    "Raw detvar histograms:", result.raw_detvar_hists_.size());
+
         if (result.raw_detvar_hists_.empty()) {
             log::info("DetectorSystematicStrategy::computeCovariance",
-                      "No detector variation samples found. Skipping detector "
-                      "systematics.");
+                      "No detector variation samples found. Skipping detector systematics.");
+
             return total_detvar_cov;
         }
 
-        std::map<SampleVariation, BinnedHistogram> total_detvar_hists;
-        for (const auto &[sample_key, var_map] : result.raw_detvar_hists_) {
-            log::debug("DetectorSystematicStrategy::computeCovariance", "Aggregating sample", sample_key.str());
-            for (const auto &[var_type, hist] : var_map) {
-                log::debug("DetectorSystematicStrategy::computeCovariance", "--> variation", variationToKey(var_type));
-                if (total_detvar_hists.find(var_type) == total_detvar_hists.end()) {
-                    total_detvar_hists[var_type] = hist;
-                } else {
-                    total_detvar_hists[var_type] = total_detvar_hists[var_type] + hist;
-                }
-            }
-        }
+        auto total_detvar_hists = aggregateVariations(result);
 
-        auto it_cv = total_detvar_hists.find(SampleVariation::kCV);
-        if (it_cv == total_detvar_hists.end()) {
-            log::warn("DetectorSystematicStrategy::computeCovariance",
-                      "No detector variation CV histogram found. Skipping.");
+        auto h_det_cv_opt = sanitizeCvHistogram(total_detvar_hists);
+
+        if (!h_det_cv_opt)
             return total_detvar_cov;
-        }
-        auto h_det_cv = it_cv->second;
-        int n_cv_bins = h_det_cv.getNumberOfBins();
-        for (int i = 0; i < n_cv_bins; ++i) {
-            double cv = h_det_cv.getBinContent(i);
-            if (!std::isfinite(cv) || cv == 0.0) {
-                h_det_cv.hist.counts[i] = 0.0;
-                h_det_cv.hist.shifts.row(i).setZero();
-            }
-        }
 
-        for (const auto &[var_key, h_det_k] : total_detvar_hists) {
-            if (var_key == SampleVariation::kCV)
-                continue;
+        auto h_det_cv = *h_det_cv_opt;
 
-            log::debug("DetectorSystematicStrategy::computeCovariance", "Projecting variation",
-                       variationToKey(var_key));
+        projectVariations(result, nominal_hist, h_det_cv, total_detvar_hists);
 
-            auto transfer_ratio = h_det_k / h_det_cv;
-            int n_tr_bins = transfer_ratio.getNumberOfBins();
-            for (int i = 0; i < n_tr_bins; ++i) {
-                if (!std::isfinite(transfer_ratio.getBinContent(i))) {
-                    transfer_ratio.hist.counts[i] = 0.0;
-                    transfer_ratio.hist.shifts.row(i).setZero();
-                }
-            }
-            auto h_proj_k = transfer_ratio * nominal_hist;
-            auto delta = h_proj_k - nominal_hist;
+        total_detvar_cov = accumulateCovariance(result, n_bins);
 
-            SystematicKey syst_key(variationToKey(var_key));
-            result.transfer_ratio_hists_[syst_key] = transfer_ratio;
-            result.variation_hists_[syst_key] = h_proj_k;
-            result.delta_hists_[syst_key] = delta;
-
-            TMatrixDSym cov_k(n_bins);
-            for (int i = 0; i < n_bins; ++i) {
-                for (int j = 0; j < n_bins; ++j) {
-                    cov_k(i, j) = delta.getBinContent(i) * delta.getBinContent(j);
-                }
-            }
-            total_detvar_cov += cov_k;
-        }
         log::debug("DetectorSystematicStrategy::computeCovariance", "Computed detector covariance with",
                    total_detvar_hists.size() - 1, "variations");
+
         return total_detvar_cov;
     }
 
@@ -103,6 +62,106 @@ class DetectorSystematicStrategy : public SystematicStrategy {
     }
 
   private:
+    std::map<SampleVariation, BinnedHistogram> aggregateVariations(const VariableResult &result) {
+        std::map<SampleVariation, BinnedHistogram> total_detvar_hists;
+
+        for (const auto &[sample_key, var_map] : result.raw_detvar_hists_) {
+            log::debug("DetectorSystematicStrategy::computeCovariance", "Aggregating sample", sample_key.str());
+
+            for (const auto &[var_type, hist] : var_map) {
+                log::debug("DetectorSystematicStrategy::computeCovariance", "--> variation", variationToKey(var_type));
+
+                if (total_detvar_hists.find(var_type) == total_detvar_hists.end())
+                    total_detvar_hists[var_type] = hist;
+                else
+                    total_detvar_hists[var_type] = total_detvar_hists[var_type] + hist;
+            }
+        }
+
+        return total_detvar_hists;
+    }
+
+    std::optional<BinnedHistogram> sanitizeCvHistogram(std::map<SampleVariation, BinnedHistogram> &total_detvar_hists) {
+        auto it = total_detvar_hists.find(SampleVariation::kCV);
+
+        if (it == total_detvar_hists.end()) {
+            log::warn("DetectorSystematicStrategy::computeCovariance",
+                      "No detector variation CV histogram found. Skipping.");
+
+            return std::nullopt;
+        }
+
+        auto h_det_cv = it->second;
+
+        int n_cv_bins = h_det_cv.getNumberOfBins();
+
+        for (int i = 0; i < n_cv_bins; ++i) {
+            double cv = h_det_cv.getBinContent(i);
+
+            if (!std::isfinite(cv) || cv == 0.0) {
+                h_det_cv.hist.counts[i] = 0.0;
+                h_det_cv.hist.shifts.row(i).setZero();
+            }
+        }
+
+        it->second = h_det_cv;
+
+        return h_det_cv;
+    }
+
+    void projectVariations(VariableResult &result, const BinnedHistogram &nominal_hist, const BinnedHistogram &h_det_cv,
+                           const std::map<SampleVariation, BinnedHistogram> &total_detvar_hists) {
+        for (const auto &[var_key, h_det_k] : total_detvar_hists) {
+            if (var_key == SampleVariation::kCV)
+                continue;
+
+            log::debug("DetectorSystematicStrategy::computeCovariance", "Projecting variation",
+                       variationToKey(var_key));
+
+            auto transfer_ratio = h_det_k / h_det_cv;
+
+            int n_tr_bins = transfer_ratio.getNumberOfBins();
+
+            for (int i = 0; i < n_tr_bins; ++i) {
+                if (!std::isfinite(transfer_ratio.getBinContent(i))) {
+                    transfer_ratio.hist.counts[i] = 0.0;
+                    transfer_ratio.hist.shifts.row(i).setZero();
+                }
+            }
+
+            auto h_proj_k = transfer_ratio * nominal_hist;
+
+            auto delta = h_proj_k - nominal_hist;
+
+            SystematicKey syst_key(variationToKey(var_key));
+
+            result.transfer_ratio_hists_[syst_key] = transfer_ratio;
+
+            result.variation_hists_[syst_key] = h_proj_k;
+
+            result.delta_hists_[syst_key] = delta;
+        }
+    }
+
+    TMatrixDSym accumulateCovariance(const VariableResult &result, int n_bins) {
+        TMatrixDSym total_detvar_cov(n_bins);
+
+        total_detvar_cov.Zero();
+
+        for (const auto &[var_key, delta] : result.delta_hists_) {
+            TMatrixDSym cov_k(n_bins);
+
+            for (int i = 0; i < n_bins; ++i) {
+                for (int j = 0; j < n_bins; ++j)
+                    cov_k(i, j) = delta.getBinContent(i) * delta.getBinContent(j);
+            }
+
+            total_detvar_cov += cov_k;
+        }
+
+        return total_detvar_cov;
+    }
+
     std::string identifier_;
 };
 


### PR DESCRIPTION
## Summary
- simplify computeCovariance by delegating to helper methods
- add utilities for aggregating histograms, sanitizing CV data, projecting variations, and accumulating covariance

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9dc71464832e8933bac671b57227