### PR TITLE
chore: remove namespace analysis comments

### DIFF
--- a/libapp/AnalysisResult.h
+++ b/libapp/AnalysisResult.h
@@ -119,6 +119,6 @@ class AnalysisResult : public TObject {
     std::map<RegionKey, VariableResults> variable_results_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/BinnedHistogram.h
+++ b/libapp/BinnedHistogram.h
@@ -103,6 +103,6 @@ class BinnedHistogram : public TNamed, private TH1DRenderer {
 
 using BinnedHistogramD = BinnedHistogram;
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/DataProcessor.h
+++ b/libapp/DataProcessor.h
@@ -25,6 +25,6 @@ class DataProcessor : public ISampleProcessor {
     ROOT::RDF::RResultPtr<TH1D> data_future_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/HistogramPolicy.h
+++ b/libapp/HistogramPolicy.h
@@ -49,6 +49,6 @@ struct TH1DRenderer {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/HistogramUncertainty.h
+++ b/libapp/HistogramUncertainty.h
@@ -257,6 +257,6 @@ inline HistogramUncertainty HistogramUncertainty::operator/(const HistogramUncer
     return tmp;
 }
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/ISampleProcessor.h
+++ b/libapp/ISampleProcessor.h
@@ -16,6 +16,6 @@ class ISampleProcessor {
     virtual void contributeTo(VariableResult &result) = 0;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -54,6 +54,6 @@ class MonteCarloProcessor : public ISampleProcessor {
     std::unordered_map<SampleVariation, ROOT::RDF::RResultPtr<TH1D>> variation_futures_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/RegionAnalysis.h
+++ b/libapp/RegionAnalysis.h
@@ -75,4 +75,4 @@ class RegionAnalysis {
     std::vector<StageCount> cut_flow_;
 };
 
-} // namespace analysis
+}

--- a/libapp/Selection.h
+++ b/libapp/Selection.h
@@ -42,6 +42,6 @@ class Selection {
     std::string expr_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libapp/SelectionRegistry.h
+++ b/libapp/SelectionRegistry.h
@@ -70,6 +70,6 @@ class SelectionRegistry {
     std::unordered_map<std::string, SelectionRule> rules_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/AnalysisDataLoader.h
+++ b/libdata/AnalysisDataLoader.h
@@ -142,6 +142,6 @@ class AnalysisDataLoader {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/BlipProcessor.h
+++ b/libdata/BlipProcessor.h
@@ -64,6 +64,6 @@ class BlipProcessor : public IEventProcessor {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/IEventProcessor.h
+++ b/libdata/IEventProcessor.h
@@ -21,6 +21,6 @@ class IEventProcessor {
     std::unique_ptr<IEventProcessor> next_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/MuonSelectionProcessor.h
+++ b/libdata/MuonSelectionProcessor.h
@@ -101,6 +101,6 @@ class MuonSelectionProcessor : public IEventProcessor {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/ReconstructionProcessor.h
+++ b/libdata/ReconstructionProcessor.h
@@ -32,6 +32,6 @@ class ReconstructionProcessor : public IEventProcessor {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/RunConfig.h
+++ b/libdata/RunConfig.h
@@ -45,6 +45,6 @@ struct RunConfig {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/RunConfigLoader.h
+++ b/libdata/RunConfigLoader.h
@@ -37,6 +37,6 @@ class RunConfigLoader {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/RunConfigRegistry.h
+++ b/libdata/RunConfigRegistry.h
@@ -34,6 +34,6 @@ class RunConfigRegistry {
     std::map<std::string, RunConfig> configs_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/SampleDefinition.h
+++ b/libdata/SampleDefinition.h
@@ -147,6 +147,6 @@ class SampleDefinition {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/TruthChannelProcessor.h
+++ b/libdata/TruthChannelProcessor.h
@@ -176,6 +176,6 @@ class TruthChannelProcessor : public IEventProcessor {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/VariableRegistry.h
+++ b/libdata/VariableRegistry.h
@@ -385,6 +385,6 @@ class VariableRegistry {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/WeightProcessor.h
+++ b/libdata/WeightProcessor.h
@@ -62,6 +62,6 @@ class WeightProcessor : public IEventProcessor {
     double total_run_pot_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/BinningDefinition.h
+++ b/libhist/BinningDefinition.h
@@ -47,6 +47,6 @@ class BinningDefinition {
     StratifierKey strat_key_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/HistogramBooker.h
+++ b/libhist/HistogramBooker.h
@@ -40,6 +40,6 @@ class HistogramBooker : public IHistogramBooker {
     StratifierManager stratifier_manager_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/IHistogramBooker.h
+++ b/libhist/IHistogramBooker.h
@@ -18,6 +18,6 @@ class IHistogramBooker {
                         const ROOT::RDF::TH1DModel &model) = 0;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/IHistogramStratifier.h
+++ b/libhist/IHistogramStratifier.h
@@ -55,6 +55,6 @@ class IHistogramStratifier {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/ScalarStratifier.h
+++ b/libhist/ScalarStratifier.h
@@ -31,6 +31,6 @@ class ScalarStratifier : public IHistogramStratifier {
     StratifierRegistry &stratifier_registry_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/StratifierRegistry.h
+++ b/libhist/StratifierRegistry.h
@@ -300,6 +300,6 @@ class StratifierRegistry {
     std::map<std::string, std::vector<int>> signal_channel_groups_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/HistogramCut.h
+++ b/libplot/HistogramCut.h
@@ -10,6 +10,6 @@ struct Cut {
     CutDirection direction;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/HistogramPlotterBase.h
+++ b/libplot/HistogramPlotterBase.h
@@ -73,6 +73,6 @@ class HistogramPlotterBase {
     std::string output_directory_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/IEventDisplay.h
+++ b/libplot/IEventDisplay.h
@@ -96,6 +96,6 @@ class SemanticDisplay : public IEventDisplay {
     std::vector<int> data_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/OccupancyMatrixPlot.h
+++ b/libplot/OccupancyMatrixPlot.h
@@ -38,6 +38,6 @@ class OccupancyMatrixPlot : public HistogramPlotterBase {
     TH2F *hist_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -263,6 +263,6 @@ class PlotCatalog {
     std::filesystem::path output_directory_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/RocCurvePlot.h
+++ b/libplot/RocCurvePlot.h
@@ -41,6 +41,6 @@ class RocCurvePlot : public HistogramPlotterBase {
     std::vector<double> background_rej_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/SelectionEfficiencyPlot.h
+++ b/libplot/SelectionEfficiencyPlot.h
@@ -117,6 +117,6 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
     bool use_log_y_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -410,6 +410,6 @@ class StackedHistogramPlot : public HistogramPlotterBase {
     std::vector<TObject *> cut_visuals_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/SystematicBreakdownPlot.cpp
+++ b/libplot/SystematicBreakdownPlot.cpp
@@ -73,4 +73,4 @@ void SystematicBreakdownPlot::draw(TCanvas &canvas) {
     legend_->Draw();
 }
 
-} // namespace analysis
+}

--- a/libplot/SystematicBreakdownPlot.h
+++ b/libplot/SystematicBreakdownPlot.h
@@ -29,6 +29,6 @@ class SystematicBreakdownPlot : public HistogramPlotterBase {
     TLegend *legend_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/UnstackedHistogramPlot.h
+++ b/libplot/UnstackedHistogramPlot.h
@@ -335,6 +335,6 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
     std::vector<TObject *> cut_visuals_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/AnalysisPluginManager.h
+++ b/libplug/AnalysisPluginManager.h
@@ -114,5 +114,5 @@ class AnalysisPluginManager {
     std::vector<void *> handles_;
 };
 
-} // namespace analysis
+}
 #endif

--- a/libplug/CutFlowPlotPlugin.cc
+++ b/libplug/CutFlowPlotPlugin.cc
@@ -146,7 +146,7 @@ class CutFlowPlotPlugin : public IPlotPlugin {
     std::vector<PlotConfig> plots_;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IPlotPlugin *createPlotPlugin(const nlohmann::json &cfg) {

--- a/libplug/EventDisplayPlugin.cc
+++ b/libplug/EventDisplayPlugin.cc
@@ -126,7 +126,7 @@ class EventDisplayPlugin : public IAnalysisPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IAnalysisPlugin *createPlugin(const nlohmann::json &cfg) {

--- a/libplug/FlashValidationPlugin.cc
+++ b/libplug/FlashValidationPlugin.cc
@@ -149,7 +149,7 @@ class FlashValidationPlugin : public IPlotPlugin {
     }
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IPlotPlugin *createPlotPlugin(const nlohmann::json &cfg) {

--- a/libplug/IAnalysisPlugin.h
+++ b/libplug/IAnalysisPlugin.h
@@ -27,5 +27,5 @@ class IAnalysisPlugin {
     virtual void onFinalisation(const AnalysisResult &results) = 0;
 };
 
-} // namespace analysis
+}
 #endif

--- a/libplug/IPlotPlugin.h
+++ b/libplug/IPlotPlugin.h
@@ -11,6 +11,6 @@ class IPlotPlugin {
     virtual void run(const AnalysisResult &result) = 0;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/OccupancyMatrixPlugin.cc
+++ b/libplug/OccupancyMatrixPlugin.cc
@@ -90,7 +90,7 @@ class OccupancyMatrixPlugin : public IAnalysisPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IAnalysisPlugin *createPlugin(const nlohmann::json &cfg) {

--- a/libplug/PlotPluginManager.h
+++ b/libplug/PlotPluginManager.h
@@ -86,6 +86,6 @@ class PlotPluginManager {
     std::vector<void *> handles_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/PluginConfigValidator.h
+++ b/libplug/PluginConfigValidator.h
@@ -90,6 +90,6 @@ struct PluginConfigValidator {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplug/RegionsPlugin.cc
+++ b/libplug/RegionsPlugin.cc
@@ -44,7 +44,7 @@ class RegionsPlugin : public IAnalysisPlugin {
     nlohmann::json config_;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IAnalysisPlugin *createRegionsPlugin(const nlohmann::json &cfg) {

--- a/libplug/RocCurvePlugin.cc
+++ b/libplug/RocCurvePlugin.cc
@@ -195,7 +195,7 @@ class RocCurvePlugin : public IAnalysisPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IAnalysisPlugin *createPlugin(const nlohmann::json &cfg) {

--- a/libplug/RunPeriodNormalizationPlugin.cc
+++ b/libplug/RunPeriodNormalizationPlugin.cc
@@ -135,7 +135,7 @@ class RunPeriodNormalizationPlugin : public IPlotPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IPlotPlugin *createPlotPlugin(const nlohmann::json &cfg) {

--- a/libplug/SlipStackingIntensityPlugin.cc
+++ b/libplug/SlipStackingIntensityPlugin.cc
@@ -104,7 +104,7 @@ class SlipStackingIntensityPlugin : public IPlotPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IPlotPlugin *createPlotPlugin(const nlohmann::json &cfg) {

--- a/libplug/SnapshotPlugin.cc
+++ b/libplug/SnapshotPlugin.cc
@@ -77,7 +77,7 @@ class SnapshotPlugin : public IAnalysisPlugin {
     inline static AnalysisDataLoader *loader_ = nullptr;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IAnalysisPlugin *createPlugin(const nlohmann::json &cfg) {

--- a/libplug/StackedHistogramPlugin.cc
+++ b/libplug/StackedHistogramPlugin.cc
@@ -81,7 +81,7 @@ class StackedHistogramPlugin : public IPlotPlugin {
     std::vector<PlotConfig> plots_;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IPlotPlugin *createPlotPlugin(const nlohmann::json &cfg) {

--- a/libplug/SystematicBreakdownPlugin.cc
+++ b/libplug/SystematicBreakdownPlugin.cc
@@ -61,7 +61,7 @@ class SystematicBreakdownPlugin : public IAnalysisPlugin {
     std::vector<PlotConfig> plots_;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IAnalysisPlugin *createPlugin(const nlohmann::json &cfg) {

--- a/libplug/UnstackedHistogramPlugin.cc
+++ b/libplug/UnstackedHistogramPlugin.cc
@@ -123,7 +123,7 @@ class UnstackedHistogramPlugin : public IAnalysisPlugin {
     std::map<RegionKey, std::map<std::string, std::vector<Cut>>> region_cuts_;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IAnalysisPlugin *createPlugin(const nlohmann::json &cfg) {

--- a/libplug/VariablesPlugin.cc
+++ b/libplug/VariablesPlugin.cc
@@ -85,7 +85,7 @@ class VariablesPlugin : public IAnalysisPlugin {
     nlohmann::json config_;
 };
 
-} // namespace analysis
+}
 
 #ifdef BUILD_PLUGIN
 extern "C" analysis::IAnalysisPlugin *createPlugin(const nlohmann::json &cfg) {

--- a/libsyst/DetectorSystematicStrategy.h
+++ b/libsyst/DetectorSystematicStrategy.h
@@ -165,6 +165,6 @@ class DetectorSystematicStrategy : public SystematicStrategy {
     std::string identifier_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libsyst/SystematicStrategy.h
+++ b/libsyst/SystematicStrategy.h
@@ -50,6 +50,6 @@ class SystematicStrategy {
                                                                          SystematicFutures &futures) = 0;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libsyst/SystematicsProcessor.h
+++ b/libsyst/SystematicsProcessor.h
@@ -135,6 +135,6 @@ class SystematicsProcessor {
     SystematicFutures systematic_futures_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -130,6 +130,6 @@ class UniverseSystematicStrategy : public SystematicStrategy {
     bool store_universe_hists_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libsyst/WeightSystematicStrategy.h
+++ b/libsyst/WeightSystematicStrategy.h
@@ -90,6 +90,6 @@ class WeightSystematicStrategy : public SystematicStrategy {
     std::string dn_column_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/AnalysisKey.h
+++ b/libutils/AnalysisKey.h
@@ -22,7 +22,7 @@ template <class Tag> class AnalysisKey {
     std::string v_;
 };
 
-} // namespace analysis
+}
 
 namespace std {
 template <class Tag> struct hash<analysis::AnalysisKey<Tag>> {

--- a/libutils/AnalysisLogger.h
+++ b/libutils/AnalysisLogger.h
@@ -132,6 +132,6 @@ template <typename... Args> inline void fatal(const std::string &ctx, const Args
 }
 } // namespace log
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/AnalysisTypes.h
+++ b/libutils/AnalysisTypes.h
@@ -53,6 +53,6 @@ struct SampleDatasetGroup {
 
 using SampleDatasetGroupMap = std::unordered_map<SampleKey, SampleDatasetGroup>;
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/DynamicBinning.h
+++ b/libutils/DynamicBinning.h
@@ -471,6 +471,6 @@ class DynamicBinning {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/DynamicBinning2D.h
+++ b/libutils/DynamicBinning2D.h
@@ -22,6 +22,6 @@ class DynamicBinning2D {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/JsonUtils.h
+++ b/libutils/JsonUtils.h
@@ -31,4 +31,4 @@ inline nlohmann::json loadJson(const std::string &path) {
     return nlohmann::json();
 }
 
-} // namespace analysis
+}

--- a/libutils/KeyTypes.h
+++ b/libutils/KeyTypes.h
@@ -25,6 +25,6 @@ using StratifierKey = AnalysisKey<StratifierKeyTag>;
 using StratumKey = AnalysisKey<StratumKeyTag>;
 using SelectionKey = AnalysisKey<SelectionKeyTag>;
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/QuadTreeBinning2D.h
+++ b/libutils/QuadTreeBinning2D.h
@@ -163,6 +163,6 @@ class QuadTreeBinning2D {
     }
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libutils/SampleTypes.h
+++ b/libutils/SampleTypes.h
@@ -50,6 +50,6 @@ inline std::string variationToKey(SampleVariation var) {
     }
 }
 
-} // namespace analysis
+}
 
 #endif


### PR DESCRIPTION
## Summary
- drop `// namespace analysis` comments throughout codebase

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory; setup commands missing)*
- `source .build.sh` *(fails: Could not find ROOT)*
- `ctest --output-on-failure` *(No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcabad18f0832eb10b9234ed10195d