### PR TITLE
Rename AnalysisLogger to Logger

### DIFF
--- a/analyse.cpp
+++ b/analyse.cpp
@@ -7,7 +7,7 @@
 #include <nlohmann/json.hpp>
 
 #include "AnalysisDataLoader.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "AnalysisRunner.h"
 #include "HistogramFactory.h"
 #include "JsonUtils.h"
@@ -62,7 +62,7 @@ static analysis::AnalysisResult runAnalysis(const nlohmann::json &samples, const
 }
 
 int main(int argc, char *argv[]) {
-    analysis::AnalysisLogger::getInstance().setLevel(analysis::LogLevel::DEBUG);
+    analysis::Logger::getInstance().setLevel(analysis::LogLevel::DEBUG);
 
     if (argc != 4) {
         analysis::log::fatal("analyse::main", "Invocation error. Expected:", argv[0], "<samples.json> <plugins.json> <output.root>");

--- a/libapp/AnalysisDefinition.h
+++ b/libapp/AnalysisDefinition.h
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "AnalysisDataLoader.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BinningDefinition.h"
 #include "DynamicBinning.h"
 #include "AnalysisKey.h"

--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -15,7 +15,7 @@
 
 #include "AnalysisDataLoader.h"
 #include "AnalysisDefinition.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "AnalysisPluginManager.h"
 #include "AnalysisResult.h"
 #include "VariableResult.h"

--- a/libapp/HistogramUncertainty.h
+++ b/libapp/HistogramUncertainty.h
@@ -8,7 +8,7 @@
 #include "TMatrixDSym.h"
 #include <Eigen/Dense>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BinningDefinition.h"
 
 namespace analysis {

--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -1,7 +1,7 @@
 #ifndef MC_PROCESSOR_H
 #define MC_PROCESSOR_H
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BinnedHistogram.h"
 #include "ISampleProcessor.h"
 #include <unordered_map>

--- a/libdata/AnalysisDataLoader.h
+++ b/libdata/AnalysisDataLoader.h
@@ -9,7 +9,7 @@
 
 #include "ROOT/RDataFrame.hxx"
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BlipProcessor.h"
 #include "IEventProcessor.h"
 #include "AnalysisKey.h"

--- a/libdata/RunConfig.h
+++ b/libdata/RunConfig.h
@@ -7,7 +7,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "SampleDefinition.h"
 
 namespace analysis {

--- a/libdata/RunConfigLoader.h
+++ b/libdata/RunConfigLoader.h
@@ -6,7 +6,7 @@
 
 #include "nlohmann/json.hpp"
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "RunConfig.h"
 #include "RunConfigRegistry.h"
 

--- a/libdata/SampleDefinition.h
+++ b/libdata/SampleDefinition.h
@@ -9,7 +9,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "nlohmann/json.hpp"
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IEventProcessor.h"
 #include "SampleTypes.h"
 #include "VariableRegistry.h"

--- a/libdata/WeightProcessor.h
+++ b/libdata/WeightProcessor.h
@@ -5,7 +5,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IEventProcessor.h"
 #include "SampleTypes.h"
 

--- a/libhist/BinningDefinition.h
+++ b/libhist/BinningDefinition.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "AnalysisKey.h"
 
 namespace analysis {

--- a/libhist/HistogramFactory.h
+++ b/libhist/HistogramFactory.h
@@ -1,7 +1,7 @@
 #ifndef HISTOGRAM_FACTORY_H
 #define HISTOGRAM_FACTORY_H
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "SampleDataset.h"
 #include "StratifierManager.h"
 #include "StratifierRegistry.h"

--- a/libhist/IHistogramStratifier.h
+++ b/libhist/IHistogramStratifier.h
@@ -11,7 +11,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "TH1D.h"
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BinnedHistogram.h"
 #include "BinningDefinition.h"
 #include "AnalysisKey.h"

--- a/libhist/StratifierManager.h
+++ b/libhist/StratifierManager.h
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <utility>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IHistogramStratifier.h"
 #include "AnalysisKey.h"
 #include "StratifierRegistry.h"

--- a/libhist/StratifierRegistry.h
+++ b/libhist/StratifierRegistry.h
@@ -14,7 +14,7 @@
 #include "RtypesCore.h"
 #include "TColor.h"
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "AnalysisKey.h"
 
 namespace analysis {

--- a/libplot/IEventDisplay.h
+++ b/libplot/IEventDisplay.h
@@ -1,7 +1,7 @@
 #ifndef IEVENTDISPLAY_H
 #define IEVENTDISPLAY_H
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "TCanvas.h"
 #include "TSystem.h"
 #include <string>

--- a/libplug/AnalysisPluginManager.h
+++ b/libplug/AnalysisPluginManager.h
@@ -11,7 +11,7 @@
 #include <nlohmann/json.hpp>
 
 #include "AnalysisDataLoader.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 
 #include "AnalysisResult.h"
 #include "IAnalysisPlugin.h"

--- a/libplug/PlotPluginManager.h
+++ b/libplug/PlotPluginManager.h
@@ -12,7 +12,7 @@
 #include <nlohmann/json.hpp>
 
 #include "AnalysisDataLoader.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IPlotPlugin.h"
 #include "PluginConfigValidator.h"
 

--- a/libplug/analysis/RegionsPlugin.cc
+++ b/libplug/analysis/RegionsPlugin.cc
@@ -1,7 +1,7 @@
 #include <nlohmann/json.hpp>
 
 #include "AnalysisDefinition.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IAnalysisPlugin.h"
 
 namespace analysis {

--- a/libplug/analysis/SnapshotPlugin.cc
+++ b/libplug/analysis/SnapshotPlugin.cc
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "AnalysisDataLoader.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IAnalysisPlugin.h"
 #include "SelectionQuery.h"
 

--- a/libplug/analysis/VariablesPlugin.cc
+++ b/libplug/analysis/VariablesPlugin.cc
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "AnalysisDefinition.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BinningDefinition.h"
 #include "DynamicBinning.h"
 #include "IAnalysisPlugin.h"

--- a/libplug/plot/CutFlowPlotPlugin.cc
+++ b/libplug/plot/CutFlowPlotPlugin.cc
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IPlotPlugin.h"
 #include "SelectionEfficiencyPlot.h"
 #include "StratifierRegistry.h"

--- a/libplug/plot/CutMatrixPlotPlugin.cc
+++ b/libplug/plot/CutMatrixPlotPlugin.cc
@@ -4,7 +4,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "HistogramCut.h"
 #include "IPlotPlugin.h"
 #include "PlotCatalog.h"

--- a/libplug/plot/EventDisplayPlugin.cc
+++ b/libplug/plot/EventDisplayPlugin.cc
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "AnalysisDataLoader.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IPlotPlugin.h"
 #include "DetectorDisplay.h"
 #include "SemanticDisplay.h"

--- a/libplug/plot/RocCurvePlugin.cc
+++ b/libplug/plot/RocCurvePlugin.cc
@@ -5,7 +5,7 @@
 #include <utility>
 
 #include "AnalysisDataLoader.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "HistogramCut.h"
 #include "IPlotPlugin.h"
 #include "RocCurvePlot.h"

--- a/libplug/plot/SlipStackingIntensityPlugin.cc
+++ b/libplug/plot/SlipStackingIntensityPlugin.cc
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "AnalysisDataLoader.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IPlotPlugin.h"
 #include "SlipStackingIntensityPlot.h"
 

--- a/libplug/plot/StackedHistogramPlugin.cc
+++ b/libplug/plot/StackedHistogramPlugin.cc
@@ -6,7 +6,7 @@
 
 #include <TSystem.h>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IPlotPlugin.h"
 #include "StackedHistogramPlot.h"
 

--- a/libplug/plot/SystematicBreakdownPlugin.cc
+++ b/libplug/plot/SystematicBreakdownPlugin.cc
@@ -6,7 +6,7 @@
 
 #include <TSystem.h>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IPlotPlugin.h"
 #include "SystematicBreakdownPlot.h"
 

--- a/libplug/plot/UnstackedHistogramPlugin.cc
+++ b/libplug/plot/UnstackedHistogramPlugin.cc
@@ -8,7 +8,7 @@
 
 #include <TSystem.h>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "IPlotPlugin.h"
 #include "UnstackedHistogramPlot.h"
 

--- a/libsyst/DetectorSystematicStrategy.h
+++ b/libsyst/DetectorSystematicStrategy.h
@@ -1,7 +1,7 @@
 #ifndef DETECTOR_SYSTEMATIC_STRATEGY_H
 #define DETECTOR_SYSTEMATIC_STRATEGY_H
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BinnedHistogram.h"
 #include "SystematicStrategy.h"
 #include <cmath>

--- a/libsyst/SystematicsProcessor.h
+++ b/libsyst/SystematicsProcessor.h
@@ -10,7 +10,7 @@
 
 #include <TMatrixDSym.h>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BinnedHistogram.h"
 #include "DetectorSystematicStrategy.h"
 #include "SystematicStrategy.h"

--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -7,7 +7,7 @@
 
 #include <TMatrixDSym.h>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BinnedHistogram.h"
 #include "SystematicStrategy.h"
 

--- a/libutils/DynamicBinning.h
+++ b/libutils/DynamicBinning.h
@@ -13,7 +13,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "ROOT/RVec.hxx"
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "BayesianBlocks.h"
 #include "BinningDefinition.h"
 

--- a/libutils/JsonUtils.h
+++ b/libutils/JsonUtils.h
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <string>
 
-#include "AnalysisLogger.h"
+#include "Logger.h"
 
 namespace analysis {
 

--- a/libutils/Logger.h
+++ b/libutils/Logger.h
@@ -1,5 +1,5 @@
-#ifndef ANALYSIS_LOGGER_H
-#define ANALYSIS_LOGGER_H
+#ifndef LOGGER_H
+#define LOGGER_H
 
 #include <chrono>
 #include <cstdlib>
@@ -12,10 +12,10 @@ namespace analysis {
 
 enum class LogLevel { DEBUG, INFO, WARN, ERROR, FATAL };
 
-class AnalysisLogger {
+class Logger {
   public:
-    static AnalysisLogger &getInstance() {
-        static AnalysisLogger instance;
+    static Logger &getInstance() {
+        static Logger instance;
         return instance;
     }
 
@@ -43,10 +43,10 @@ class AnalysisLogger {
     }
 
   private:
-    AnalysisLogger() = default;
-    ~AnalysisLogger() = default;
-    AnalysisLogger(const AnalysisLogger &) = delete;
-    AnalysisLogger &operator=(const AnalysisLogger &) = delete;
+    Logger() = default;
+    ~Logger() = default;
+    Logger(const Logger &) = delete;
+    Logger &operator=(const Logger &) = delete;
 
     template <typename T, typename... Args>
     void printArgs(std::ostream &os, const T &first, const Args &...rest) const {
@@ -116,19 +116,19 @@ class AnalysisLogger {
 
 namespace log {
 template <typename... Args> inline void debug(const std::string &ctx, const Args &...args) {
-    AnalysisLogger::getInstance().debug(ctx, args...);
+    Logger::getInstance().debug(ctx, args...);
 }
 template <typename... Args> inline void info(const std::string &ctx, const Args &...args) {
-    AnalysisLogger::getInstance().info(ctx, args...);
+    Logger::getInstance().info(ctx, args...);
 }
 template <typename... Args> inline void warn(const std::string &ctx, const Args &...args) {
-    AnalysisLogger::getInstance().warn(ctx, args...);
+    Logger::getInstance().warn(ctx, args...);
 }
 template <typename... Args> inline void error(const std::string &ctx, const Args &...args) {
-    AnalysisLogger::getInstance().error(ctx, args...);
+    Logger::getInstance().error(ctx, args...);
 }
 template <typename... Args> inline void fatal(const std::string &ctx, const Args &...args) {
-    AnalysisLogger::getInstance().fatal(ctx, args...);
+    Logger::getInstance().fatal(ctx, args...);
 }
 } // namespace log
 

--- a/plot.cpp
+++ b/plot.cpp
@@ -6,7 +6,7 @@
 #include <nlohmann/json.hpp>
 
 #include "AnalysisDataLoader.h"
-#include "AnalysisLogger.h"
+#include "Logger.h"
 #include "AnalysisResult.h"
 #include "JsonUtils.h"
 #include "PlotPluginManager.h"
@@ -52,7 +52,7 @@ static int runPlotting(const nlohmann::json &samples, const nlohmann::json &plot
 }
 
 int main(int argc, char *argv[]) {
-    analysis::AnalysisLogger::getInstance().setLevel(analysis::LogLevel::DEBUG);
+    analysis::Logger::getInstance().setLevel(analysis::LogLevel::DEBUG);
 
     if (argc != 4) {
         analysis::log::fatal("plot::main", "Invocation error. Expected:", argv[0], "<samples.json> <plugins.json> <input.root>");


### PR DESCRIPTION
## Summary
- Rename `AnalysisLogger` to `Logger` for clearer terminology
- Update includes and references across the codebase

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT"*

------
https://chatgpt.com/codex/tasks/task_e_68bccd087478832eb38603c3992b65f6