### PR TITLE
Fix std::onPlottime_error typo in plot plugins

### DIFF
--- a/libplug/plot/CutFlowPlotPlugin.cc
+++ b/libplug/plot/CutFlowPlotPlugin.cc
@@ -29,7 +29,7 @@ class CutFlowPlotPlugin : public IPlotPlugin {
 
     explicit CutFlowPlotPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("CutFlowPlotPlugin missing plots");
+            throw std::runtime_error("CutFlowPlotPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.selection_rule = p.at("selection_rule").get<std::string>();

--- a/libplug/plot/EventDisplayPlugin.cc
+++ b/libplug/plot/EventDisplayPlugin.cc
@@ -30,7 +30,7 @@ class EventDisplayPlugin : public IPlotPlugin {
 
     explicit EventDisplayPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("event_displays") || !cfg.at("event_displays").is_array()) {
-            throw std::onPlottime_error("EventDisplayPlugin missing event_displays");
+            throw std::runtime_error("EventDisplayPlugin missing event_displays");
         }
         SelectionRegistry sel_reg;
         for (auto const &ed : cfg.at("event_displays")) {

--- a/libplug/plot/FlashValidationPlugin.cc
+++ b/libplug/plot/FlashValidationPlugin.cc
@@ -30,7 +30,7 @@ class FlashValidationPlugin : public IPlotPlugin {
 
     explicit FlashValidationPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("FlashValidationPlugin missing plots");
+            throw std::runtime_error("FlashValidationPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.time_column = p.value("time_column", std::string("h_flash_time"));

--- a/libplug/plot/OccupancyMatrixPlugin.cc
+++ b/libplug/plot/OccupancyMatrixPlugin.cc
@@ -26,7 +26,7 @@ class OccupancyMatrixPlugin : public IPlotPlugin {
 
     explicit OccupancyMatrixPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("occupancy_matrix_plots") || !cfg.at("occupancy_matrix_plots").is_array())
-            throw std::onPlottime_error("OccupancyMatrixPlugin missing occupancy_matrix_plots");
+            throw std::runtime_error("OccupancyMatrixPlugin missing occupancy_matrix_plots");
         for (auto const &p : cfg.at("occupancy_matrix_plots")) {
             PlotConfig pc;
             pc.x_variable = p.at("x").get<std::string>();

--- a/libplug/plot/RocCurvePlugin.cc
+++ b/libplug/plot/RocCurvePlugin.cc
@@ -34,7 +34,7 @@ class RocCurvePlugin : public IPlotPlugin {
 
     explicit RocCurvePlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("roc_curves") || !cfg.at("roc_curves").is_array()) {
-            throw std::onPlottime_error("RocCurvePlugin missing roc_curves");
+            throw std::runtime_error("RocCurvePlugin missing roc_curves");
         }
         for (auto const &p : cfg.at("roc_curves")) {
             PlotConfig pc;

--- a/libplug/plot/RunPeriodNormalizationPlugin.cc
+++ b/libplug/plot/RunPeriodNormalizationPlugin.cc
@@ -21,7 +21,7 @@ class RunPeriodNormalizationPlugin : public IPlotPlugin {
 
     explicit RunPeriodNormalizationPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("RunPeriodNormalizationPlugin missing plots");
+            throw std::runtime_error("RunPeriodNormalizationPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.run_column = p.at("run_column").get<std::string>();

--- a/libplug/plot/SlipStackingIntensityPlugin.cc
+++ b/libplug/plot/SlipStackingIntensityPlugin.cc
@@ -21,7 +21,7 @@ class SlipStackingIntensityPlugin : public IPlotPlugin {
 
     explicit SlipStackingIntensityPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("SlipStackingIntensityPlugin missing plots");
+            throw std::runtime_error("SlipStackingIntensityPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.run_column = p.at("run_column").get<std::string>();

--- a/libplug/plot/StackedHistogramPlugin.cc
+++ b/libplug/plot/StackedHistogramPlugin.cc
@@ -32,7 +32,7 @@ class StackedHistogramPlugin : public IPlotPlugin {
 
     explicit StackedHistogramPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("StackedHistogramPlugin missing plots");
+            throw std::runtime_error("StackedHistogramPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.variable = p.at("variable").get<std::string>();

--- a/libplug/plot/SystematicBreakdownPlugin.cc
+++ b/libplug/plot/SystematicBreakdownPlugin.cc
@@ -23,7 +23,7 @@ class SystematicBreakdownPlugin : public IPlotPlugin {
 
     explicit SystematicBreakdownPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("SystematicBreakdownPlugin missing plots");
+            throw std::runtime_error("SystematicBreakdownPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.variable = p.at("variable").get<std::string>();

--- a/libplug/plot/UnstackedHistogramPlugin.cc
+++ b/libplug/plot/UnstackedHistogramPlugin.cc
@@ -31,7 +31,7 @@ class UnstackedHistogramPlugin : public IPlotPlugin {
 
     explicit UnstackedHistogramPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("UnstackedHistogramPlugin missing plots");
+            throw std::runtime_error("UnstackedHistogramPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.variable = p.at("variable").get<std::string>();


### PR DESCRIPTION
## Summary
- Replace erroneous `std::onPlottime_error` with `std::runtime_error` in plot plugins

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT"; add the installation prefix of "ROOT" to CMAKE_PREFIX_PATH or set "ROOT_DIR")*


------
https://chatgpt.com/codex/tasks/task_e_68bcc81b2c8c832e9af140c000b24d04