### PR TITLE
Refine plot plugin interface naming

### DIFF
--- a/docs/class_diagram.puml
+++ b/docs/class_diagram.puml
@@ -87,7 +87,7 @@ package plug #LightYellow {
   }
 
   interface IPlotPlugin {
-    +render()
+    +onPlot()
   }
 
   class PlotPluginManager {

--- a/libplug/IPlotPlugin.h
+++ b/libplug/IPlotPlugin.h
@@ -8,7 +8,7 @@ namespace analysis {
 class IPlotPlugin {
   public:
     virtual ~IPlotPlugin() = default;
-    virtual void run(const AnalysisResult &result) = 0;
+    virtual void onPlot(const AnalysisResult &result) = 0;
 };
 
 }

--- a/libplug/PlotPluginManager.h
+++ b/libplug/PlotPluginManager.h
@@ -63,9 +63,9 @@ class PlotPluginManager {
         }
     }
 
-    void run(const AnalysisResult &res) {
+    void notifyPlot(const AnalysisResult &res) {
         for (auto &pl : plugins_)
-            pl->run(res);
+            pl->onPlot(res);
     }
 
     ~PlotPluginManager() {

--- a/libplug/plot/CutFlowPlotPlugin.cc
+++ b/libplug/plot/CutFlowPlotPlugin.cc
@@ -29,7 +29,7 @@ class CutFlowPlotPlugin : public IPlotPlugin {
 
     explicit CutFlowPlotPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::runtime_error("CutFlowPlotPlugin missing plots");
+            throw std::onPlottime_error("CutFlowPlotPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.selection_rule = p.at("selection_rule").get<std::string>();
@@ -46,7 +46,7 @@ class CutFlowPlotPlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &res) override {
+    void onPlot(const AnalysisResult &res) override {
         StratifierRegistry strat_reg;
         for (const auto &pc : plots_) {
             auto signal_keys = this->fetchSignalKeys(strat_reg, pc.signal_group);
@@ -65,7 +65,7 @@ class CutFlowPlotPlugin : public IPlotPlugin {
                                          metrics.eff_errors, metrics.purities, metrics.pur_errors, pc.output_directory,
                                          pc.use_log_y);
             plot.drawAndSave("pdf");
-            log::info("CutFlowPlotPlugin::run", pc.output_directory + "/" + pc.plot_name + "_" + pc.region + ".pdf");
+            log::info("CutFlowPlotPlugin::onPlot", pc.output_directory + "/" + pc.plot_name + "_" + pc.region + ".pdf");
         }
     }
 
@@ -74,7 +74,7 @@ class CutFlowPlotPlugin : public IPlotPlugin {
         try {
             return strat_reg.getSignalKeys(group);
         } catch (const std::exception &e) {
-            log::error("CutFlowPlotPlugin::run", e.what());
+            log::error("CutFlowPlotPlugin::onPlot", e.what());
             return std::nullopt;
         }
     }

--- a/libplug/plot/EventDisplayPlugin.cc
+++ b/libplug/plot/EventDisplayPlugin.cc
@@ -30,7 +30,7 @@ class EventDisplayPlugin : public IPlotPlugin {
 
     explicit EventDisplayPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("event_displays") || !cfg.at("event_displays").is_array()) {
-            throw std::runtime_error("EventDisplayPlugin missing event_displays");
+            throw std::onPlottime_error("EventDisplayPlugin missing event_displays");
         }
         SelectionRegistry sel_reg;
         for (auto const &ed : cfg.at("event_displays")) {
@@ -52,9 +52,9 @@ class EventDisplayPlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &) override {
+    void onPlot(const AnalysisResult &) override {
         if (!loader_) {
-            log::error("EventDisplayPlugin::run", "No AnalysisDataLoader context provided");
+            log::error("EventDisplayPlugin::onPlot", "No AnalysisDataLoader context provided");
             return;
         }
         for (auto const &cfg : configs_) {

--- a/libplug/plot/FlashValidationPlugin.cc
+++ b/libplug/plot/FlashValidationPlugin.cc
@@ -30,7 +30,7 @@ class FlashValidationPlugin : public IPlotPlugin {
 
     explicit FlashValidationPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::runtime_error("FlashValidationPlugin missing plots");
+            throw std::onPlottime_error("FlashValidationPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.time_column = p.value("time_column", std::string("h_flash_time"));
@@ -47,9 +47,9 @@ class FlashValidationPlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &) override {
+    void onPlot(const AnalysisResult &) override {
         if (!loader_) {
-            log::error("FlashValidationPlugin::run", "No AnalysisDataLoader context provided");
+            log::error("FlashValidationPlugin::onPlot", "No AnalysisDataLoader context provided");
             return;
         }
 

--- a/libplug/plot/OccupancyMatrixPlugin.cc
+++ b/libplug/plot/OccupancyMatrixPlugin.cc
@@ -26,7 +26,7 @@ class OccupancyMatrixPlugin : public IPlotPlugin {
 
     explicit OccupancyMatrixPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("occupancy_matrix_plots") || !cfg.at("occupancy_matrix_plots").is_array())
-            throw std::runtime_error("OccupancyMatrixPlugin missing occupancy_matrix_plots");
+            throw std::onPlottime_error("OccupancyMatrixPlugin missing occupancy_matrix_plots");
         for (auto const &p : cfg.at("occupancy_matrix_plots")) {
             PlotConfig pc;
             pc.x_variable = p.at("x").get<std::string>();
@@ -51,9 +51,9 @@ class OccupancyMatrixPlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &result) override {
+    void onPlot(const AnalysisResult &result) override {
         if (!loader_) {
-            log::error("OccupancyMatrixPlugin::run", "No AnalysisDataLoader context provided");
+            log::error("OccupancyMatrixPlugin::onPlot", "No AnalysisDataLoader context provided");
             return;
         }
         for (auto const &pc : plots_) {
@@ -61,7 +61,7 @@ class OccupancyMatrixPlugin : public IPlotPlugin {
             VariableKey x_key{pc.x_variable};
             VariableKey y_key{pc.y_variable};
             if (!result.hasResult(rkey, x_key) || !result.hasResult(rkey, y_key)) {
-                log::error("OccupancyMatrixPlugin::run", "Missing variables for region", rkey.str());
+                log::error("OccupancyMatrixPlugin::onPlot", "Missing variables for region", rkey.str());
                 continue;
             }
             PlotCatalog catalog(*loader_, 800, pc.output_directory);

--- a/libplug/plot/RocCurvePlugin.cc
+++ b/libplug/plot/RocCurvePlugin.cc
@@ -34,7 +34,7 @@ class RocCurvePlugin : public IPlotPlugin {
 
     explicit RocCurvePlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("roc_curves") || !cfg.at("roc_curves").is_array()) {
-            throw std::runtime_error("RocCurvePlugin missing roc_curves");
+            throw std::onPlottime_error("RocCurvePlugin missing roc_curves");
         }
         for (auto const &p : cfg.at("roc_curves")) {
             PlotConfig pc;
@@ -56,9 +56,9 @@ class RocCurvePlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &) override {
+    void onPlot(const AnalysisResult &) override {
         if (!loader_) {
-            log::error("RocCurvePlugin::run", "No AnalysisDataLoader context provided");
+            log::error("RocCurvePlugin::onPlot", "No AnalysisDataLoader context provided");
             return;
         }
 
@@ -88,7 +88,7 @@ class RocCurvePlugin : public IPlotPlugin {
         try {
             signal_keys = strat_reg.getSignalKeys(pc.signal_group);
         } catch (const std::exception &e) {
-            log::error("RocCurvePlugin::run", e.what());
+            log::error("RocCurvePlugin::onPlot", e.what());
             return false;
         }
 

--- a/libplug/plot/RunPeriodNormalizationPlugin.cc
+++ b/libplug/plot/RunPeriodNormalizationPlugin.cc
@@ -25,7 +25,7 @@ class RunPeriodNormalizationPlugin : public IPlotPlugin {
 
     explicit RunPeriodNormalizationPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::runtime_error("RunPeriodNormalizationPlugin missing plots");
+            throw std::onPlottime_error("RunPeriodNormalizationPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.run_column = p.at("run_column").get<std::string>();
@@ -38,9 +38,9 @@ class RunPeriodNormalizationPlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &) override {
+    void onPlot(const AnalysisResult &) override {
         if (!loader_) {
-            log::error("RunPeriodNormalizationPlugin::run", "No AnalysisDataLoader context provided");
+            log::error("RunPeriodNormalizationPlugin::onPlot", "No AnalysisDataLoader context provided");
             return;
         }
         for (auto const &pc : plots_) {

--- a/libplug/plot/SlipStackingIntensityPlugin.cc
+++ b/libplug/plot/SlipStackingIntensityPlugin.cc
@@ -26,7 +26,7 @@ class SlipStackingIntensityPlugin : public IPlotPlugin {
 
     explicit SlipStackingIntensityPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::runtime_error("SlipStackingIntensityPlugin missing plots");
+            throw std::onPlottime_error("SlipStackingIntensityPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.run_column = p.at("run_column").get<std::string>();
@@ -39,9 +39,9 @@ class SlipStackingIntensityPlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &) override {
+    void onPlot(const AnalysisResult &) override {
         if (!loader_) {
-            log::error("SlipStackingIntensityPlugin::run", "No AnalysisDataLoader context provided");
+            log::error("SlipStackingIntensityPlugin::onPlot", "No AnalysisDataLoader context provided");
             return;
         }
         for (auto const &pc : plots_) {

--- a/libplug/plot/StackedHistogramPlugin.cc
+++ b/libplug/plot/StackedHistogramPlugin.cc
@@ -32,7 +32,7 @@ class StackedHistogramPlugin : public IPlotPlugin {
 
     explicit StackedHistogramPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::runtime_error("StackedHistogramPlugin missing plots");
+            throw std::onPlottime_error("StackedHistogramPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.variable = p.at("variable").get<std::string>();
@@ -58,13 +58,13 @@ class StackedHistogramPlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &result) override {
+    void onPlot(const AnalysisResult &result) override {
         gSystem->mkdir("plots", true);
         for (auto const &pc : plots_) {
             RegionKey rkey{pc.region};
             VariableKey vkey{pc.variable};
             if (!result.hasResult(rkey, vkey)) {
-                log::error("StackedHistogramPlugin::run", "Could not find variable", vkey.str(), "in region",
+                log::error("StackedHistogramPlugin::onPlot", "Could not find variable", vkey.str(), "in region",
                            rkey.str());
                 continue;
             }

--- a/libplug/plot/SystematicBreakdownPlugin.cc
+++ b/libplug/plot/SystematicBreakdownPlugin.cc
@@ -23,7 +23,7 @@ class SystematicBreakdownPlugin : public IPlotPlugin {
 
     explicit SystematicBreakdownPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::runtime_error("SystematicBreakdownPlugin missing plots");
+            throw std::onPlottime_error("SystematicBreakdownPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.variable = p.at("variable").get<std::string>();
@@ -34,13 +34,13 @@ class SystematicBreakdownPlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &result) override {
+    void onPlot(const AnalysisResult &result) override {
         gSystem->mkdir("plots", true);
         for (auto const &pc : plots_) {
             RegionKey rkey{pc.region};
             VariableKey vkey{pc.variable};
             if (!result.hasResult(rkey, vkey)) {
-                log::error("SystematicBreakdownPlugin::run", "Could not find variable", vkey.str(),
+                log::error("SystematicBreakdownPlugin::onPlot", "Could not find variable", vkey.str(),
                            "in region", rkey.str());
                 continue;
             }

--- a/libplug/plot/UnstackedHistogramPlugin.cc
+++ b/libplug/plot/UnstackedHistogramPlugin.cc
@@ -31,7 +31,7 @@ class UnstackedHistogramPlugin : public IPlotPlugin {
 
     explicit UnstackedHistogramPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::runtime_error("UnstackedHistogramPlugin missing plots");
+            throw std::onPlottime_error("UnstackedHistogramPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.variable = p.at("variable").get<std::string>();
@@ -54,13 +54,13 @@ class UnstackedHistogramPlugin : public IPlotPlugin {
         }
     }
 
-    void run(const AnalysisResult &result) override {
+    void onPlot(const AnalysisResult &result) override {
         gSystem->mkdir("plots", true);
         for (auto const &pc : plots_) {
             RegionKey rkey{pc.region};
             VariableKey vkey{pc.variable};
             if (!result.hasResult(rkey, vkey)) {
-                log::error("UnstackedHistogramPlugin::run", "Could not find variable", vkey.str(),
+                log::error("UnstackedHistogramPlugin::onPlot", "Could not find variable", vkey.str(),
                            "in region", rkey.str());
                 continue;
             }

--- a/plot.cpp
+++ b/plot.cpp
@@ -42,9 +42,9 @@ static int runPlotting(const nlohmann::json &samples, const nlohmann::json &plot
     for (auto &[beam, loader] : loaders) {
         analysis::PlotPluginManager manager;
         manager.loadPlugins(plotting, loader.get());
-        auto it = result_map.find(beam);
-        if (it != result_map.end())
-            manager.run(it->second);
+          auto it = result_map.find(beam);
+          if (it != result_map.end())
+              manager.notifyPlot(it->second);
     }
 
     analysis::log::info("plot::main", "Plotting routine terminated nominally.");


### PR DESCRIPTION
## Summary
- Rename `IPlotPlugin` hook `run` to `onPlot` for clearer behavior
- Adjust `PlotPluginManager` and call sites to use `notifyPlot`
- Update plot plugins and class diagram to reflect new naming

## Testing
- `bash .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bcc5771280832e85b4842cf6ca6613