### PR TITLE
Remove unused sample processing hooks from analysis plugins

### DIFF
--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -65,10 +65,6 @@ class AnalysisRunner {
 
             analysis_regions[region_handle.key_] = std::move(region_analysis);
 
-            for (auto &[sample_key, _] : sample_processors) {
-                plugin_manager_.notifyPostSampleProcessing(sample_key, region_handle.key_, analysis_regions);
-            }
-
             log::info("AnalysisRunner::run", "Region protocol complete (", region_index, "/", region_count,
                       "):", region_handle.key_.str());
         }
@@ -110,8 +106,6 @@ class AnalysisRunner {
             if (accounted_runs.insert(run_config->label()).second) {
                 region_analysis.addProtonsOnTarget(run_config->nominal_pot);
             }
-            plugin_manager_.notifyPreSampleProcessing(sample_key, region_handle.key_, *run_config);
-
             log::info("AnalysisRunner::run", "--> Conditioning sample (", sample_index, "/", sample_total,
                       "):", sample_key.str());
 

--- a/libplug/AnalysisPluginManager.h
+++ b/libplug/AnalysisPluginManager.h
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <dlfcn.h>
-#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -22,8 +21,6 @@ namespace analysis {
 
 class AnalysisPluginManager {
   public:
-    using RegionAnalysisMap = std::map<RegionKey, RegionAnalysis>;
-
     void loadPlugins(const nlohmann::json &jobj, AnalysisDataLoader *loader = nullptr) {
         if (!jobj.contains("plugins"))
             return;
@@ -79,16 +76,6 @@ class AnalysisPluginManager {
     void notifyInitialisation(AnalysisDefinition &def, const SelectionRegistry &selec_reg) {
         for (auto &pl : plugins_)
             pl->onInitialisation(def, selec_reg);
-    }
-
-    void notifyPreSampleProcessing(const SampleKey &skey, const RegionKey &rkey, const RunConfig &run_config) {
-        for (auto &pl : plugins_)
-            pl->onPreSampleProcessing(skey, rkey, run_config);
-    }
-
-    void notifyPostSampleProcessing(const SampleKey &skey, const RegionKey &rkey, const RegionAnalysisMap &res) {
-        for (auto &pl : plugins_)
-            pl->onPostSampleProcessing(skey, rkey, res);
     }
 
     void notifyFinalisation(const AnalysisResult &res) {

--- a/libplug/IAnalysisPlugin.h
+++ b/libplug/IAnalysisPlugin.h
@@ -3,11 +3,8 @@
 
 #include <nlohmann/json.hpp>
 
-#include "AnalysisDataLoader.h"
 #include "AnalysisDefinition.h"
 #include "AnalysisResult.h"
-#include "AnalysisTypes.h"
-#include "RunConfig.h"
 #include "SelectionRegistry.h"
 
 namespace analysis {
@@ -17,12 +14,6 @@ class IAnalysisPlugin {
     virtual ~IAnalysisPlugin() = default;
 
     virtual void onInitialisation(AnalysisDefinition &def, const SelectionRegistry &sel_reg) = 0;
-
-    virtual void onPreSampleProcessing(const SampleKey &sample_key, const RegionKey &region_key,
-                                       const RunConfig &run_config) = 0;
-
-    virtual void onPostSampleProcessing(const SampleKey &sample_key, const RegionKey &region_key,
-                                        const RegionAnalysisMap &results) = 0;
 
     virtual void onFinalisation(const AnalysisResult &results) = 0;
 };

--- a/libplug/analysis/RegionsPlugin.cc
+++ b/libplug/analysis/RegionsPlugin.cc
@@ -36,8 +36,6 @@ class RegionsPlugin : public IAnalysisPlugin {
             }
         }
     }
-    void onPreSampleProcessing(const SampleKey &, const RegionKey &, const RunConfig &) override {}
-    void onPostSampleProcessing(const SampleKey &, const RegionKey &, const RegionAnalysisMap &) override {}
     void onFinalisation(const AnalysisResult &) override {}
 
   private:

--- a/libplug/analysis/SnapshotPlugin.cc
+++ b/libplug/analysis/SnapshotPlugin.cc
@@ -45,9 +45,6 @@ class SnapshotPlugin : public IAnalysisPlugin {
         }
     }
 
-    void onPreSampleProcessing(const SampleKey &, const RegionKey &, const RunConfig &) override {}
-    void onPostSampleProcessing(const SampleKey &, const RegionKey &, const RegionAnalysisMap &) override {}
-
     void onFinalisation(const AnalysisResult &) override {
         if (!loader_) {
             log::error("SnapshotPlugin::onFinalisation", "No AnalysisDataLoader context provided");

--- a/libplug/analysis/VariablesPlugin.cc
+++ b/libplug/analysis/VariablesPlugin.cc
@@ -77,8 +77,6 @@ class VariablesPlugin : public IAnalysisPlugin {
         }
     }
 
-    void onPreSampleProcessing(const SampleKey &, const RegionKey &, const RunConfig &) override {}
-    void onPostSampleProcessing(const SampleKey &, const RegionKey &, const RegionAnalysisMap &) override {}
     void onFinalisation(const AnalysisResult &) override {}
 
   private:


### PR DESCRIPTION
## Summary
- Drop unused pre/post sample processing callbacks from plugin interface
- Clean up plugin manager and runner after removing these hooks
- Trim empty overrides in plugin implementations

## Testing
- `cmake ..` *(fails: Could not find ROOTConfig.cmake)*
- `ctest --output-on-failure` *(no tests run due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc58dde64832e8ee2ba0c370122ca