### PR TITLE
refactor: convert scalar stratifier to source

### DIFF
--- a/libhist/CMakeLists.txt
+++ b/libhist/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(libhist VectorStratifier.cpp)
+add_library(libhist ScalarStratifier.cpp VectorStratifier.cpp)
 
 target_include_directories(libhist
   PUBLIC

--- a/libhist/ScalarStratifier.cpp
+++ b/libhist/ScalarStratifier.cpp
@@ -1,11 +1,9 @@
-#ifndef SCALAR_STRATIFIER_H
-#define SCALAR_STRATIFIER_H
-
 #include "IHistogramStratifier.h"
 #include "KeyTypes.h"
 #include "StratifierRegistry.h"
+
+#include <memory>
 #include <string>
-#include <vector>
 
 namespace analysis {
 
@@ -15,22 +13,28 @@ class ScalarStratifier : public IHistogramStratifier {
         : stratifier_key_(key), stratifier_registry_(registry) {}
 
   protected:
-    ROOT::RDF::RNode defineFilterColumn(ROOT::RDF::RNode dataframe, int key,
-                                        const std::string &new_column_name) const override {
-
+    ROOT::RDF::RNode defineFilterColumn(ROOT::RDF::RNode dataframe, int key, const std::string &new_column_name) const override {
         std::string filter_expression = this->getSchemeName() + " == " + std::to_string(key);
+
         return dataframe.Define(new_column_name, filter_expression);
     }
 
-    const std::string &getSchemeName() const override { return stratifier_key_.str(); }
+    const std::string &getSchemeName() const override {
+        return stratifier_key_.str();
+    }
 
-    const StratifierRegistry &getRegistry() const override { return stratifier_registry_; }
+    const StratifierRegistry &getRegistry() const override {
+        return stratifier_registry_;
+    }
 
   private:
     StratifierKey stratifier_key_;
     StratifierRegistry &stratifier_registry_;
 };
 
+std::unique_ptr<IHistogramStratifier> makeScalarStratifier(const StratifierKey &key, StratifierRegistry &registry) {
+    return std::make_unique<ScalarStratifier>(key, registry);
 }
 
-#endif
+}
+

--- a/libhist/StratifierManager.h
+++ b/libhist/StratifierManager.h
@@ -9,11 +9,11 @@
 #include "AnalysisLogger.h"
 #include "IHistogramStratifier.h"
 #include "KeyTypes.h"
-#include "ScalarStratifier.h"
 #include "StratifierRegistry.h"
 
 namespace analysis {
 
+std::unique_ptr<IHistogramStratifier> makeScalarStratifier(const StratifierKey &key, StratifierRegistry &registry);
 std::unique_ptr<IHistogramStratifier> makeVectorStratifier(const StratifierKey &key, StratifierRegistry &registry);
 
 class StratifierManager {
@@ -33,7 +33,7 @@ class StratifierManager {
             StratifierType type = registry_.findSchemeType(key);
 
             if (type == StratifierType::kScalar) {
-                stratifier = std::make_unique<ScalarStratifier>(key, registry_);
+                stratifier = makeScalarStratifier(key, registry_);
             } else if (type == StratifierType::kVector) {
                 stratifier = makeVectorStratifier(key, registry_);
             } else {


### PR DESCRIPTION
## Summary
- move scalar stratifier logic into ScalarStratifier.cpp and expose factory
- update StratifierManager to construct scalar stratifiers via factory
- include ScalarStratifier.cpp in libhist build

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: setup not found)*
- `source .build.sh` *(fails: Could not find package configuration file provided by "ROOT")*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb7d733e0832eba4e5f2a7b1ca016