### PR TITLE
Set default indentation to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
- add `.editorconfig` to enforce 4-space indentation and LF line endings for all files

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: setup commands not found)*
- `source .build.sh` *(fails: could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb0472a68832e98763aab3abbf1d2