### PR TITLE
Convert plot implementations to headers

### DIFF
--- a/libplot/OccupancyMatrixPlot.h
+++ b/libplot/OccupancyMatrixPlot.h
@@ -1,3 +1,6 @@
+#ifndef OCCUPANCYMATRIXPLOT_H
+#define OCCUPANCYMATRIXPLOT_H
+
 #include <string>
 
 #include "TCanvas.h"
@@ -39,3 +42,5 @@ class OccupancyMatrixPlot : public IHistogramPlot {
 };
 
 }
+
+#endif

--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -11,11 +11,11 @@
 #include "AnalysisDataLoader.h"
 #include "AnalysisResult.h"
 #include "HistogramCut.h"
-#include "OccupancyMatrixPlot.cpp"
+#include "OccupancyMatrixPlot.h"
 #include "QuadTreeBinning2D.h"
 #include "Selection.h"
-#include "StackedHistogramPlot.cpp"
-#include "UnstackedHistogramPlot.cpp"
+#include "StackedHistogramPlot.h"
+#include "UnstackedHistogramPlot.h"
 
 namespace analysis {
 

--- a/libplot/RocCurvePlot.h
+++ b/libplot/RocCurvePlot.h
@@ -1,3 +1,6 @@
+#ifndef ROCCURVEPLOT_H
+#define ROCCURVEPLOT_H
+
 #include <string>
 #include <vector>
 
@@ -45,3 +48,5 @@ class RocCurvePlot : public IHistogramPlot {
 };
 
 }
+
+#endif

--- a/libplot/SelectionEfficiencyPlot.h
+++ b/libplot/SelectionEfficiencyPlot.h
@@ -1,3 +1,6 @@
+#ifndef SELECTIONEFFICIENCYPLOT_H
+#define SELECTIONEFFICIENCYPLOT_H
+
 #include <string>
 #include <vector>
 #include <utility>
@@ -147,3 +150,5 @@ class SelectionEfficiencyPlot : public IHistogramPlot {
 };
 
 }
+
+#endif

--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -1,3 +1,6 @@
+#ifndef STACKEDHISTOGRAMPLOT_H
+#define STACKEDHISTOGRAMPLOT_H
+
 #include <algorithm>
 #include <iomanip>
 #include <map>
@@ -408,4 +411,6 @@ class StackedHistogramPlot : public IHistogramPlot {
 };
 
 }
+
+#endif
 

--- a/libplot/SystematicBreakdownPlot.h
+++ b/libplot/SystematicBreakdownPlot.h
@@ -1,3 +1,6 @@
+#ifndef SYSTEMATICBREAKDOWNPLOT_H
+#define SYSTEMATICBREAKDOWNPLOT_H
+
 #include <string>
 #include <vector>
 #include <algorithm>
@@ -101,3 +104,5 @@ class SystematicBreakdownPlot : public IHistogramPlot {
 };
 
 }
+
+#endif

--- a/libplot/UnstackedHistogramPlot.h
+++ b/libplot/UnstackedHistogramPlot.h
@@ -1,3 +1,6 @@
+#ifndef UNSTACKEDHISTOGRAMPLOT_H
+#define UNSTACKEDHISTOGRAMPLOT_H
+
 #include <algorithm>
 #include <iomanip>
 #include <locale>
@@ -383,7 +386,9 @@ class UnstackedHistogramPlot : public IHistogramPlot {
     std::vector<TH1D *> hists_;
     TLegend *legend_ = nullptr;
     std::vector<TObject *> cut_visuals_;
-};
+  };
 
-}
+ }
+
+#endif
 

--- a/libplug/CutFlowPlotPlugin.cc
+++ b/libplug/CutFlowPlotPlugin.cc
@@ -8,7 +8,7 @@
 
 #include "AnalysisLogger.h"
 #include "IPlotPlugin.h"
-#include "SelectionEfficiencyPlot.cpp"
+#include "SelectionEfficiencyPlot.h"
 #include "StratifierRegistry.h"
 
 namespace analysis {

--- a/libplug/RocCurvePlugin.cc
+++ b/libplug/RocCurvePlugin.cc
@@ -8,7 +8,7 @@
 #include "AnalysisLogger.h"
 #include "HistogramCut.h"
 #include "IAnalysisPlugin.h"
-#include "RocCurvePlot.cpp"
+#include "RocCurvePlot.h"
 #include "SelectionRegistry.h"
 #include "StratifierRegistry.h"
 

--- a/libplug/StackedHistogramPlugin.cc
+++ b/libplug/StackedHistogramPlugin.cc
@@ -8,7 +8,7 @@
 
 #include "AnalysisLogger.h"
 #include "IPlotPlugin.h"
-#include "StackedHistogramPlot.cpp"
+#include "StackedHistogramPlot.h"
 
 namespace analysis {
 

--- a/libplug/SystematicBreakdownPlugin.cc
+++ b/libplug/SystematicBreakdownPlugin.cc
@@ -8,7 +8,7 @@
 
 #include "AnalysisLogger.h"
 #include "IAnalysisPlugin.h"
-#include "SystematicBreakdownPlot.cpp"
+#include "SystematicBreakdownPlot.h"
 
 namespace analysis {
 

--- a/libplug/UnstackedHistogramPlugin.cc
+++ b/libplug/UnstackedHistogramPlugin.cc
@@ -10,7 +10,7 @@
 
 #include "AnalysisLogger.h"
 #include "IAnalysisPlugin.h"
-#include "UnstackedHistogramPlot.cpp"
+#include "UnstackedHistogramPlot.h"
 
 namespace analysis {
 


### PR DESCRIPTION
## Summary
- make plot classes header-only by converting .cpp files to .h
- update includes in plot catalog and plugins

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*
- `apt-get update` *(fails: repository 'archive.ubuntu.com' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbc6dae64832ea21804a42169c201