### PR TITLE
refactor: split event display headers

### DIFF
--- a/libplot/DetectorDisplay.h
+++ b/libplot/DetectorDisplay.h
@@ -1,0 +1,45 @@
+#ifndef DETECTORDISPLAY_H
+#define DETECTORDISPLAY_H
+
+#include "IEventDisplay.h"
+#include "TH2F.h"
+#include <vector>
+
+namespace analysis {
+
+class DetectorDisplay : public IEventDisplay {
+  public:
+    DetectorDisplay(std::string tag, std::vector<float> data, int image_size, std::string output_directory)
+        : IEventDisplay(std::move(tag), image_size, std::move(output_directory)), data_(std::move(data)) {}
+
+  protected:
+    void draw(TCanvas &canvas) override {
+        const int bin_offset = 1;
+        const float threshold = 4;
+        const float min_val = 1;
+        const float max_val = 1000;
+
+        TH2F hist(tag_.c_str(), tag_.c_str(), image_size_, 0, image_size_, image_size_, 0, image_size_);
+
+        for (int r = 0; r < image_size_; ++r) {
+            for (int c = 0; c < image_size_; ++c) {
+                float v = data_[r * image_size_ + c];
+                hist.SetBinContent(c + bin_offset, r + bin_offset, v > threshold ? v : min_val);
+            }
+        }
+
+        canvas.SetLogz();
+        hist.SetMinimum(min_val);
+        hist.SetMaximum(max_val);
+        hist.GetXaxis()->SetTitle("Wire");
+        hist.GetYaxis()->SetTitle("Time");
+        hist.Draw("COL");
+    }
+
+  private:
+    std::vector<float> data_;
+};
+
+} // namespace analysis
+
+#endif

--- a/libplot/IEventDisplay.h
+++ b/libplot/IEventDisplay.h
@@ -3,12 +3,9 @@
 
 #include "AnalysisLogger.h"
 #include "TCanvas.h"
-#include "TColor.h"
-#include "TH2F.h"
-#include "TStyle.h"
 #include "TSystem.h"
 #include <string>
-#include <vector>
+#include <utility>
 
 namespace analysis {
 
@@ -37,77 +34,6 @@ class IEventDisplay {
     std::string output_directory_;
 };
 
-class DetectorDisplay : public IEventDisplay {
-  public:
-    DetectorDisplay(std::string tag, std::vector<float> data, int image_size, std::string output_directory)
-        : IEventDisplay(std::move(tag), image_size, std::move(output_directory)), data_(std::move(data)) {}
-
-  protected:
-    void draw(TCanvas &canvas) override {
-        const int bin_offset = 1;
-        const float threshold = 4;
-        const float min_val = 1;
-        const float max_val = 1000;
-
-        TH2F hist(tag_.c_str(), tag_.c_str(), image_size_, 0, image_size_, image_size_, 0, image_size_);
-
-        for (int r = 0; r < image_size_; ++r) {
-            for (int c = 0; c < image_size_; ++c) {
-                float v = data_[r * image_size_ + c];
-                hist.SetBinContent(c + bin_offset, r + bin_offset, v > threshold ? v : min_val);
-            }
-        }
-
-        canvas.SetLogz();
-        hist.SetMinimum(min_val);
-        hist.SetMaximum(max_val);
-        hist.GetXaxis()->SetTitle("Wire");
-        hist.GetYaxis()->SetTitle("Time");
-        hist.Draw("COL");
-    }
-
-  private:
-    std::vector<float> data_;
-};
-
-class SemanticDisplay : public IEventDisplay {
-  public:
-    SemanticDisplay(std::string tag, std::vector<int> data, int image_size, std::string output_directory)
-        : IEventDisplay(std::move(tag), image_size, std::move(output_directory)), data_(std::move(data)) {}
-
-  protected:
-    void draw(TCanvas &) override {
-        const int palette_size = 10;
-        const int palette_step = 2;
-        const int bin_offset = 1;
-        const int stats_off = 0;
-        const double z_min = -0.5;
-        const double z_max = 9.5;
-
-        TH2F hist(tag_.c_str(), tag_.c_str(), image_size_, 0, image_size_, image_size_, 0, image_size_);
-
-        int palette[palette_size];
-        for (int i = 0; i < palette_size; ++i)
-            palette[i] = kWhite + (i > 0 ? i * palette_step : 0);
-        gStyle->SetPalette(palette_size, palette);
-
-        for (int r = 0; r < image_size_; ++r) {
-            for (int c = 0; c < image_size_; ++c) {
-                hist.SetBinContent(c + bin_offset, r + bin_offset, data_[r * image_size_ + c]);
-            }
-        }
-
-        hist.SetStats(stats_off);
-        hist.GetZaxis()->SetRangeUser(z_min, z_max);
-        hist.GetXaxis()->SetTitle("Time");
-        hist.GetYaxis()->SetTitle("Wire");
-        hist.Draw("COL");
-    }
-
-  private:
-    std::vector<int> data_;
-};
-
-}
+} // namespace analysis
 
 #endif

--- a/libplot/SemanticDisplay.h
+++ b/libplot/SemanticDisplay.h
@@ -1,0 +1,52 @@
+#ifndef SEMANTICDISPLAY_H
+#define SEMANTICDISPLAY_H
+
+#include "IEventDisplay.h"
+#include "TColor.h"
+#include "TH2F.h"
+#include "TStyle.h"
+#include <vector>
+
+namespace analysis {
+
+class SemanticDisplay : public IEventDisplay {
+  public:
+    SemanticDisplay(std::string tag, std::vector<int> data, int image_size, std::string output_directory)
+        : IEventDisplay(std::move(tag), image_size, std::move(output_directory)), data_(std::move(data)) {}
+
+  protected:
+    void draw(TCanvas &) override {
+        const int palette_size = 10;
+        const int palette_step = 2;
+        const int bin_offset = 1;
+        const int stats_off = 0;
+        const double z_min = -0.5;
+        const double z_max = 9.5;
+
+        TH2F hist(tag_.c_str(), tag_.c_str(), image_size_, 0, image_size_, image_size_, 0, image_size_);
+
+        int palette[palette_size];
+        for (int i = 0; i < palette_size; ++i)
+            palette[i] = kWhite + (i > 0 ? i * palette_step : 0);
+        gStyle->SetPalette(palette_size, palette);
+
+        for (int r = 0; r < image_size_; ++r) {
+            for (int c = 0; c < image_size_; ++c) {
+                hist.SetBinContent(c + bin_offset, r + bin_offset, data_[r * image_size_ + c]);
+            }
+        }
+
+        hist.SetStats(stats_off);
+        hist.GetZaxis()->SetRangeUser(z_min, z_max);
+        hist.GetXaxis()->SetTitle("Time");
+        hist.GetYaxis()->SetTitle("Wire");
+        hist.Draw("COL");
+    }
+
+  private:
+    std::vector<int> data_;
+};
+
+} // namespace analysis
+
+#endif

--- a/libplug/EventDisplayPlugin.cc
+++ b/libplug/EventDisplayPlugin.cc
@@ -10,7 +10,8 @@
 #include "AnalysisDataLoader.h"
 #include "AnalysisLogger.h"
 #include "IAnalysisPlugin.h"
-#include "IEventDisplay.h"
+#include "DetectorDisplay.h"
+#include "SemanticDisplay.h"
 #include "Selection.h"
 
 namespace analysis {


### PR DESCRIPTION
## Summary
- Move IEventDisplay base class into its own header
- Create DetectorDisplay.h and SemanticDisplay.h for concrete event display implementations
- Update EventDisplayPlugin to include new headers

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: Could not find package configuration file provided by "ROOT")*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbf9b8618832eb118f3d94edf1209