### PR TITLE
Align variable naming across analysis and plotting

### DIFF
--- a/plot.cpp
+++ b/plot.cpp
@@ -19,7 +19,7 @@ static int runPlotting(const nlohmann::json &samples, const nlohmann::json &plot
     ROOT::EnableImplicitMT();
     analysis::log::info("plot::runPlotting", "Implicit multithreading engaged across", ROOT::GetThreadPoolSize(), "threads.");
 
-    std::string ntupledir = samples.at("ntupledir").get<std::string>();
+    std::string ntuple_dir = samples.at("ntupledir").get<std::string>();
     analysis::log::info("plot::runPlotting", "Configuration loaded for", samples.at("beamlines").size(), "beamlines.");
 
     analysis::RunConfigRegistry run_config_registry;
@@ -28,13 +28,14 @@ static int runPlotting(const nlohmann::json &samples, const nlohmann::json &plot
     analysis::VariableRegistry variable_registry;
     std::map<std::string, std::unique_ptr<analysis::AnalysisDataLoader>> loaders;
 
-    for (auto const &[beam, run] : samples.at("beamlines").items()) {
+    for (auto const &[beam, runs] : samples.at("beamlines").items()) {
         std::vector<std::string> periods;
-        for (auto const &p : run.items()) {
-            periods.push_back(p.key());
+        periods.reserve(runs.size());
+        for (auto const &[period, _] : runs.items()) {
+            periods.emplace_back(period);
         }
 
-        loaders.emplace(beam, std::make_unique<analysis::AnalysisDataLoader>(run_config_registry, variable_registry, beam, periods, ntupledir, true));
+        loaders.emplace(beam, std::make_unique<analysis::AnalysisDataLoader>(run_config_registry, variable_registry, beam, periods, ntuple_dir, true));
     }
 
     auto result_map = result.resultsByBeam();


### PR DESCRIPTION
## Summary
- Standardize variable names in `analyse.cpp` to snake_case and harmonize them with `plot.cpp`
- Use consistent loop structures and naming in plotting driver

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bca952a754832ead617cadf7a408b0