### PR TITLE
Refactor libplot to eliminate magic numbers

### DIFF
--- a/libplot/IEventDisplay.h
+++ b/libplot/IEventDisplay.h
@@ -44,18 +44,23 @@ class DetectorDisplay : public IEventDisplay {
 
   protected:
     void draw(TCanvas &canvas) override {
+        const int bin_offset = 1;
+        const float threshold = 4;
+        const float min_val = 1;
+        const float max_val = 1000;
+
         TH2F hist(tag_.c_str(), tag_.c_str(), image_size_, 0, image_size_, image_size_, 0, image_size_);
 
         for (int r = 0; r < image_size_; ++r) {
             for (int c = 0; c < image_size_; ++c) {
                 float v = data_[r * image_size_ + c];
-                hist.SetBinContent(c + 1, r + 1, v > 4 ? v : 1);
+                hist.SetBinContent(c + bin_offset, r + bin_offset, v > threshold ? v : min_val);
             }
         }
 
         canvas.SetLogz();
-        hist.SetMinimum(1);
-        hist.SetMaximum(1000);
+        hist.SetMinimum(min_val);
+        hist.SetMaximum(max_val);
         hist.GetXaxis()->SetTitle("Wire");
         hist.GetYaxis()->SetTitle("Time");
         hist.Draw("COL");
@@ -72,21 +77,28 @@ class SemanticDisplay : public IEventDisplay {
 
   protected:
     void draw(TCanvas &) override {
+        const int palette_size = 10;
+        const int palette_step = 2;
+        const int bin_offset = 1;
+        const int stats_off = 0;
+        const double z_min = -0.5;
+        const double z_max = 9.5;
+
         TH2F hist(tag_.c_str(), tag_.c_str(), image_size_, 0, image_size_, image_size_, 0, image_size_);
 
-        int palette[10];
-        for (int i = 0; i < 10; ++i)
-            palette[i] = kWhite + (i > 0 ? i * 2 : 0);
-        gStyle->SetPalette(10, palette);
+        int palette[palette_size];
+        for (int i = 0; i < palette_size; ++i)
+            palette[i] = kWhite + (i > 0 ? i * palette_step : 0);
+        gStyle->SetPalette(palette_size, palette);
 
         for (int r = 0; r < image_size_; ++r) {
             for (int c = 0; c < image_size_; ++c) {
-                hist.SetBinContent(c + 1, r + 1, data_[r * image_size_ + c]);
+                hist.SetBinContent(c + bin_offset, r + bin_offset, data_[r * image_size_ + c]);
             }
         }
 
-        hist.SetStats(0);
-        hist.GetZaxis()->SetRangeUser(-0.5, 9.5);
+        hist.SetStats(stats_off);
+        hist.GetZaxis()->SetRangeUser(z_min, z_max);
         hist.GetXaxis()->SetTitle("Time");
         hist.GetYaxis()->SetTitle("Wire");
         hist.Draw("COL");

--- a/libplot/OccupancyMatrixPlot.h
+++ b/libplot/OccupancyMatrixPlot.h
@@ -21,16 +21,20 @@ class OccupancyMatrixPlot : public HistogramPlotterBase {
   private:
     void draw(TCanvas &canvas) override {
         canvas.cd();
+        const int stats_off = 0;
+        const int contour_count = 255;
+        const double margin = 0.15;
+        const double title_offset = 1.2;
 
-        gStyle->SetOptStat(0);
-        gStyle->SetNumberContours(255);
+        gStyle->SetOptStat(stats_off);
+        gStyle->SetNumberContours(contour_count);
 
         canvas.SetLogz();
-        canvas.SetLeftMargin(0.15);
-        canvas.SetRightMargin(0.15);
+        canvas.SetLeftMargin(margin);
+        canvas.SetRightMargin(margin);
 
         hist_->SetTitle("");
-        hist_->GetZaxis()->SetTitleOffset(1.2);
+        hist_->GetZaxis()->SetTitleOffset(title_offset);
 
         hist_->Draw("COLZ");
     }

--- a/libplot/RocCurvePlot.h
+++ b/libplot/RocCurvePlot.h
@@ -26,14 +26,21 @@ class RocCurvePlot : public HistogramPlotterBase {
         for (int i = 0; i < n; ++i) {
             graph.SetPoint(i, signal_eff_[i], background_rej_[i]);
         }
-        graph.SetLineColor(kBlue + 1);
-        graph.SetLineWidth(2);
-        graph.SetMarkerColor(kBlue + 1);
-        graph.SetMarkerStyle(20);
+
+        const int colour_offset = 1;
+        const int line_width = 2;
+        const int marker_style = 20;
+        const double axis_min = 0.0;
+        const double axis_max = 1.0;
+
+        graph.SetLineColor(kBlue + colour_offset);
+        graph.SetLineWidth(line_width);
+        graph.SetMarkerColor(kBlue + colour_offset);
+        graph.SetMarkerStyle(marker_style);
         graph.GetXaxis()->SetTitle("Signal Efficiency");
         graph.GetYaxis()->SetTitle("Background Rejection");
-        graph.GetXaxis()->SetLimits(0.0, 1.0);
-        graph.GetYaxis()->SetRangeUser(0.0, 1.0);
+        graph.GetXaxis()->SetLimits(axis_min, axis_max);
+        graph.GetYaxis()->SetRangeUser(axis_min, axis_max);
         graph.DrawClone("ALP");
     }
 

--- a/libplot/SelectionEfficiencyPlot.h
+++ b/libplot/SelectionEfficiencyPlot.h
@@ -45,67 +45,97 @@ class SelectionEfficiencyPlot : public HistogramPlotterBase {
 
     void setupFrame(TCanvas &canvas, TH1F &frame) {
         canvas.cd();
+        const double log_y_min = 1e-3;
+        const double lin_y_min = 0.0;
+        const double y_max = 1.05;
+        const int bin_offset = 1;
+
         if (use_log_y_)
             canvas.SetLogy();
-        double y_min = use_log_y_ ? 1e-3 : 0.0;
-        frame.GetYaxis()->SetRangeUser(y_min, 1.05);
+        double y_min = use_log_y_ ? log_y_min : lin_y_min;
+        frame.GetYaxis()->SetRangeUser(y_min, y_max);
         frame.GetYaxis()->SetTitle("Fraction");
         for (size_t i = 0; i < stages_.size(); ++i)
-            frame.GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
+            frame.GetXaxis()->SetBinLabel(i + bin_offset, stages_[i].c_str());
         frame.DrawClone("AXIS");
     }
 
     std::pair<TGraphErrors, TGraphErrors> buildGraphs() {
+        const double x_center_offset = 0.5;
+        const double zero = 0.0;
+        const int colour_offset = 1;
+        const int eff_marker = 20;
+        const int pur_marker = 21;
+        const int line_width = 2;
+
         int n = stages_.size();
         TGraphErrors eff_graph(n);
         TGraphErrors pur_graph(n);
         for (int i = 0; i < n; ++i) {
-            double x = i + 0.5;
+            double x = i + x_center_offset;
             eff_graph.SetPoint(i, x, efficiencies_[i]);
-            eff_graph.SetPointError(i, 0.0, efficiency_errors_[i]);
+            eff_graph.SetPointError(i, zero, efficiency_errors_[i]);
             pur_graph.SetPoint(i, x, purities_[i]);
-            pur_graph.SetPointError(i, 0.0, purity_errors_[i]);
+            pur_graph.SetPointError(i, zero, purity_errors_[i]);
         }
-        eff_graph.SetLineColor(kBlue + 1);
-        eff_graph.SetMarkerColor(kBlue + 1);
-        eff_graph.SetMarkerStyle(20);
-        eff_graph.SetLineWidth(2);
-        pur_graph.SetLineColor(kRed + 1);
-        pur_graph.SetMarkerColor(kRed + 1);
-        pur_graph.SetMarkerStyle(21);
-        pur_graph.SetLineWidth(2);
+        eff_graph.SetLineColor(kBlue + colour_offset);
+        eff_graph.SetMarkerColor(kBlue + colour_offset);
+        eff_graph.SetMarkerStyle(eff_marker);
+        eff_graph.SetLineWidth(line_width);
+        pur_graph.SetLineColor(kRed + colour_offset);
+        pur_graph.SetMarkerColor(kRed + colour_offset);
+        pur_graph.SetMarkerStyle(pur_marker);
+        pur_graph.SetLineWidth(line_width);
         return {eff_graph, pur_graph};
     }
 
     void annotatePoints() {
         TLatex latex;
-        latex.SetTextAlign(23);
-        latex.SetTextFont(42);
-        latex.SetTextSize(0.035);
+        const int text_align = 23;
+        const int font_style = 42;
+        const double text_size = 0.035;
+        const double x_center_offset = 0.5;
+        const double value_offset = 0.02;
+        const int colour_offset = 1;
+
+        latex.SetTextAlign(text_align);
+        latex.SetTextFont(font_style);
+        latex.SetTextSize(text_size);
         for (size_t i = 0; i < stages_.size(); ++i) {
-            double x = i + 0.5;
+            double x = i + x_center_offset;
             double ye = efficiencies_[i];
             double yp = purities_[i];
-            latex.SetTextColor(kBlue + 1);
-            latex.DrawLatex(x, ye + 0.02, Form("%.2f", ye));
-            latex.SetTextColor(kRed + 1);
-            latex.DrawLatex(x, yp + 0.02, Form("%.2f", yp));
+            latex.SetTextColor(kBlue + colour_offset);
+            latex.DrawLatex(x, ye + value_offset, Form("%.2f", ye));
+            latex.SetTextColor(kRed + colour_offset);
+            latex.DrawLatex(x, yp + value_offset, Form("%.2f", yp));
         }
     }
 
     TLegend buildLegend() {
-        TLegend legend(0.6, 0.75, 0.88, 0.88);
-        legend.SetBorderSize(0);
-        legend.SetFillStyle(0);
-        legend.SetTextFont(42);
+        const double x1 = 0.6;
+        const double y1 = 0.75;
+        const double x2 = 0.88;
+        const double y2 = 0.88;
+        const int border = 0;
+        const int fill = 0;
+        const int font_style = 42;
+        const int colour_offset = 1;
+        const int eff_marker = 20;
+        const int pur_marker = 21;
+
+        TLegend legend(x1, y1, x2, y2);
+        legend.SetBorderSize(border);
+        legend.SetFillStyle(fill);
+        legend.SetTextFont(font_style);
         auto *eff_entry = legend.AddEntry((TObject *)nullptr, "Signal Efficiency", "lep");
-        eff_entry->SetLineColor(kBlue + 1);
-        eff_entry->SetMarkerColor(kBlue + 1);
-        eff_entry->SetMarkerStyle(20);
+        eff_entry->SetLineColor(kBlue + colour_offset);
+        eff_entry->SetMarkerColor(kBlue + colour_offset);
+        eff_entry->SetMarkerStyle(eff_marker);
         auto *pur_entry = legend.AddEntry((TObject *)nullptr, "Signal Purity", "lep");
-        pur_entry->SetLineColor(kRed + 1);
-        pur_entry->SetMarkerColor(kRed + 1);
-        pur_entry->SetMarkerStyle(21);
+        pur_entry->SetLineColor(kRed + colour_offset);
+        pur_entry->SetMarkerColor(kRed + colour_offset);
+        pur_entry->SetMarkerStyle(pur_marker);
         return legend;
     }
 

--- a/libplot/SystematicBreakdownPlot.cpp
+++ b/libplot/SystematicBreakdownPlot.cpp
@@ -39,24 +39,35 @@ void SystematicBreakdownPlot::draw(TCanvas &canvas) {
     }
 
     stack_ = new THStack("syst_stack", "");
-    legend_ = new TLegend(0.65, 0.7, 0.9, 0.9);
-    legend_->SetBorderSize(0);
-    legend_->SetFillStyle(0);
-    legend_->SetTextFont(42);
+    const double x1 = 0.65;
+    const double y1 = 0.7;
+    const double x2 = 0.9;
+    const double y2 = 0.9;
+    const int border = 0;
+    const int fill = 0;
+    const int font_style = 42;
+    const int colour_offset = 1;
+    const int bin_offset = 1;
+    const double zero = 0.0;
 
-    int colour = kRed + 1;
+    legend_ = new TLegend(x1, y1, x2, y2);
+    legend_->SetBorderSize(border);
+    legend_->SetFillStyle(fill);
+    legend_->SetTextFont(font_style);
+
+    int colour = kRed + colour_offset;
     for (const auto &[key, cov] : variable_result_.covariance_matrices_) {
         TH1D *hist = new TH1D(key.str().c_str(), "", nbins, edges.data());
         const int n = cov.GetNrows();
         for (int i = 0; i < nbins && i < n; ++i) {
             double val = cov(i, i);
             if (std::isfinite(val)) {
-                if (normalise_ && bin_totals[i] > 0.0) {
+                if (normalise_ && bin_totals[i] > zero) {
                     val /= bin_totals[i];
                 }
-                hist->SetBinContent(i + 1, val);
+                hist->SetBinContent(i + bin_offset, val);
             } else {
-                hist->SetBinContent(i + 1, 0.0);
+                hist->SetBinContent(i + bin_offset, zero);
             }
         }
         hist->SetFillColor(colour);

--- a/libplot/UnstackedHistogramPlot.h
+++ b/libplot/UnstackedHistogramPlot.h
@@ -103,19 +103,30 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
 
     void renderWatermark(TPad *pad, const std::vector<std::string> &lines) const {
         pad->cd();
+        const int align = 33;
+        const int bold_font = 62;
+        const int regular_font = 42;
+        const double base_size = 0.05;
+        const double size_scale = 0.8;
+        const double offset = 0.03;
+        const double line_spacing = 0.06;
 
         TLatex watermark;
         watermark.SetNDC();
-        watermark.SetTextAlign(33);
-        watermark.SetTextFont(62);
-        watermark.SetTextSize(0.05);
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.03, lines[0].c_str());
-        watermark.SetTextFont(42);
-        watermark.SetTextSize(0.05 * 0.8);
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.09, lines[1].c_str());
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.15, lines[2].c_str());
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.21, lines[3].c_str());
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03, 1 - pad->GetTopMargin() - 0.27, lines[4].c_str());
+        watermark.SetTextAlign(align);
+        watermark.SetTextFont(bold_font);
+        watermark.SetTextSize(base_size);
+        watermark.DrawLatex(1 - pad->GetRightMargin() - offset, 1 - pad->GetTopMargin() - offset, lines[0].c_str());
+        watermark.SetTextFont(regular_font);
+        watermark.SetTextSize(base_size * size_scale);
+        watermark.DrawLatex(1 - pad->GetRightMargin() - offset,
+                            1 - pad->GetTopMargin() - (offset + line_spacing * 1), lines[1].c_str());
+        watermark.DrawLatex(1 - pad->GetRightMargin() - offset,
+                            1 - pad->GetTopMargin() - (offset + line_spacing * 2), lines[2].c_str());
+        watermark.DrawLatex(1 - pad->GetRightMargin() - offset,
+                            1 - pad->GetTopMargin() - (offset + line_spacing * 3), lines[3].c_str());
+        watermark.DrawLatex(1 - pad->GetRightMargin() - offset,
+                            1 - pad->GetTopMargin() - (offset + line_spacing * 4), lines[4].c_str());
     }
 
     void drawWatermark(TPad *pad, double total_mc_events) const {
@@ -125,22 +136,30 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
     }
 
     std::pair<TPad *, TPad *> setupPads(TCanvas &canvas) const {
-        const double PLOT_LEGEND_SPLIT = 0.85;
+        const double split = 0.85;
+        const double zero = 0.0;
+        const double one = 1.0;
+        const double top_margin = 0.01;
+        const double bottom_margin = 0.12;
+        const double left_margin = 0.12;
+        const double right_margin = 0.05;
+        const double legend_top = 0.05;
+        const double legend_bottom = 0.01;
 
         canvas.cd();
-        TPad *p_main = new TPad("main_pad", "main_pad", 0.0, 0.0, 1.0, PLOT_LEGEND_SPLIT);
-        TPad *p_legend = new TPad("legend_pad", "legend_pad", 0.0, PLOT_LEGEND_SPLIT, 1.0, 1.0);
+        TPad *p_main = new TPad("main_pad", "main_pad", zero, zero, one, split);
+        TPad *p_legend = new TPad("legend_pad", "legend_pad", zero, split, one, one);
 
-        p_main->SetTopMargin(0.01);
-        p_main->SetBottomMargin(0.12);
-        p_main->SetLeftMargin(0.12);
-        p_main->SetRightMargin(0.05);
+        p_main->SetTopMargin(top_margin);
+        p_main->SetBottomMargin(bottom_margin);
+        p_main->SetLeftMargin(left_margin);
+        p_main->SetRightMargin(right_margin);
 
         if (use_log_y_)
             p_main->SetLogy();
 
-        p_legend->SetTopMargin(0.05);
-        p_legend->SetBottomMargin(0.01);
+        p_legend->SetTopMargin(legend_top);
+        p_legend->SetBottomMargin(legend_bottom);
         p_legend->Draw();
         p_main->Draw();
 
@@ -169,13 +188,24 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
     void buildLegend(TPad *p_legend, const std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists) {
         p_legend->cd();
 
-        legend_ = new TLegend(0.12, 0.0, 0.95, 1.0);
-        legend_->SetBorderSize(0);
-        legend_->SetFillStyle(0);
-        legend_->SetTextFont(42);
+        const double x1 = 0.12;
+        const double y1 = 0.0;
+        const double x2 = 0.95;
+        const double y2 = 1.0;
+        const int border = 0;
+        const int fill = 0;
+        const int font_style = 42;
+        const int threshold = 4;
+        const int cols_large = 3;
+        const int cols_small = 2;
+
+        legend_ = new TLegend(x1, y1, x2, y2);
+        legend_->SetBorderSize(border);
+        legend_->SetFillStyle(fill);
+        legend_->SetTextFont(font_style);
 
         const int n_entries = mc_hists.size();
-        int n_cols = (n_entries > 4) ? 3 : 2;
+        int n_cols = (n_entries > threshold) ? cols_large : cols_small;
         legend_->SetNColumns(n_cols);
 
         auto format_double = [](double val, int precision) {
@@ -187,13 +217,16 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
 
         StratifierRegistry registry;
 
+        const int line_width = 2;
+        const int fill_style = 0;
+
         for (const auto &[key, hist] : mc_hists) {
             TH1D *h_leg = new TH1D();
 
             const auto &stratum = registry.getStratumProperties(category_column_, std::stoi(key.str()));
             h_leg->SetLineColor(stratum.fill_colour);
-            h_leg->SetLineWidth(2);
-            h_leg->SetFillStyle(0);
+            h_leg->SetLineWidth(line_width);
+            h_leg->SetFillStyle(fill_style);
 
             std::string tex_label = stratum.tex_label;
 
@@ -213,7 +246,14 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
 
         StratifierRegistry registry;
 
-        double max_y = use_log_y_ ? 0.1 : 0.0;
+        const double log_y_init = 0.1;
+        const double lin_y_init = 0.0;
+        const int line_width = 2;
+        const int fill_style = 0;
+        const double unit = 1.0;
+        const double zero = 0.0;
+
+        double max_y = use_log_y_ ? log_y_init : lin_y_init;
         bool first_drawn = false;
 
         for (const auto &[key, hist] : mc_hists) {
@@ -222,11 +262,11 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
 
             const auto &stratum = registry.getStratumProperties(category_column_, std::stoi(key.str()));
             h->SetLineColor(stratum.fill_colour);
-            h->SetLineWidth(2);
-            h->SetFillStyle(0);
+            h->SetLineWidth(line_width);
+            h->SetFillStyle(fill_style);
 
-            if (area_normalise_ && h->Integral() > 0)
-                h->Scale(1.0 / h->Integral());
+            if (area_normalise_ && h->Integral() > zero)
+                h->Scale(unit / h->Integral());
 
             max_y = std::max(max_y, h->GetMaximum());
 
@@ -243,14 +283,20 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
     }
 
     void renderCuts(double max_y) {
-        for (const auto &cut : cuts_) {
-            double y_arrow_pos = max_y * 0.85;
-            double x_range = hists_.empty() ? 0.0 : hists_[0]->GetXaxis()->GetXmax() - hists_[0]->GetXaxis()->GetXmin();
-            double arrow_length = x_range * 0.04;
+        const double arrow_pos_factor = 0.85;
+        const double arrow_len_factor = 0.04;
+        const double line_scale = 1.3;
+        const int line_width = 2;
+        const double arrow_size = 0.025;
 
-            TLine *line = new TLine(cut.threshold, 0, cut.threshold, max_y * 1.3);
+        for (const auto &cut : cuts_) {
+            double y_arrow_pos = max_y * arrow_pos_factor;
+            double x_range = hists_.empty() ? 0.0 : hists_[0]->GetXaxis()->GetXmax() - hists_[0]->GetXaxis()->GetXmin();
+            double arrow_length = x_range * arrow_len_factor;
+
+            TLine *line = new TLine(cut.threshold, 0, cut.threshold, max_y * line_scale);
             line->SetLineColor(kRed);
-            line->SetLineWidth(2);
+            line->SetLineWidth(line_width);
             line->SetLineStyle(kDashed);
             line->Draw("same");
             cut_visuals_.push_back(line);
@@ -265,36 +311,43 @@ class UnstackedHistogramPlot : public HistogramPlotterBase {
                 x_end = cut.threshold - arrow_length;
             }
 
-            TArrow *arrow = new TArrow(x_start, y_arrow_pos, x_end, y_arrow_pos, 0.025, ">");
+            TArrow *arrow = new TArrow(x_start, y_arrow_pos, x_end, y_arrow_pos, arrow_size, ">");
             arrow->SetLineColor(kRed);
             arrow->SetFillColor(kRed);
-            arrow->SetLineWidth(2);
+            arrow->SetLineWidth(line_width);
             arrow->Draw("same");
             cut_visuals_.push_back(arrow);
         }
     }
 
     void configureAxes() {
+        const double title_offset = 1.0;
+        const int divisions = 520;
+        const double tick_length = 0.02;
+        const int first_bin = 1;
+        const int default_setting = -1;
+
         if (hists_.empty())
             return;
 
         hists_[0]->GetXaxis()->SetTitle(variable_result_.binning_.getTexLabel().c_str());
         hists_[0]->GetYaxis()->SetTitle(y_axis_label_.c_str());
-        hists_[0]->GetXaxis()->SetTitleOffset(1.0);
-        hists_[0]->GetYaxis()->SetTitleOffset(1.0);
+        hists_[0]->GetXaxis()->SetTitleOffset(title_offset);
+        hists_[0]->GetYaxis()->SetTitleOffset(title_offset);
 
         const auto &edges = variable_result_.binning_.getEdges();
         hists_[0]->GetXaxis()->SetLimits(edges.front(), edges.back());
-        hists_[0]->GetXaxis()->SetNdivisions(520);
-        hists_[0]->GetXaxis()->SetTickLength(0.02);
+        hists_[0]->GetXaxis()->SetNdivisions(divisions);
+        hists_[0]->GetXaxis()->SetTickLength(tick_length);
 
         if (edges.size() >= 3) {
             std::ostringstream uf_label, of_label;
-            uf_label << "<" << edges[1];
+            uf_label << "<" << edges[first_bin];
             of_label << ">" << edges[edges.size() - 2];
-            hists_[0]->GetXaxis()->ChangeLabel(1, -1, -1, -1, -1, -1, uf_label.str().c_str());
-            hists_[0]->GetXaxis()->ChangeLabel(hists_[0]->GetXaxis()->GetNbins(), -1, -1, -1, -1, -1,
-                                               of_label.str().c_str());
+            hists_[0]->GetXaxis()->ChangeLabel(first_bin, default_setting, default_setting, default_setting, default_setting,
+                                               default_setting, uf_label.str().c_str());
+            hists_[0]->GetXaxis()->ChangeLabel(hists_[0]->GetXaxis()->GetNbins(), default_setting, default_setting,
+                                               default_setting, default_setting, default_setting, of_label.str().c_str());
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace hard-coded numeric literals in ROC curve, event displays, occupancy matrix, selection efficiency, systematic breakdown, and unstacked histogram plots with named variables.

## Testing
- `cmake -S . -B build` *(fails: could not find package ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb1201ed8832e8c574fab6d3ccf9a