### PR TITLE
Link libhist with nlohmann json

### DIFF
--- a/libhist/CMakeLists.txt
+++ b/libhist/CMakeLists.txt
@@ -9,4 +9,5 @@ target_include_directories(libhist
 target_link_libraries(libhist
   PUBLIC
     libutils
+    nlohmann_json::nlohmann_json
 )


### PR DESCRIPTION
## Summary
- link libhist with nlohmann_json to provide required headers

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT"; Add the installation prefix of "ROOT" to CMAKE_PREFIX_PATH or set "ROOT_DIR" to a directory containing one of the above files)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.243 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68bca6ec3b30832eb283a0e01ac9d3cf