### PR TITLE
Format selection rules for clarity

### DIFF
--- a/config/plugins/selection_efficiency.json
+++ b/config/plugins/selection_efficiency.json
@@ -9,7 +9,7 @@
               "initial_label": "empty",
               "clauses": [
                 "in_reco_fiducial",
-                "num_slices == 1"
+                "num_slices == 1",
                 "optical_filter_pe_beam > 20",
                 "muon_score > 0.5",
                 "muon_length > 10",

--- a/libapp/SelectionRegistry.h
+++ b/libapp/SelectionRegistry.h
@@ -50,19 +50,39 @@ class SelectionRegistry {
     void registerDefaults() {
         const std::vector<std::pair<std::string, SelectionRule>> defaults{
             {"QUALITY", {"Quality Preselection", {"quality_event"}}},
+
             {"QUALITY_BREAKDOWN",
              {"Quality Preselection Breakdown",
-              {"in_reco_fiducial", "num_slices == 1", "selection_pass", "optical_filter_pe_beam > 20"}}},
+              {"in_reco_fiducial",
+               "num_slices == 1",
+               "selection_pass",
+               "optical_filter_pe_beam > 20"}}},
 
             {"NUMU_CC", {"NuMu CC Selection", {"has_muon", "n_pfps_gen2 > 1"}}},
-            {"NUMU_CC_BREAKDOWN",
-             {"NuMu CC Selection Breakdown", {"muon_score", "muon_length", "has_muon", "n_pfps_gen2 > 1"}}},
 
-            {"QUALITY_NUMU_CC", {"Quality + NuMu CC Selection", {"quality_event", "has_muon", "n_pfps_gen2 > 1"}}},
+            {"NUMU_CC_BREAKDOWN",
+             {"NuMu CC Selection Breakdown",
+              {"muon_score",
+               "muon_length",
+               "has_muon",
+               "n_pfps_gen2 > 1"}}},
+
+            {"QUALITY_NUMU_CC",
+             {"Quality + NuMu CC Selection",
+              {"quality_event",
+               "has_muon",
+               "n_pfps_gen2 > 1"}}},
+
             {"QUALITY_NUMU_CC_BREAKDOWN",
              {"Quality + NuMu CC Selection Breakdown",
-              {"in_reco_fiducial", "num_slices == 1", "selection_pass", "optical_filter_pe_beam > 20", "muon_score",
-               "muon_length", "has_muon", "n_pfps_gen2 > 1"}}},
+              {"in_reco_fiducial",
+               "num_slices == 1",
+               "selection_pass",
+               "optical_filter_pe_beam > 20",
+               "muon_score",
+               "muon_length",
+               "has_muon",
+               "n_pfps_gen2 > 1"}}},
 
             {"ALL_EVENTS", {"All Events", {}}},
             {"NONE", {"No Preselection", {}}}};

--- a/libdata/ReconstructionProcessor.h
+++ b/libdata/ReconstructionProcessor.h
@@ -25,8 +25,13 @@ class ReconstructionProcessor : public IEventProcessor {
                                       [](const ROOT::RVec<unsigned> &gens) { return ROOT::VecOps::Sum(gens == 3u); },
                                       {"pfp_generations"});
 
-        auto quality_df = gen3_df.Define("quality_event", "in_reco_fiducial && num_slices == 1 && "
-                                                          "selection_pass && optical_filter_pe_beam > 20");
+        auto quality_df = gen3_df.Define(
+            "quality_event",
+            "in_reco_fiducial && "
+            "num_slices == 1 && "
+            "selection_pass && "
+            "optical_filter_pe_beam > 20"
+        );
 
         return next_ ? next_->process(quality_df, st) : quality_df;
     }


### PR DESCRIPTION
## Summary
- Place each selection clause on its own line in ReconstructionProcessor and selection registry for improved readability.
- Fix plugin configuration so each selection rule is a standalone entry.

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bcbb5c7bb4832eaaf90f0ab6b87343