### PR TITLE
Fix ROOT interface usage for dynamic binning and flash validation

### DIFF
--- a/libplug/FlashValidationPlugin.cc
+++ b/libplug/FlashValidationPlugin.cc
@@ -108,7 +108,7 @@ class FlashValidationPlugin : public IPlotPlugin {
         bool first = true;
 
         for (size_t i = 0; i < hd.h_time.size(); ++i) {
-            auto h = hd.h_time[i].Get();
+            auto h = hd.h_time[i].GetPtr();
             h->SetLineColor(hd.colors[i]);
             h->SetLineWidth(2);
             if (first) {
@@ -131,7 +131,7 @@ class FlashValidationPlugin : public IPlotPlugin {
         bool first = true;
 
         for (size_t i = 0; i < hd.h_pe.size(); ++i) {
-            auto h = hd.h_pe[i].Get();
+            auto h = hd.h_pe[i].GetPtr();
             h->SetLineColor(hd.colors[i]);
             h->SetLineWidth(2);
             if (first) {

--- a/libutils/DynamicBinning.h
+++ b/libutils/DynamicBinning.h
@@ -39,7 +39,7 @@ class DynamicBinning {
     }
 
   private:
-    static std::string determineColumnType(const std::vector<ROOT::RDF::RNode> &nodes,
+    static std::string determineColumnType(std::vector<ROOT::RDF::RNode> &nodes,
                                            const BinningDefinition &bdef) {
         const std::string &branch = bdef.getVariable();
         return nodes.front().GetColumnType(branch);


### PR DESCRIPTION
## Summary
- Adjust DynamicBinning type detection to use non-const RNodes
- Use public ROOT RResultPtr API when extracting histograms in FlashValidationPlugin

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bca22c0bb4832eb12a758697febc80