### PR TITLE
Remove duplicate EventDisplayPlugin target

### DIFF
--- a/libplug/CMakeLists.txt
+++ b/libplug/CMakeLists.txt
@@ -36,7 +36,6 @@ function(add_plugin NAME SRC EXTRA_LIBS)
 endfunction()
 
 # Analysis plugins
-add_plugin(EventDisplayPlugin analysis/EventDisplayPlugin.cc "")
 add_plugin(RegionsPlugin analysis/RegionsPlugin.cc "")
 add_plugin(SnapshotPlugin analysis/SnapshotPlugin.cc "")
 add_plugin(VariablesPlugin analysis/VariablesPlugin.cc "")


### PR DESCRIPTION
## Summary
- eliminate duplicate EventDisplayPlugin entry in libplug CMake lists

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*
- `ctest --test-dir build --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc6882a0c832eb0f0d191f1803ae4