### PR TITLE
Replace invalid exception in plot plugins

### DIFF
--- a/libplug/plot/CutFlowPlotPlugin.cc
+++ b/libplug/plot/CutFlowPlotPlugin.cc
@@ -29,7 +29,7 @@ class CutFlowPlotPlugin : public IPlotPlugin {
 
     explicit CutFlowPlotPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("CutFlowPlotPlugin missing plots");
+            throw std::runtime_error("CutFlowPlotPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.selection_rule = p.at("selection_rule").get<std::string>();

--- a/libplug/plot/CutMatrixPlotPlugin.cc
+++ b/libplug/plot/CutMatrixPlotPlugin.cc
@@ -26,7 +26,7 @@ class CutMatrixPlotPlugin : public IPlotPlugin {
 
     explicit CutMatrixPlotPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("cut_matrix_plots") || !cfg.at("cut_matrix_plots").is_array())
-            throw std::onPlottime_error("CutMatrixPlotPlugin missing cut_matrix_plots");
+            throw std::runtime_error("CutMatrixPlotPlugin missing cut_matrix_plots");
         for (auto const &p : cfg.at("cut_matrix_plots")) {
             PlotConfig pc;
             pc.x_variable = p.at("x").get<std::string>();

--- a/libplug/plot/EventDisplayPlugin.cc
+++ b/libplug/plot/EventDisplayPlugin.cc
@@ -30,7 +30,7 @@ class EventDisplayPlugin : public IPlotPlugin {
 
     explicit EventDisplayPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("event_displays") || !cfg.at("event_displays").is_array()) {
-            throw std::onPlottime_error("EventDisplayPlugin missing event_displays");
+            throw std::runtime_error("EventDisplayPlugin missing event_displays");
         }
         SelectionRegistry sel_reg;
         for (auto const &ed : cfg.at("event_displays")) {

--- a/libplug/plot/RocCurvePlugin.cc
+++ b/libplug/plot/RocCurvePlugin.cc
@@ -34,7 +34,7 @@ class RocCurvePlugin : public IPlotPlugin {
 
     explicit RocCurvePlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("roc_curves") || !cfg.at("roc_curves").is_array()) {
-            throw std::onPlottime_error("RocCurvePlugin missing roc_curves");
+            throw std::runtime_error("RocCurvePlugin missing roc_curves");
         }
         for (auto const &p : cfg.at("roc_curves")) {
             PlotConfig pc;

--- a/libplug/plot/SlipStackingIntensityPlugin.cc
+++ b/libplug/plot/SlipStackingIntensityPlugin.cc
@@ -1,4 +1,5 @@
 #include <nlohmann/json.hpp>
+#include <stdexcept>
 #include <string>
 
 #include "AnalysisDataLoader.h"
@@ -21,7 +22,7 @@ class SlipStackingIntensityPlugin : public IPlotPlugin {
 
     explicit SlipStackingIntensityPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("SlipStackingIntensityPlugin missing plots");
+            throw std::runtime_error("SlipStackingIntensityPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.run_column = p.at("run_column").get<std::string>();

--- a/libplug/plot/StackedHistogramPlugin.cc
+++ b/libplug/plot/StackedHistogramPlugin.cc
@@ -32,7 +32,7 @@ class StackedHistogramPlugin : public IPlotPlugin {
 
     explicit StackedHistogramPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("StackedHistogramPlugin missing plots");
+            throw std::runtime_error("StackedHistogramPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.variable = p.at("variable").get<std::string>();

--- a/libplug/plot/SystematicBreakdownPlugin.cc
+++ b/libplug/plot/SystematicBreakdownPlugin.cc
@@ -23,7 +23,7 @@ class SystematicBreakdownPlugin : public IPlotPlugin {
 
     explicit SystematicBreakdownPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("SystematicBreakdownPlugin missing plots");
+            throw std::runtime_error("SystematicBreakdownPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.variable = p.at("variable").get<std::string>();

--- a/libplug/plot/UnstackedHistogramPlugin.cc
+++ b/libplug/plot/UnstackedHistogramPlugin.cc
@@ -31,7 +31,7 @@ class UnstackedHistogramPlugin : public IPlotPlugin {
 
     explicit UnstackedHistogramPlugin(const nlohmann::json &cfg) {
         if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::onPlottime_error("UnstackedHistogramPlugin missing plots");
+            throw std::runtime_error("UnstackedHistogramPlugin missing plots");
         for (auto const &p : cfg.at("plots")) {
             PlotConfig pc;
             pc.variable = p.at("variable").get<std::string>();


### PR DESCRIPTION
## Summary
- replace `std::onPlottime_error` with standard `std::runtime_error` across plot plugins
- include `<stdexcept>` where needed to resolve compilation errors

## Testing
- `bash .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bcc9751ea0832eb4ca63d981cdc02a