### PR TITLE
Refactor muon selection processing

### DIFF
--- a/libdata/MuonSelectionProcessor.h
+++ b/libdata/MuonSelectionProcessor.h
@@ -16,59 +16,72 @@ class MuonSelectionProcessor : public IEventProcessor {
             return next_ ? next_->process(df, st) : df;
         }
 
-        auto avg_df = df.Define("trk_rr_dedx_avg",
-                                [](const ROOT::RVec<float> &u, const ROOT::RVec<float> &v, const ROOT::RVec<float> &y) {
-                                    ROOT::RVec<float> avg(u.size());
-                                    for (size_t i = 0; i < u.size(); ++i) {
-                                        int count = 0;
-                                        float sum = 0;
-                                        if (u[i] > 0) {
-                                            sum += u[i];
-                                            ++count;
-                                        }
-                                        if (v[i] > 0) {
-                                            sum += v[i];
-                                            ++count;
-                                        }
-                                        if (y[i] > 0) {
-                                            sum += y[i];
-                                            ++count;
-                                        }
-                                        avg[i] = count ? sum / count : -1;
-                                    }
-                                    return avg;
-                                },
-                                {"track_trunk_rr_dedx_u", "track_trunk_rr_dedx_v", "track_trunk_rr_dedx_y"});
+        auto df1 = computeAverageDedx(df);
 
-        auto score_df = avg_df.Define("muon_score", "ROOT::VecOps::Any(track_shower_scores > 0.3f)");
+        auto df2 = buildMuonMask(df1);
 
-        auto length_df =
-            score_df.Define("muon_length", "ROOT::VecOps::Any((track_shower_scores > 0.3f) && (track_length > 5))");
+        auto df3 = extractMuonFeatures(df2);
 
-        auto mask_df =
-            length_df.Define("muon_mask",
-                             [](const ROOT::RVec<float> &scores, const ROOT::RVec<float> &lengths,
-                                const ROOT::RVec<float> &dists, const ROOT::RVec<float> &avg) {
-                                 static_cast<void>(dists);
-                                 ROOT::RVec<bool> mask(scores.size());
-                                 for (size_t i = 0; i < scores.size(); ++i) {
-                                     mask[i] = (scores[i] > 0.3f && lengths[i] > 5 && avg[i] < 3);
+        return next_ ? next_->process(df3, st) : df3;
+    }
+
+  private:
+    ROOT::RDF::RNode computeAverageDedx(ROOT::RDF::RNode df) const {
+        return df.Define("trk_rr_dedx_avg",
+                         [](const ROOT::RVec<float> &u, const ROOT::RVec<float> &v, const ROOT::RVec<float> &y) {
+                             ROOT::RVec<float> avg(u.size());
+                             for (size_t i = 0; i < u.size(); ++i) {
+                                 int count = 0;
+                                 float sum = 0;
+                                 if (u[i] > 0) {
+                                     sum += u[i];
+                                     ++count;
                                  }
-                                 return mask;
-                             },
-                             {"track_shower_scores", "track_length", "track_distance_to_vertex", "trk_rr_dedx_avg"});
+                                 if (v[i] > 0) {
+                                     sum += v[i];
+                                     ++count;
+                                 }
+                                 if (y[i] > 0) {
+                                     sum += y[i];
+                                     ++count;
+                                 }
+                                 avg[i] = count ? sum / count : -1;
+                             }
+                             return avg;
+                         },
+                         {"track_trunk_rr_dedx_u", "track_trunk_rr_dedx_v", "track_trunk_rr_dedx_y"});
+    }
 
-        auto mu_len_df = mask_df.Define("muon_track_length",
-                                        [](const ROOT::RVec<float> &lengths, const ROOT::RVec<bool> &mask) {
-                                            ROOT::RVec<float> out;
-                                            out.reserve(lengths.size());
-                                            for (size_t i = 0; i < lengths.size(); ++i) {
-                                                if (mask[i])
-                                                    out.push_back(lengths[i]);
-                                            }
-                                            return out;
-                                        },
-                                        {"track_length", "muon_mask"});
+    ROOT::RDF::RNode buildMuonMask(ROOT::RDF::RNode df) const {
+        return df.Define("muon_mask",
+                         [](const ROOT::RVec<float> &scores, const ROOT::RVec<float> &lengths,
+                            const ROOT::RVec<float> &dists, const ROOT::RVec<float> &avg) {
+                             static_cast<void>(dists);
+                             ROOT::RVec<bool> mask(scores.size());
+                             for (size_t i = 0; i < scores.size(); ++i) {
+                                 mask[i] = (scores[i] > 0.3f && lengths[i] > 5 && avg[i] < 3);
+                             }
+                             return mask;
+                         },
+                         {"track_shower_scores", "track_length", "track_distance_to_vertex", "trk_rr_dedx_avg"});
+    }
+
+    ROOT::RDF::RNode extractMuonFeatures(ROOT::RDF::RNode df) const {
+        auto score_df = df.Define("muon_score", "ROOT::VecOps::Any(track_shower_scores > 0.3f)");
+
+        auto length_df = score_df.Define("muon_length", "ROOT::VecOps::Any((track_shower_scores > 0.3f) && (track_length > 5))");
+
+        auto mu_len_df = length_df.Define("muon_track_length",
+                                          [](const ROOT::RVec<float> &lengths, const ROOT::RVec<bool> &mask) {
+                                              ROOT::RVec<float> out;
+                                              out.reserve(lengths.size());
+                                              for (size_t i = 0; i < lengths.size(); ++i) {
+                                                  if (mask[i])
+                                                      out.push_back(lengths[i]);
+                                              }
+                                              return out;
+                                          },
+                                          {"track_length", "muon_mask"});
 
         auto mu_cos_df = mu_len_df.Define("muon_track_costheta",
                                           [](const ROOT::RVec<float> &theta, const ROOT::RVec<bool> &mask) {
@@ -84,9 +97,7 @@ class MuonSelectionProcessor : public IEventProcessor {
 
         auto count_df = mu_cos_df.Define("n_muons", "ROOT::VecOps::Sum(muon_mask)");
 
-        auto has_df = count_df.Define("has_muon", "n_muons > 0");
-
-        return next_ ? next_->process(has_df, st) : has_df;
+        return count_df.Define("has_muon", "n_muons > 0");
     }
 };
 


### PR DESCRIPTION
## Summary
- split muon selection pipeline into helper steps for average dE/dx, mask creation, and feature extraction
- updated process to compose the new helpers

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bc9dd0ed9c832e863274da521e2277