### PR TITLE
Refactor matrix plot logic into MatrixPlot

### DIFF
--- a/libplot/IHistogramPlot.h
+++ b/libplot/IHistogramPlot.h
@@ -13,66 +13,75 @@
 namespace analysis {
 
 class IHistogramPlot {
-  public:
-    IHistogramPlot(std::string plot_name, std::string output_directory = "plots")
-        : plot_name_(std::move(plot_name)), output_directory_(std::move(output_directory)) {
-        gSystem->mkdir(output_directory_.c_str(), true);
-    }
+public:
+  IHistogramPlot(std::string plot_name, std::string output_directory = "plots")
+      : plot_name_(std::move(plot_name)),
+        output_directory_(std::move(output_directory)) {
+    gSystem->mkdir(output_directory_.c_str(), true);
+  }
 
-    virtual ~IHistogramPlot() = default;
+  virtual ~IHistogramPlot() = default;
 
-    virtual void draw(TCanvas &canvas) = 0;
+  virtual void draw(TCanvas &canvas) = 0;
 
-    void drawAndSave(const std::string &format = "png") {
-        this->setGlobalStyle();
-        TCanvas canvas(plot_name_.c_str(), plot_name_.c_str(), 800, 600);
-        this->draw(canvas);
-        canvas.SaveAs((output_directory_ + "/" + plot_name_ + "." + format).c_str());
-    }
+  void drawAndSave(const std::string &format = "png") {
+    this->setGlobalStyle();
+    TCanvas canvas(plot_name_.c_str(), plot_name_.c_str(), 800, 600);
+    this->draw(canvas);
+    canvas.SaveAs(
+        (output_directory_ + "/" + plot_name_ + "." + format).c_str());
+  }
 
-  protected:
-    virtual void setGlobalStyle() const {
-        const int font_style = 42;
-        TStyle *style = new TStyle("PlotterStyle", "Plotter Style");
-        style->SetTitleFont(font_style, "X");
-        style->SetTitleFont(font_style, "Y");
-        style->SetTitleFont(font_style, "Z");
-        style->SetTitleSize(0.05, "X");
-        style->SetTitleSize(0.05, "Y");
-        style->SetTitleSize(0.04, "Z");
-        style->SetLabelFont(font_style, "X");
-        style->SetLabelFont(font_style, "Y");
-        style->SetLabelFont(font_style, "Z");
-        style->SetLabelSize(0.045, "X");
-        style->SetLabelSize(0.045, "Y");
-        style->SetLabelSize(0.045, "Z");
-        style->SetTitleOffset(0.93, "X");
-        style->SetTitleOffset(1.06, "Y");
-        style->SetOptStat(0);
-        style->SetPadTickX(1);
-        style->SetPadTickY(1);
-        style->SetPadLeftMargin(0.15);
-        style->SetPadRightMargin(0.05);
-        style->SetPadTopMargin(0.07);
-        style->SetPadBottomMargin(0.12);
-        style->SetMarkerSize(1.0);
-        style->SetCanvasColor(0);
-        style->SetPadColor(0);
-        style->SetFrameFillColor(0);
-        style->SetCanvasBorderMode(0);
-        style->SetPadBorderMode(0);
-        style->SetStatColor(0);
-        style->SetFrameBorderMode(0);
-        style->SetTitleFillColor(0);
-        style->SetTitleBorderSize(0);
-        gROOT->SetStyle("PlotterStyle");
-        gROOT->ForceStyle();
-    }
+  static std::string sanitise(std::string s) {
+    for (auto &c : s)
+      if (c == '.' || c == '/' || c == ' ')
+        c = '_';
+    return s;
+  }
 
-    std::string plot_name_;
-    std::string output_directory_;
+protected:
+  virtual void setGlobalStyle() const {
+    const int font_style = 42;
+    TStyle *style = new TStyle("PlotterStyle", "Plotter Style");
+    style->SetTitleFont(font_style, "X");
+    style->SetTitleFont(font_style, "Y");
+    style->SetTitleFont(font_style, "Z");
+    style->SetTitleSize(0.05, "X");
+    style->SetTitleSize(0.05, "Y");
+    style->SetTitleSize(0.04, "Z");
+    style->SetLabelFont(font_style, "X");
+    style->SetLabelFont(font_style, "Y");
+    style->SetLabelFont(font_style, "Z");
+    style->SetLabelSize(0.045, "X");
+    style->SetLabelSize(0.045, "Y");
+    style->SetLabelSize(0.045, "Z");
+    style->SetTitleOffset(0.93, "X");
+    style->SetTitleOffset(1.06, "Y");
+    style->SetOptStat(0);
+    style->SetPadTickX(1);
+    style->SetPadTickY(1);
+    style->SetPadLeftMargin(0.15);
+    style->SetPadRightMargin(0.05);
+    style->SetPadTopMargin(0.07);
+    style->SetPadBottomMargin(0.12);
+    style->SetMarkerSize(1.0);
+    style->SetCanvasColor(0);
+    style->SetPadColor(0);
+    style->SetFrameFillColor(0);
+    style->SetCanvasBorderMode(0);
+    style->SetPadBorderMode(0);
+    style->SetStatColor(0);
+    style->SetFrameBorderMode(0);
+    style->SetTitleFillColor(0);
+    style->SetTitleBorderSize(0);
+    gROOT->SetStyle("PlotterStyle");
+    gROOT->ForceStyle();
+  }
+
+  std::string plot_name_;
+  std::string output_directory_;
 };
 
-}
+} // namespace analysis
 
 #endif

--- a/libplot/MatrixPlot.h
+++ b/libplot/MatrixPlot.h
@@ -1,7 +1,16 @@
 #ifndef MATRIXPLOT_H
 #define MATRIXPLOT_H
 
+#include <algorithm>
 #include <string>
+#include <utility>
+#include <vector>
+
+#include "AnalysisDataLoader.h"
+#include "AnalysisResult.h"
+#include "HistogramCut.h"
+#include "QuadTreeBinning2D.h"
+#include "Selection.h"
 
 #include "TCanvas.h"
 #include "TH2F.h"
@@ -12,35 +21,207 @@
 namespace analysis {
 
 class MatrixPlot : public IHistogramPlot {
-  public:
-    MatrixPlot(std::string plot_name, TH2F *hist, std::string output_directory = "plots")
-        : IHistogramPlot(std::move(plot_name), std::move(output_directory)), hist_(hist) {}
+public:
+  MatrixPlot(std::string plot_name, const VariableResult &x_res,
+             const VariableResult &y_res, AnalysisDataLoader &loader,
+             const Selection &selection, std::string output_directory = "plots",
+             const std::vector<Cut> &x_cuts = {},
+             const std::vector<Cut> &y_cuts = {})
+      : IHistogramPlot(std::move(plot_name), std::move(output_directory)) {
+    auto edges = determineEdges(loader, x_res, y_res);
+    hist_ = new TH2F(plot_name_.c_str(), plot_name_.c_str(),
+                     edges.first.size() - 1, edges.first.data(),
+                     edges.second.size() - 1, edges.second.data());
+    hist_->GetXaxis()->SetTitle(x_res.binning_.getTexLabel().c_str());
+    hist_->GetYaxis()->SetTitle(y_res.binning_.getTexLabel().c_str());
 
-    ~MatrixPlot() override { delete hist_; }
+    std::string filter = selection.str();
 
-  private:
-    void draw(TCanvas &canvas) override {
-        canvas.cd();
-        const int stats_off = 0;
-        const int contour_count = 255;
-        const double margin = 0.15;
-        const double title_offset = 1.2;
+    for (auto &kv : loader.getSampleFrames()) {
+      auto df = kv.second.nominal_node_;
+      df = applySelectionFilters(df, x_res, y_res, filter, x_cuts, y_cuts);
+      auto data = extractValues(df, x_res, y_res);
+      fillHistogram(hist_, data);
+    }
+  }
 
-        gStyle->SetOptStat(stats_off);
-        gStyle->SetNumberContours(contour_count);
+  ~MatrixPlot() override { delete hist_; }
 
-        canvas.SetLogz();
-        canvas.SetLeftMargin(margin);
-        canvas.SetRightMargin(margin);
+private:
+  static std::pair<std::vector<double>, std::vector<double>>
+  determineEdges(AnalysisDataLoader &loader, const VariableResult &x_res,
+                 const VariableResult &y_res) {
+    auto x_edges = x_res.binning_.getEdges();
+    auto y_edges = y_res.binning_.getEdges();
 
-        hist_->SetTitle("");
-        hist_->GetZaxis()->SetTitleOffset(title_offset);
-        hist_->Draw("COLZ");
+    std::vector<ROOT::RDF::RNode> mc_nodes;
+    for (auto &[key, sample] : loader.getSampleFrames())
+      if (sample.isMc())
+        mc_nodes.emplace_back(sample.nominal_node_);
+    if (!mc_nodes.empty()) {
+      auto bins = QuadTreeBinning2D::calculate(mc_nodes, x_res.binning_,
+                                               y_res.binning_);
+      x_edges = bins.first.getEdges();
+      y_edges = bins.second.getEdges();
     }
 
-    TH2F *hist_;
+    return {x_edges, y_edges};
+  }
+
+  static ROOT::RDF::RNode
+  applySelectionFilters(ROOT::RDF::RNode df, const VariableResult &x_res,
+                        const VariableResult &y_res, const std::string &filter,
+                        const std::vector<Cut> &x_cuts,
+                        const std::vector<Cut> &y_cuts) {
+    if (filter.find_first_not_of(" \t\n\r") != std::string::npos)
+      df = df.Filter(filter);
+
+    for (auto const &c : x_cuts) {
+      std::string expr =
+          x_res.binning_.getVariable() +
+          (c.direction == CutDirection::GreaterThan ? ">" : "<") +
+          std::to_string(c.threshold);
+      df = df.Filter(expr);
+    }
+
+    for (auto const &c : y_cuts) {
+      std::string expr =
+          y_res.binning_.getVariable() +
+          (c.direction == CutDirection::GreaterThan ? ">" : "<") +
+          std::to_string(c.threshold);
+      df = df.Filter(expr);
+    }
+
+    return df;
+  }
+
+  struct SampleData {
+    bool x_is_vec;
+    bool y_is_vec;
+    std::vector<double> ws;
+    std::vector<double> xs;
+    std::vector<double> ys;
+    std::vector<std::vector<double>> xs_vec;
+    std::vector<std::vector<double>> ys_vec;
+  };
+
+  static SampleData extractValues(ROOT::RDF::RNode df,
+                                  const VariableResult &x_res,
+                                  const VariableResult &y_res) {
+    SampleData data;
+
+    bool has_w = df.HasColumn("nominal_event_weight");
+    const auto &x_col = x_res.binning_.getVariable();
+    const auto &y_col = y_res.binning_.getVariable();
+
+    auto x_type = df.GetColumnType(x_col);
+    auto y_type = df.GetColumnType(y_col);
+    data.x_is_vec = x_type.find("vector") != std::string::npos ||
+                    x_type.find("RVec") != std::string::npos;
+    data.y_is_vec = y_type.find("vector") != std::string::npos ||
+                    y_type.find("RVec") != std::string::npos;
+
+    size_t n_events = df.Count().GetValue();
+    if (has_w) {
+      auto w_type = df.GetColumnType("nominal_event_weight");
+      if (w_type.find("float") != std::string::npos) {
+        auto wv = df.Take<float>("nominal_event_weight").GetValue();
+        data.ws.assign(wv.begin(), wv.end());
+      } else {
+        data.ws = df.Take<double>("nominal_event_weight").GetValue();
+      }
+    } else {
+      data.ws.assign(n_events, 1.0);
+    }
+
+    auto get_scalar = [&](const std::string &col, const std::string &type) {
+      std::vector<double> vals;
+      if (type.find("float") != std::string::npos) {
+        auto v = df.Take<float>(col).GetValue();
+        vals.assign(v.begin(), v.end());
+      } else if (type.find("int") != std::string::npos ||
+                 type.find("unsigned") != std::string::npos) {
+        auto v = df.Take<int>(col).GetValue();
+        vals.assign(v.begin(), v.end());
+      } else {
+        vals = df.Take<double>(col).GetValue();
+      }
+      return vals;
+    };
+
+    auto get_vector = [&](const std::string &col, const std::string &type) {
+      std::vector<std::vector<double>> vals;
+      if (type.find("float") != std::string::npos) {
+        auto v = df.Take<std::vector<float>>(col).GetValue();
+        for (auto &inner : v)
+          vals.emplace_back(inner.begin(), inner.end());
+      } else if (type.find("int") != std::string::npos ||
+                 type.find("unsigned") != std::string::npos) {
+        auto v = df.Take<std::vector<int>>(col).GetValue();
+        for (auto &inner : v)
+          vals.emplace_back(inner.begin(), inner.end());
+      } else {
+        vals = df.Take<std::vector<double>>(col).GetValue();
+      }
+      return vals;
+    };
+
+    if (!data.x_is_vec)
+      data.xs = get_scalar(x_col, x_type);
+    else
+      data.xs_vec = get_vector(x_col, x_type);
+
+    if (!data.y_is_vec)
+      data.ys = get_scalar(y_col, y_type);
+    else
+      data.ys_vec = get_vector(y_col, y_type);
+
+    return data;
+  }
+
+  static void fillHistogram(TH2F *hist, const SampleData &data) {
+    if (!data.x_is_vec && !data.y_is_vec) {
+      for (size_t i = 0; i < data.xs.size(); ++i)
+        hist->Fill(data.xs[i], data.ys[i], data.ws[i]);
+    } else if (data.x_is_vec && !data.y_is_vec) {
+      for (size_t i = 0; i < data.xs_vec.size(); ++i)
+        for (double xv : data.xs_vec[i])
+          hist->Fill(xv, data.ys[i], data.ws[i]);
+    } else if (!data.x_is_vec && data.y_is_vec) {
+      for (size_t i = 0; i < data.ys_vec.size(); ++i)
+        for (double yv : data.ys_vec[i])
+          hist->Fill(data.xs[i], yv, data.ws[i]);
+    } else {
+      for (size_t i = 0; i < data.xs_vec.size(); ++i) {
+        size_t lim = std::min(data.xs_vec[i].size(), data.ys_vec[i].size());
+        for (size_t j = 0; j < lim; ++j)
+          hist->Fill(data.xs_vec[i][j], data.ys_vec[i][j], data.ws[i]);
+      }
+    }
+  }
+
+  void draw(TCanvas &canvas) override {
+    canvas.cd();
+    const int stats_off = 0;
+    const int contour_count = 255;
+    const double margin = 0.15;
+    const double title_offset = 1.2;
+
+    gStyle->SetOptStat(stats_off);
+    gStyle->SetNumberContours(contour_count);
+
+    canvas.SetLogz();
+    canvas.SetLeftMargin(margin);
+    canvas.SetRightMargin(margin);
+
+    hist_->SetTitle("");
+    hist_->GetZaxis()->SetTitleOffset(title_offset);
+    hist_->Draw("COLZ");
+  }
+
+  TH2F *hist_;
 };
 
-}
+} // namespace analysis
 
 #endif

--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -1,7 +1,6 @@
 #ifndef PLOT_CATALOG_H
 #define PLOT_CATALOG_H
 
-#include <algorithm>
 #include <filesystem>
 #include <stdexcept>
 #include <string>
@@ -11,8 +10,8 @@
 #include "AnalysisDataLoader.h"
 #include "AnalysisResult.h"
 #include "HistogramCut.h"
+#include "IHistogramPlot.h"
 #include "MatrixPlot.h"
-#include "QuadTreeBinning2D.h"
 #include "Selection.h"
 #include "StackedHistogramPlot.h"
 #include "UnstackedHistogramPlot.h"
@@ -20,249 +19,96 @@
 namespace analysis {
 
 class PlotCatalog {
-  public:
-    PlotCatalog(AnalysisDataLoader &loader, int image_size, const std::string &output_directory = "./plots")
-        : loader_(loader), image_size_(image_size) {
-        auto p = std::filesystem::absolute(output_directory).lexically_normal();
-        std::filesystem::create_directories(p);
-        output_directory_ = p;
+public:
+  PlotCatalog(AnalysisDataLoader &loader, int image_size,
+              const std::string &output_directory = "./plots")
+      : loader_(loader), image_size_(image_size) {
+    auto p = std::filesystem::absolute(output_directory).lexically_normal();
+    std::filesystem::create_directories(p);
+    output_directory_ = p;
+  }
+
+  void generateStackedPlot(const AnalysisResult &res,
+                           const std::string &variable,
+                           const std::string &region,
+                           const std::string &category_column,
+                           bool overlay_signal = true,
+                           const std::vector<Cut> &cut_list = {},
+                           bool annotate_numbers = true) const {
+    const auto &result = this->fetchResult(res, variable, region);
+    std::string name =
+        "stacked_" + IHistogramPlot::sanitise(variable) + "_" +
+        IHistogramPlot::sanitise(region.empty() ? "default" : region) + "_" +
+        IHistogramPlot::sanitise(category_column);
+
+    const RegionAnalysis &region_info = res.region(RegionKey{region});
+
+    StackedHistogramPlot plot(std::move(name), result, region_info,
+                              category_column, output_directory_.string(),
+                              overlay_signal, cut_list, annotate_numbers);
+    plot.drawAndSave();
+  }
+
+  void generateUnstackedPlot(
+      const AnalysisResult &res, const std::string &variable,
+      const std::string &region, const std::string &category_column,
+      const std::vector<Cut> &cut_list = {}, bool annotate_numbers = true,
+      bool area_normalise = false, bool use_log_y = false,
+      const std::string &y_axis_label = "Events") const {
+    const auto &result = this->fetchResult(res, variable, region);
+    std::string name =
+        "unstacked_" + IHistogramPlot::sanitise(variable) + "_" +
+        IHistogramPlot::sanitise(region.empty() ? "default" : region) + "_" +
+        IHistogramPlot::sanitise(category_column);
+
+    const RegionAnalysis &region_info = res.region(RegionKey{region});
+
+    UnstackedHistogramPlot plot(std::move(name), result, region_info,
+                                category_column, output_directory_.string(),
+                                cut_list, annotate_numbers, use_log_y,
+                                y_axis_label, area_normalise);
+    plot.drawAndSave();
+  }
+
+  void generateMatrixPlot(const AnalysisResult &res,
+                          const std::string &x_variable,
+                          const std::string &y_variable,
+                          const std::string &region, const Selection &selection,
+                          const std::vector<Cut> &x_cuts = {},
+                          const std::vector<Cut> &y_cuts = {}) const {
+    const auto &x_res = this->fetchResult(res, x_variable, region);
+    const auto &y_res = this->fetchResult(res, y_variable, region);
+
+    std::string name =
+        "occupancy_matrix_" + IHistogramPlot::sanitise(x_variable) + "_vs_" +
+        IHistogramPlot::sanitise(y_variable) + "_" +
+        IHistogramPlot::sanitise(region.empty() ? "default" : region);
+
+    MatrixPlot plot(std::move(name), x_res, y_res, loader_, selection,
+                    output_directory_.string(), x_cuts, y_cuts);
+    plot.drawAndSave();
+  }
+
+private:
+  const VariableResult &fetchResult(const AnalysisResult &res,
+                                    const std::string &variable,
+                                    const std::string &region) const {
+    RegionKey rkey{region};
+    VariableKey vkey{variable};
+    if (res.hasResult(rkey, vkey)) {
+      return res.result(rkey, vkey);
     }
+    log::fatal("PlotCatalog::fetchResult",
+               "Missing analysis result for variable", variable, "in region",
+               region);
+    throw std::runtime_error("Missing analysis result for variable");
+  }
 
-    void generateStackedPlot(const AnalysisResult &res, const std::string &variable, const std::string &region,
-                             const std::string &category_column, bool overlay_signal = true,
-                             const std::vector<Cut> &cut_list = {}, bool annotate_numbers = true) const {
-        const auto &result = this->fetchResult(res, variable, region);
-        auto sanitise = [&](std::string s) {
-            for (auto &c : s)
-                if (c == '.' || c == '/' || c == ' ')
-                    c = '_';
-            return s;
-        };
-        std::string name = "stacked_" + sanitise(variable) + "_" + sanitise(region.empty() ? "default" : region) + "_" +
-                           sanitise(category_column);
-
-        const RegionAnalysis &region_info = res.region(RegionKey{region});
-
-        StackedHistogramPlot plot(std::move(name), result, region_info, category_column, output_directory_.string(),
-                                  overlay_signal, cut_list, annotate_numbers);
-        plot.drawAndSave();
-    }
-
-    void generateUnstackedPlot(const AnalysisResult &res, const std::string &variable, const std::string &region,
-                               const std::string &category_column, const std::vector<Cut> &cut_list = {},
-                               bool annotate_numbers = true, bool area_normalise = false, bool use_log_y = false,
-                               const std::string &y_axis_label = "Events") const {
-        const auto &result = this->fetchResult(res, variable, region);
-        auto sanitise = [&](std::string s) {
-            for (auto &c : s)
-                if (c == '.' || c == '/' || c == ' ')
-                    c = '_';
-            return s;
-        };
-        std::string name = "unstacked_" + sanitise(variable) + "_" + sanitise(region.empty() ? "default" : region) +
-                           "_" + sanitise(category_column);
-
-        const RegionAnalysis &region_info = res.region(RegionKey{region});
-
-        UnstackedHistogramPlot plot(std::move(name), result, region_info, category_column, output_directory_.string(),
-                                    cut_list, annotate_numbers, use_log_y, y_axis_label, area_normalise);
-        plot.drawAndSave();
-    }
-
-    void generateMatrixPlot(const AnalysisResult &res, const std::string &x_variable,
-                            const std::string &y_variable, const std::string &region,
-                            const Selection &selection, const std::vector<Cut> &x_cuts = {},
-                            const std::vector<Cut> &y_cuts = {}) const {
-        const auto &x_res = this->fetchResult(res, x_variable, region);
-        const auto &y_res = this->fetchResult(res, y_variable, region);
-
-        auto sanitise = [&](std::string s) {
-            for (auto &c : s)
-                if (c == '.' || c == '/' || c == ' ')
-                    c = '_';
-            return s;
-        };
-        std::string name = "occupancy_matrix_" + sanitise(x_variable) + "_vs_" + sanitise(y_variable) + "_" +
-                           sanitise(region.empty() ? "default" : region);
-
-        auto edges = this->determineEdges(x_res, y_res);
-
-        TH2F *hist = new TH2F(name.c_str(), name.c_str(), edges.first.size() - 1, edges.first.data(),
-                              edges.second.size() - 1, edges.second.data());
-        hist->GetXaxis()->SetTitle(x_res.binning_.getTexLabel().c_str());
-        hist->GetYaxis()->SetTitle(y_res.binning_.getTexLabel().c_str());
-
-        std::string filter = selection.str();
-
-        for (auto &kv : loader_.getSampleFrames()) {
-            auto df = kv.second.nominal_node_;
-            df = this->applySelectionFilters(df, x_res, y_res, filter, x_cuts, y_cuts);
-            auto data = this->extractValues(df, x_res, y_res);
-            this->fillHistogram(hist, data);
-        }
-
-        MatrixPlot plot(std::move(name), hist, output_directory_.string());
-        plot.drawAndSave();
-    }
-
-  private:
-    const VariableResult &fetchResult(const AnalysisResult &res, const std::string &variable,
-                                      const std::string &region) const {
-        RegionKey rkey{region};
-        VariableKey vkey{variable};
-        if (res.hasResult(rkey, vkey)) {
-            return res.result(rkey, vkey);
-        }
-        log::fatal("PlotCatalog::fetchResult", "Missing analysis result for variable", variable, "in region", region);
-        throw std::runtime_error("Missing analysis result for variable");
-    }
-
-    std::pair<std::vector<double>, std::vector<double>> determineEdges(const VariableResult &x_res,
-                                                                        const VariableResult &y_res) const {
-        auto x_edges = x_res.binning_.getEdges();
-        auto y_edges = y_res.binning_.getEdges();
-
-        std::vector<ROOT::RDF::RNode> mc_nodes;
-        for (auto &[key, sample] : loader_.getSampleFrames())
-            if (sample.isMc())
-                mc_nodes.emplace_back(sample.nominal_node_);
-        if (!mc_nodes.empty()) {
-            auto bins = QuadTreeBinning2D::calculate(mc_nodes, x_res.binning_, y_res.binning_);
-            x_edges = bins.first.getEdges();
-            y_edges = bins.second.getEdges();
-        }
-
-        return {x_edges, y_edges};
-    }
-
-    ROOT::RDF::RNode applySelectionFilters(ROOT::RDF::RNode df, const VariableResult &x_res,
-                                           const VariableResult &y_res, const std::string &filter,
-                                           const std::vector<Cut> &x_cuts, const std::vector<Cut> &y_cuts) const {
-        if (filter.find_first_not_of(" \t\n\r") != std::string::npos)
-            df = df.Filter(filter);
-
-        for (auto const &c : x_cuts) {
-            std::string expr = x_res.binning_.getVariable() +
-                               (c.direction == CutDirection::GreaterThan ? ">" : "<") +
-                               std::to_string(c.threshold);
-            df = df.Filter(expr);
-        }
-
-        for (auto const &c : y_cuts) {
-            std::string expr = y_res.binning_.getVariable() +
-                               (c.direction == CutDirection::GreaterThan ? ">" : "<") +
-                               std::to_string(c.threshold);
-            df = df.Filter(expr);
-        }
-
-        return df;
-    }
-
-    struct SampleData {
-        bool x_is_vec;
-        bool y_is_vec;
-        std::vector<double> ws;
-        std::vector<double> xs;
-        std::vector<double> ys;
-        std::vector<std::vector<double>> xs_vec;
-        std::vector<std::vector<double>> ys_vec;
-    };
-
-    SampleData extractValues(ROOT::RDF::RNode df, const VariableResult &x_res,
-                             const VariableResult &y_res) const {
-        SampleData data;
-
-        bool has_w = df.HasColumn("nominal_event_weight");
-        const auto &x_col = x_res.binning_.getVariable();
-        const auto &y_col = y_res.binning_.getVariable();
-
-        auto x_type = df.GetColumnType(x_col);
-        auto y_type = df.GetColumnType(y_col);
-        data.x_is_vec = x_type.find("vector") != std::string::npos || x_type.find("RVec") != std::string::npos;
-        data.y_is_vec = y_type.find("vector") != std::string::npos || y_type.find("RVec") != std::string::npos;
-
-        size_t n_events = df.Count().GetValue();
-        if (has_w) {
-            auto w_type = df.GetColumnType("nominal_event_weight");
-            if (w_type.find("float") != std::string::npos) {
-                auto wv = df.Take<float>("nominal_event_weight").GetValue();
-                data.ws.assign(wv.begin(), wv.end());
-            } else {
-                data.ws = df.Take<double>("nominal_event_weight").GetValue();
-            }
-        } else {
-            data.ws.assign(n_events, 1.0);
-        }
-
-        auto get_scalar = [&](const std::string &col, const std::string &type) {
-            std::vector<double> vals;
-            if (type.find("float") != std::string::npos) {
-                auto v = df.Take<float>(col).GetValue();
-                vals.assign(v.begin(), v.end());
-            } else if (type.find("int") != std::string::npos || type.find("unsigned") != std::string::npos) {
-                auto v = df.Take<int>(col).GetValue();
-                vals.assign(v.begin(), v.end());
-            } else {
-                vals = df.Take<double>(col).GetValue();
-            }
-            return vals;
-        };
-
-        auto get_vector = [&](const std::string &col, const std::string &type) {
-            std::vector<std::vector<double>> vals;
-            if (type.find("float") != std::string::npos) {
-                auto v = df.Take<std::vector<float>>(col).GetValue();
-                for (auto &inner : v)
-                    vals.emplace_back(inner.begin(), inner.end());
-            } else if (type.find("int") != std::string::npos || type.find("unsigned") != std::string::npos) {
-                auto v = df.Take<std::vector<int>>(col).GetValue();
-                for (auto &inner : v)
-                    vals.emplace_back(inner.begin(), inner.end());
-            } else {
-                vals = df.Take<std::vector<double>>(col).GetValue();
-            }
-            return vals;
-        };
-
-        if (!data.x_is_vec)
-            data.xs = get_scalar(x_col, x_type);
-        else
-            data.xs_vec = get_vector(x_col, x_type);
-
-        if (!data.y_is_vec)
-            data.ys = get_scalar(y_col, y_type);
-        else
-            data.ys_vec = get_vector(y_col, y_type);
-
-        return data;
-    }
-
-    void fillHistogram(TH2F *hist, const SampleData &data) const {
-        if (!data.x_is_vec && !data.y_is_vec) {
-            for (size_t i = 0; i < data.xs.size(); ++i)
-                hist->Fill(data.xs[i], data.ys[i], data.ws[i]);
-        } else if (data.x_is_vec && !data.y_is_vec) {
-            for (size_t i = 0; i < data.xs_vec.size(); ++i)
-                for (double xv : data.xs_vec[i])
-                    hist->Fill(xv, data.ys[i], data.ws[i]);
-        } else if (!data.x_is_vec && data.y_is_vec) {
-            for (size_t i = 0; i < data.ys_vec.size(); ++i)
-                for (double yv : data.ys_vec[i])
-                    hist->Fill(data.xs[i], yv, data.ws[i]);
-        } else {
-            for (size_t i = 0; i < data.xs_vec.size(); ++i) {
-                size_t lim = std::min(data.xs_vec[i].size(), data.ys_vec[i].size());
-                for (size_t j = 0; j < lim; ++j)
-                    hist->Fill(data.xs_vec[i][j], data.ys_vec[i][j], data.ws[i]);
-            }
-        }
-    }
-
-    AnalysisDataLoader &loader_;
-    int image_size_;
-    std::filesystem::path output_directory_;
+  AnalysisDataLoader &loader_;
+  int image_size_;
+  std::filesystem::path output_directory_;
 };
 
-}
+} // namespace analysis
 
 #endif


### PR DESCRIPTION
## Summary
- Move matrix plotting helpers from `PlotCatalog` to a richer `MatrixPlot` class
- Provide shared `IHistogramPlot::sanitise` utility for plot name generation
- Simplify `PlotCatalog` by delegating matrix plot creation and using new sanitise helper

## Testing
- `cmake ..` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc0e6a304832eba2d24746fa3ed8a