### PR TITLE
Fix histogram access qualifiers in FlashValidationPlugin

### DIFF
--- a/libplug/FlashValidationPlugin.cc
+++ b/libplug/FlashValidationPlugin.cc
@@ -102,7 +102,7 @@ class FlashValidationPlugin : public IPlotPlugin {
         return hd;
     }
 
-    void drawTimeDistributions(const PlotConfig &pc, const HistData &hd) {
+    void drawTimeDistributions(const PlotConfig &pc, HistData &hd) {
         TCanvas c;
         TLegend l(0.7, 0.7, 0.9, 0.9);
         bool first = true;
@@ -125,7 +125,7 @@ class FlashValidationPlugin : public IPlotPlugin {
         c.SaveAs((pc.output_directory + "/" + pc.plot_name + "_time.pdf").c_str());
     }
 
-    void drawPeDistributions(const PlotConfig &pc, const HistData &hd) {
+    void drawPeDistributions(const PlotConfig &pc, HistData &hd) {
         TCanvas c;
         TLegend l(0.7, 0.7, 0.9, 0.9);
         bool first = true;


### PR DESCRIPTION
## Summary
- Allow FlashValidationPlugin histogram drawing helpers to mutate histogram handles

## Testing
- `source ./.setup.sh && cmake -S . -B build` *(fails: FindROOT.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca2f00eec832eb13087642720b740