### PR TITLE
refactor: make stratifiers header-only

### DIFF
--- a/libhist/CMakeLists.txt
+++ b/libhist/CMakeLists.txt
@@ -1,13 +1,13 @@
-add_library(libhist ScalarStratifier.cpp VectorStratifier.cpp)
+add_library(libhist INTERFACE)
 
 target_include_directories(libhist
-  PUBLIC
+  INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 
 target_link_libraries(libhist
-  PUBLIC
+  INTERFACE
     libutils
     libdata
     nlohmann_json::nlohmann_json

--- a/libhist/ScalarStratifier.h
+++ b/libhist/ScalarStratifier.h
@@ -1,3 +1,6 @@
+#ifndef SCALAR_STRATIFIER_H
+#define SCALAR_STRATIFIER_H
+
 #include "IHistogramStratifier.h"
 #include "AnalysisKey.h"
 #include "StratifierRegistry.h"
@@ -13,28 +16,27 @@ class ScalarStratifier : public IHistogramStratifier {
         : stratifier_key_(key), stratifier_registry_(registry) {}
 
   protected:
-    ROOT::RDF::RNode defineFilterColumn(ROOT::RDF::RNode dataframe, int key, const std::string &new_column_name) const override {
+    ROOT::RDF::RNode defineFilterColumn(ROOT::RDF::RNode dataframe, int key,
+                                        const std::string &new_column_name) const override {
         std::string filter_expression = this->getSchemeName() + " == " + std::to_string(key);
 
         return dataframe.Define(new_column_name, filter_expression);
     }
 
-    const std::string &getSchemeName() const override {
-        return stratifier_key_.str();
-    }
+    const std::string &getSchemeName() const override { return stratifier_key_.str(); }
 
-    const StratifierRegistry &getRegistry() const override {
-        return stratifier_registry_;
-    }
+    const StratifierRegistry &getRegistry() const override { return stratifier_registry_; }
 
   private:
     StratifierKey stratifier_key_;
     StratifierRegistry &stratifier_registry_;
 };
 
-std::unique_ptr<IHistogramStratifier> makeScalarStratifier(const StratifierKey &key, StratifierRegistry &registry) {
+inline std::unique_ptr<IHistogramStratifier> makeScalarStratifier(const StratifierKey &key,
+                                                                  StratifierRegistry &registry) {
     return std::make_unique<ScalarStratifier>(key, registry);
 }
 
-}
+} // namespace analysis
 
+#endif

--- a/libhist/StratifierManager.h
+++ b/libhist/StratifierManager.h
@@ -10,11 +10,10 @@
 #include "IHistogramStratifier.h"
 #include "AnalysisKey.h"
 #include "StratifierRegistry.h"
+#include "ScalarStratifier.h"
+#include "VectorStratifier.h"
 
 namespace analysis {
-
-std::unique_ptr<IHistogramStratifier> makeScalarStratifier(const StratifierKey &key, StratifierRegistry &registry);
-std::unique_ptr<IHistogramStratifier> makeVectorStratifier(const StratifierKey &key, StratifierRegistry &registry);
 
 class StratifierManager {
   public:

--- a/libhist/VectorStratifier.h
+++ b/libhist/VectorStratifier.h
@@ -1,3 +1,6 @@
+#ifndef VECTOR_STRATIFIER_H
+#define VECTOR_STRATIFIER_H
+
 #include "IHistogramStratifier.h"
 #include "AnalysisKey.h"
 #include "ROOT/RVec.hxx"
@@ -13,10 +16,12 @@ namespace analysis {
 
 class VectorStratifier : public IHistogramStratifier {
   public:
-    VectorStratifier(const StratifierKey &key, StratifierRegistry &registry) : strat_key_(key), strat_registry_(registry) {}
+    VectorStratifier(const StratifierKey &key, StratifierRegistry &registry)
+        : strat_key_(key), strat_registry_(registry) {}
 
   protected:
-    ROOT::RDF::RNode defineFilterColumn(ROOT::RDF::RNode dataframe, int key, const std::string &new_column_name) const override {
+    ROOT::RDF::RNode defineFilterColumn(ROOT::RDF::RNode dataframe, int key,
+                                        const std::string &new_column_name) const override {
         std::vector<std::string> columns = {this->getSchemeName()};
 
         return dataframe.Define(
@@ -28,21 +33,20 @@ class VectorStratifier : public IHistogramStratifier {
             columns);
     }
 
-    const std::string &getSchemeName() const override {
-        return strat_key_.str();
-    }
+    const std::string &getSchemeName() const override { return strat_key_.str(); }
 
-    const StratifierRegistry &getRegistry() const override {
-        return strat_registry_;
-    }
+    const StratifierRegistry &getRegistry() const override { return strat_registry_; }
 
   private:
     StratifierKey strat_key_;
     StratifierRegistry &strat_registry_;
 };
 
-std::unique_ptr<IHistogramStratifier> makeVectorStratifier(const StratifierKey &key, StratifierRegistry &registry) {
+inline std::unique_ptr<IHistogramStratifier>
+makeVectorStratifier(const StratifierKey &key, StratifierRegistry &registry) {
     return std::make_unique<VectorStratifier>(key, registry);
 }
 
-}
+} // namespace analysis
+
+#endif


### PR DESCRIPTION
## Summary
- convert scalar and vector stratifiers to header-only headers
- adjust stratifier manager to include new headers
- update libhist CMake to an interface library

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bccd588830832e8fad31a123bc0582