### PR TITLE
Rename OccupancyMatrixPlot to MatrixPlot

### DIFF
--- a/docs/class_diagram.puml
+++ b/docs/class_diagram.puml
@@ -106,7 +106,7 @@ package plot #LightGreen {
 
   class StackedHistogramPlot
   class UnstackedHistogramPlot
-  class OccupancyMatrixPlot
+  class MatrixPlot
   class SelectionEfficiencyPlot
   class SystematicBreakdownPlot
   class RocCurvePlot
@@ -114,7 +114,7 @@ package plot #LightGreen {
 
 IHistogramPlot <|-- StackedHistogramPlot
 IHistogramPlot <|-- UnstackedHistogramPlot
-IHistogramPlot <|-- OccupancyMatrixPlot
+IHistogramPlot <|-- MatrixPlot
 IHistogramPlot <|-- SelectionEfficiencyPlot
 IHistogramPlot <|-- SystematicBreakdownPlot
 IHistogramPlot <|-- RocCurvePlot

--- a/libplot/MatrixPlot.h
+++ b/libplot/MatrixPlot.h
@@ -1,5 +1,5 @@
-#ifndef OCCUPANCYMATRIXPLOT_H
-#define OCCUPANCYMATRIXPLOT_H
+#ifndef MATRIXPLOT_H
+#define MATRIXPLOT_H
 
 #include <string>
 
@@ -11,12 +11,12 @@
 
 namespace analysis {
 
-class OccupancyMatrixPlot : public IHistogramPlot {
+class MatrixPlot : public IHistogramPlot {
   public:
-    OccupancyMatrixPlot(std::string plot_name, TH2F *hist, std::string output_directory = "plots")
+    MatrixPlot(std::string plot_name, TH2F *hist, std::string output_directory = "plots")
         : IHistogramPlot(std::move(plot_name), std::move(output_directory)), hist_(hist) {}
 
-    ~OccupancyMatrixPlot() override { delete hist_; }
+    ~MatrixPlot() override { delete hist_; }
 
   private:
     void draw(TCanvas &canvas) override {

--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -11,7 +11,7 @@
 #include "AnalysisDataLoader.h"
 #include "AnalysisResult.h"
 #include "HistogramCut.h"
-#include "OccupancyMatrixPlot.h"
+#include "MatrixPlot.h"
 #include "QuadTreeBinning2D.h"
 #include "Selection.h"
 #include "StackedHistogramPlot.h"
@@ -69,10 +69,10 @@ class PlotCatalog {
         plot.drawAndSave();
     }
 
-    void generateOccupancyMatrixPlot(const AnalysisResult &res, const std::string &x_variable,
-                                     const std::string &y_variable, const std::string &region,
-                                     const Selection &selection, const std::vector<Cut> &x_cuts = {},
-                                     const std::vector<Cut> &y_cuts = {}) const {
+    void generateMatrixPlot(const AnalysisResult &res, const std::string &x_variable,
+                            const std::string &y_variable, const std::string &region,
+                            const Selection &selection, const std::vector<Cut> &x_cuts = {},
+                            const std::vector<Cut> &y_cuts = {}) const {
         const auto &x_res = this->fetchResult(res, x_variable, region);
         const auto &y_res = this->fetchResult(res, y_variable, region);
 
@@ -101,7 +101,7 @@ class PlotCatalog {
             this->fillHistogram(hist, data);
         }
 
-        OccupancyMatrixPlot plot(std::move(name), hist, output_directory_.string());
+        MatrixPlot plot(std::move(name), hist, output_directory_.string());
         plot.drawAndSave();
     }
 

--- a/libplug/OccupancyMatrixPlugin.cc
+++ b/libplug/OccupancyMatrixPlugin.cc
@@ -78,8 +78,8 @@ class OccupancyMatrixPlugin : public IAnalysisPlugin {
                 continue;
             }
             PlotCatalog catalog(*loader_, 800, pc.output_directory);
-            catalog.generateOccupancyMatrixPlot(result, pc.x_variable, pc.y_variable, pc.region, pc.selection,
-                                                pc.x_cuts, pc.y_cuts);
+            catalog.generateMatrixPlot(result, pc.x_variable, pc.y_variable, pc.region, pc.selection,
+                                       pc.x_cuts, pc.y_cuts);
         }
     }
 


### PR DESCRIPTION
## Summary
- Rename OccupancyMatrixPlot to MatrixPlot
- Update PlotCatalog and OccupancyMatrixPlugin to use MatrixPlot
- Adjust class diagram to reflect new plot name

## Testing
- `bash ./.build.sh` *(fails: Could not find package configuration file provided by "ROOT"; no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbf371314832e954c95fbea886f72