### PR TITLE
Use explicit this for internal calls

### DIFF
--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -94,7 +94,7 @@ class AnalysisRunner {
         size_t sample_total = 0;
         for (auto &[sample_key, _] : sample_frames) {
             const auto *run_config = data_loader_.getRunConfigForSample(sample_key);
-            if (!isSampleEligible(sample_key, run_config, region_beam, region_runs))
+            if (!this->isSampleEligible(sample_key, run_config, region_beam, region_runs))
                 continue;
             ++sample_total;
         }
@@ -103,7 +103,7 @@ class AnalysisRunner {
         std::set<std::string> accounted_runs;
         for (auto &[sample_key, sample_def] : sample_frames) {
             const auto *run_config = data_loader_.getRunConfigForSample(sample_key);
-            if (!isSampleEligible(sample_key, run_config, region_beam, region_runs))
+            if (!this->isSampleEligible(sample_key, run_config, region_beam, region_runs))
                 continue;
             ++sample_index;
 

--- a/libdata/AnalysisDataLoader.h
+++ b/libdata/AnalysisDataLoader.h
@@ -99,7 +99,7 @@ class AnalysisDataLoader {
         if constexpr (sizeof...(tail) == 0) {
             return head;
         } else {
-            auto next = chainEventProcessors(std::move(tail)...);
+            auto next = this->chainEventProcessors(std::move(tail)...);
             head->chainNextProcessor(std::move(next));
             return head;
         }
@@ -115,7 +115,7 @@ class AnalysisDataLoader {
                 continue;
             }
 
-            auto pipeline = chainEventProcessors(
+            auto pipeline = this->chainEventProcessors(
                 std::make_unique<WeightProcessor>(sample_json, total_pot_), std::make_unique<TruthChannelProcessor>(),
                 std::make_unique<BlipProcessor>(), std::make_unique<MuonSelectionProcessor>(),
                 std::make_unique<ReconstructionProcessor>());
@@ -137,7 +137,7 @@ class AnalysisDataLoader {
             total_pot_ += rc.nominal_pot;
             total_triggers_ += rc.nominal_triggers;
 
-            processPeriod(period);
+            this->processPeriod(period);
         }
     }
 };

--- a/libdata/SampleDefinition.h
+++ b/libdata/SampleDefinition.h
@@ -31,7 +31,7 @@ class SampleDefinition {
     SampleDefinition(const nlohmann::json &j, const nlohmann::json &all_samples_json, const std::string &base_dir,
                      const VariableRegistry &var_reg, IEventProcessor &processor)
         : sample_key_(SampleKey{j.at("sample_key").get<std::string>()}),
-          nominal_node_(this->makeDataFrame(base_dir, var_reg, processor, parseMetadata(j), all_samples_json)) {
+          nominal_node_(this->makeDataFrame(base_dir, var_reg, processor, this->parseMetadata(j), all_samples_json)) {
         if (sample_origin_ == SampleOrigin::kMonteCarlo) {
             for (auto &[dv, path] : var_paths_) {
                 SampleKey dataset_key{sample_key_.str() + "_" + variationToKey(dv)};
@@ -84,7 +84,7 @@ class SampleDefinition {
         triggers_ = j.value("triggers", 0L);
         if (j.contains("detector_variations")) {
             for (auto &dv : j.at("detector_variations")) {
-                SampleVariation dvt = convertDetVarType(dv.at("variation_type").get<std::string>());
+                SampleVariation dvt = this->convertDetVarType(dv.at("variation_type").get<std::string>());
                 var_paths_[dvt] = dv.at("relative_path").get<std::string>();
             }
         }

--- a/libdata/TruthChannelProcessor.h
+++ b/libdata/TruthChannelProcessor.h
@@ -18,11 +18,11 @@ class TruthChannelProcessor : public IEventProcessor {
             return processNonMc(df, st);
         }
 
-        auto counts_df = defineCounts(df);
+        auto counts_df = this->defineCounts(df);
 
-        auto incl_df = assignInclusiveChannels(counts_df);
+        auto incl_df = this->assignInclusiveChannels(counts_df);
 
-        auto excl_df = assignExclusiveChannels(incl_df);
+        auto excl_df = this->assignExclusiveChannels(incl_df);
 
         return next_ ? next_->process(excl_df, st) : excl_df;
     }

--- a/libhist/IHistogramStratifier.h
+++ b/libhist/IHistogramStratifier.h
@@ -34,7 +34,7 @@ class IHistogramStratifier {
         for (const auto &key : this->getRegistryKeys()) {
             std::string stratum_key_str = key.str();
             std::replace(stratum_key_str.begin(), stratum_key_str.end(), '-', 'n');
-            std::string filter_col_name = "pass_" + getSchemeName() + "_" + stratum_key_str;
+            std::string filter_col_name = "pass_" + this->getSchemeName() + "_" + stratum_key_str;
 
             df_with_filters = this->defineFilterColumn(df_with_filters, std::stoi(key.str()), filter_col_name);
             strat_futurs[key] =

--- a/libhist/ScalarStratifier.h
+++ b/libhist/ScalarStratifier.h
@@ -18,7 +18,7 @@ class ScalarStratifier : public IHistogramStratifier {
     ROOT::RDF::RNode defineFilterColumn(ROOT::RDF::RNode dataframe, int key,
                                         const std::string &new_column_name) const override {
 
-        std::string filter_expression = getSchemeName() + " == " + std::to_string(key);
+        std::string filter_expression = this->getSchemeName() + " == " + std::to_string(key);
         return dataframe.Define(new_column_name, filter_expression);
     }
 

--- a/libhist/VectorStratifier.cpp
+++ b/libhist/VectorStratifier.cpp
@@ -20,7 +20,7 @@ class VectorStratifier : public IHistogramStratifier {
     ROOT::RDF::RNode defineFilterColumn(ROOT::RDF::RNode dataframe, int key,
                                         const std::string &new_column_name) const override {
 
-        std::vector<std::string> columns = {getSchemeName()};
+        std::vector<std::string> columns = {this->getSchemeName()};
 
         return dataframe.Define(
             new_column_name,

--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -85,7 +85,7 @@ class PlotCatalog {
         std::string name = "occupancy_matrix_" + sanitise(x_variable) + "_vs_" + sanitise(y_variable) + "_" +
                            sanitise(region.empty() ? "default" : region);
 
-        auto edges = determineEdges(x_res, y_res);
+        auto edges = this->determineEdges(x_res, y_res);
 
         TH2F *hist = new TH2F(name.c_str(), name.c_str(), edges.first.size() - 1, edges.first.data(),
                               edges.second.size() - 1, edges.second.data());
@@ -96,9 +96,9 @@ class PlotCatalog {
 
         for (auto &kv : loader_.getSampleFrames()) {
             auto df = kv.second.nominal_node_;
-            df = applySelectionFilters(df, x_res, y_res, filter, x_cuts, y_cuts);
-            auto data = extractValues(df, x_res, y_res);
-            fillHistogram(hist, data);
+            df = this->applySelectionFilters(df, x_res, y_res, filter, x_cuts, y_cuts);
+            auto data = this->extractValues(df, x_res, y_res);
+            this->fillHistogram(hist, data);
         }
 
         OccupancyMatrixPlot plot(std::move(name), hist, output_directory_.string());

--- a/libplug/CutFlowPlotPlugin.cc
+++ b/libplug/CutFlowPlotPlugin.cc
@@ -49,7 +49,7 @@ class CutFlowPlotPlugin : public IPlotPlugin {
     void run(const AnalysisResult &res) override {
         StratifierRegistry strat_reg;
         for (const auto &pc : plots_) {
-            auto signal_keys = fetchSignalKeys(strat_reg, pc.signal_group);
+            auto signal_keys = this->fetchSignalKeys(strat_reg, pc.signal_group);
             if (!signal_keys)
                 continue;
 
@@ -58,8 +58,8 @@ class CutFlowPlotPlugin : public IPlotPlugin {
             auto stage_labels = std::vector<std::string>{pc.initial_label};
             stage_labels.insert(stage_labels.end(), pc.clauses.begin(), pc.clauses.end());
 
-            auto counts = computeCounts(cf, pc.channel_column, *signal_keys);
-            auto metrics = computeMetrics(cf, pc.channel_column, *signal_keys, counts.first, counts.second);
+            auto counts = this->computeCounts(cf, pc.channel_column, *signal_keys);
+            auto metrics = this->computeMetrics(cf, pc.channel_column, *signal_keys, counts.first, counts.second);
 
             SelectionEfficiencyPlot plot(pc.plot_name + "_" + pc.region, stage_labels, metrics.efficiencies,
                                          metrics.eff_errors, metrics.purities, metrics.pur_errors, pc.output_directory,

--- a/libplug/FlashValidationPlugin.cc
+++ b/libplug/FlashValidationPlugin.cc
@@ -54,11 +54,11 @@ class FlashValidationPlugin : public IPlotPlugin {
         }
 
         for (auto const &pc : plots_) {
-            auto hd = buildHistograms(pc);
+            auto hd = this->buildHistograms(pc);
 
-            drawTimeDistributions(pc, hd);
+            this->drawTimeDistributions(pc, hd);
 
-            drawPeDistributions(pc, hd);
+            this->drawPeDistributions(pc, hd);
         }
     }
 

--- a/libplug/RocCurvePlugin.cc
+++ b/libplug/RocCurvePlugin.cc
@@ -83,14 +83,14 @@ class RocCurvePlugin : public IAnalysisPlugin {
             std::string signal_expr;
             std::string selection_expr;
 
-            if (!buildExpressions(pc, strat_reg, signal_expr, selection_expr))
+            if (!this->buildExpressions(pc, strat_reg, signal_expr, selection_expr))
                 continue;
 
-            auto [total_hist, sig_hist] = accumulateHistograms(pc, signal_expr, selection_expr);
+            auto [total_hist, sig_hist] = this->accumulateHistograms(pc, signal_expr, selection_expr);
 
-            auto [efficiencies, rejections] = computeRocPoints(pc, total_hist, sig_hist);
+            auto [efficiencies, rejections] = this->computeRocPoints(pc, total_hist, sig_hist);
 
-            renderPlot(pc, efficiencies, rejections);
+            this->renderPlot(pc, efficiencies, rejections);
         }
     }
 

--- a/libplug/RunPeriodNormalizationPlugin.cc
+++ b/libplug/RunPeriodNormalizationPlugin.cc
@@ -44,9 +44,9 @@ class RunPeriodNormalizationPlugin : public IPlotPlugin {
             return;
         }
         for (auto const &pc : plots_) {
-            auto stats = collectRunStats(pc);
+            auto stats = this->collectRunStats(pc);
 
-            createRunGraphs(pc, stats);
+            this->createRunGraphs(pc, stats);
         }
     }
 

--- a/libplug/UnstackedHistogramPlugin.cc
+++ b/libplug/UnstackedHistogramPlugin.cc
@@ -63,7 +63,7 @@ class UnstackedHistogramPlugin : public IAnalysisPlugin {
                 continue;
             try {
                 const auto &sel_str = def.region(rkey).selection().str();
-                parseSelectionCuts(rkey, sel_str);
+                this->parseSelectionCuts(rkey, sel_str);
             } catch (const std::exception &e) {
                 log::error("UnstackedHistogramPlugin::onInitialisation", "Could not parse selection for region",
                            rkey.str(), e.what());

--- a/libsyst/DetectorSystematicStrategy.h
+++ b/libsyst/DetectorSystematicStrategy.h
@@ -37,18 +37,18 @@ class DetectorSystematicStrategy : public SystematicStrategy {
             return total_detvar_cov;
         }
 
-        auto total_detvar_hists = aggregateVariations(result);
+        auto total_detvar_hists = this->aggregateVariations(result);
 
-        auto h_det_cv_opt = sanitizeCvHistogram(total_detvar_hists);
+        auto h_det_cv_opt = this->sanitizeCvHistogram(total_detvar_hists);
 
         if (!h_det_cv_opt)
             return total_detvar_cov;
 
         auto h_det_cv = *h_det_cv_opt;
 
-        projectVariations(result, nominal_hist, h_det_cv, total_detvar_hists);
+        this->projectVariations(result, nominal_hist, h_det_cv, total_detvar_hists);
 
-        total_detvar_cov = accumulateCovariance(result, n_bins);
+        total_detvar_cov = this->accumulateCovariance(result, n_bins);
 
         log::debug("DetectorSystematicStrategy::computeCovariance", "Computed detector covariance with",
                    total_detvar_hists.size() - 1, "variations");

--- a/libsyst/SystematicsProcessor.h
+++ b/libsyst/SystematicsProcessor.h
@@ -23,7 +23,9 @@ namespace analysis {
 class SystematicsProcessor {
   public:
     SystematicsProcessor(const VariableRegistry &registry, bool store_universe_hists = false)
-        : SystematicsProcessor(createKnobs(registry), createUniverses(registry), store_universe_hists) {}
+        : SystematicsProcessor(SystematicsProcessor::createKnobs(registry),
+                               SystematicsProcessor::createUniverses(registry),
+                               store_universe_hists) {}
 
     SystematicsProcessor(std::vector<KnobDef> knob_definitions, std::vector<UniverseDef> universe_definitions,
                          bool store_universe_hists = false)
@@ -58,12 +60,12 @@ class SystematicsProcessor {
             SystematicKey key{strategy->getName()};
             log::debug("SystematicsProcessor::processSystematics", "Computing covariance for", key.str());
             auto cov = strategy->computeCovariance(result, systematic_futures_);
-            sanitizeMatrix(cov);
+            this->sanitizeMatrix(cov);
             log::debug("SystematicsProcessor::processSystematics", key.str(), "matrix size", cov.GetNrows(), "x",
                        cov.GetNcols());
             result.covariance_matrices_.insert_or_assign(key, cov);
         }
-        combineCovariances(result);
+        this->combineCovariances(result);
         log::debug("SystematicsProcessor::processSystematics", "Covariance calculation complete");
     }
 
@@ -91,7 +93,7 @@ class SystematicsProcessor {
         for (const auto &[name, cov_matrix] : result.covariance_matrices_) {
             if (cov_matrix.GetNrows() == n_bins) {
                 TMatrixDSym cov = cov_matrix;
-                sanitizeMatrix(cov);
+                SystematicsProcessor::sanitizeMatrix(cov);
 
                 log::debug("SystematicsProcessor::combineCovariances", "Adding matrix", name.str());
 
@@ -103,7 +105,7 @@ class SystematicsProcessor {
             }
         }
 
-        sanitizeMatrix(result.total_covariance_);
+        SystematicsProcessor::sanitizeMatrix(result.total_covariance_);
 
         result.nominal_with_band_ = result.total_mc_hist_;
         result.nominal_with_band_.hist.shifts.resize(n_bins, 0);

--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -59,12 +59,12 @@ class UniverseSystematicStrategy : public SystematicStrategy {
                 continue;
             }
 
-            auto h_universe = buildUniverseHistogram(binning, n, uni_key, futures);
+            auto h_universe = this->buildUniverseHistogram(binning, n, uni_key, futures);
 
-            updateCovarianceMatrix(cov, nominal_hist, h_universe);
+            this->updateCovarianceMatrix(cov, nominal_hist, h_universe);
 
             ++processed_universes;
-            storeUniverseHistogram(stored_hists, std::move(h_universe));
+            this->storeUniverseHistogram(stored_hists, std::move(h_universe));
         }
 
         double n_universes = static_cast<double>(processed_universes);


### PR DESCRIPTION
## Summary
- qualify internal method calls with `this->` across analysis, data, histogram and plugin classes
- ensure systematics utilities explicitly reference internal helpers
- update plot utilities and plugins to consistently use `this->` for member functions

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68bcafc39600832e9f1018f29aa6ca65