### PR TITLE
Fix circular include in SelectionRegistry header

### DIFF
--- a/libapp/SelectionRegistry.h
+++ b/libapp/SelectionRegistry.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "AnalysisDefinition.h"
 #include "Selection.h"
 
 namespace analysis {


### PR DESCRIPTION
## Summary
- Remove unnecessary AnalysisDefinition include from SelectionRegistry to avoid circular dependency

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by ROOT)*


------
https://chatgpt.com/codex/tasks/task_e_68bcc5d65720832e9d412b317f77ae92