### PR TITLE
Limit dynamic binning to core strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ The configuration files contain analysis and plotting directives.
     "min": 0.0,
     "max": 3000.0,
     "include_out_of_range_bins": true,
-    "strategy": "freedman_diaconis"
+    "strategy": "bayesian_blocks"
   }
 }
 ```
 
-The `strategy` field accepts `equal_weight`, `freedman_diaconis`, `scott`, `sturges`, `rice`, or `sqrt`.
+The `strategy` field accepts `equal_weight`, `uniform`, or `bayesian_blocks`.
 
 ```json
 {

--- a/libplug/analysis/VariablesPlugin.cc
+++ b/libplug/analysis/VariablesPlugin.cc
@@ -41,11 +41,7 @@ class VariablesPlugin : public IAnalysisPlugin {
                 std::string strat_mode = bins_cfg.value("strategy", std::string("equal_weight"));
                 static const std::unordered_map<std::string, DynamicBinningStrategy> strategy_map = {
                     {"equal_weight", DynamicBinningStrategy::EqualWeight},
-                    {"freedman_diaconis", DynamicBinningStrategy::FreedmanDiaconis},
-                    {"scott", DynamicBinningStrategy::Scott},
-                    {"sturges", DynamicBinningStrategy::Sturges},
-                    {"rice", DynamicBinningStrategy::Rice},
-                    {"sqrt", DynamicBinningStrategy::Sqrt},
+                    {"uniform", DynamicBinningStrategy::Uniform},
                     {"bayesian_blocks", DynamicBinningStrategy::BayesianBlocks}};
                 DynamicBinningStrategy strategy = DynamicBinningStrategy::EqualWeight;
                 auto it = strategy_map.find(strat_mode);

--- a/libutils/DynamicBinning.h
+++ b/libutils/DynamicBinning.h
@@ -19,7 +19,7 @@
 
 namespace analysis {
 
-enum class DynamicBinningStrategy { EqualWeight, FreedmanDiaconis, Scott, Sturges, Rice, Sqrt, BayesianBlocks };
+enum class DynamicBinningStrategy { EqualWeight, Uniform, BayesianBlocks };
 
 class DynamicBinning {
   public:
@@ -267,70 +267,16 @@ class DynamicBinning {
             edges.insert(edges.end(), bb_edges.begin(), bb_edges.end());
             break;
         }
-        case DynamicBinningStrategy::FreedmanDiaconis: {
-            auto quant = [&](double q) {
-                double target = q * sumw;
-                double cum = 0.0;
-                for (const auto &p : in_range) {
-                    cum += p.second;
-                    if (cum >= target)
-                        return p.first;
-                }
-                return in_range.back().first;
-            };
-
-            double q1 = quant(0.25);
-            double q3 = quant(0.75);
-            double iqr = q3 - q1;
-            if (!(iqr > 0.0)) {
-                iqr = xmax - xmin;
-            }
-            size_t n = in_range.size();
-            double bin_width = 2.0 * iqr * std::pow(static_cast<double>(n), -1.0 / 3.0);
-            if (!(bin_width > 0.0)) {
-                bin_width = xmax - xmin;
-            }
-            int target_bins = std::max(1, static_cast<int>(std::ceil((xmax - xmin) / bin_width)));
+        case DynamicBinningStrategy::Uniform: {
+            int target_bins =
+                std::max(1, static_cast<int>(std::floor(neff_total / std::max(min_neff_per_bin, 1.0))));
             add_uniform_edges(target_bins);
             break;
         }
-        case DynamicBinningStrategy::Scott: {
-            double sumwx = 0.0;
-            for (const auto &p : in_range) {
-                sumwx += p.first * p.second;
-            }
-            double mean = sumwx / sumw;
-            double swvar = 0.0;
-            for (const auto &p : in_range) {
-                double diff = p.first - mean;
-                swvar += p.second * diff * diff;
-            }
-            double sigma = std::sqrt(swvar / sumw);
-            double bin_width = 3.5 * sigma * std::pow(neff_total, -1.0 / 3.0);
-            if (!(bin_width > 0.0)) {
-                bin_width = xmax - xmin;
-            }
-            int target_bins = std::max(1, static_cast<int>(std::ceil((xmax - xmin) / bin_width)));
-            add_uniform_edges(target_bins);
-            break;
-        }
-        case DynamicBinningStrategy::Sturges: {
-            int target_bins = std::max(1, static_cast<int>(std::ceil(std::log2(neff_total) + 1.0)));
-            add_uniform_edges(target_bins);
-            break;
-        }
-        case DynamicBinningStrategy::Rice: {
-            int target_bins = std::max(1, static_cast<int>(std::ceil(2.0 * std::cbrt(neff_total))));
-            add_uniform_edges(target_bins);
-            break;
-        }
-        case DynamicBinningStrategy::Sqrt: {
-            int target_bins = std::max(1, static_cast<int>(std::ceil(std::sqrt(neff_total))));
-            add_uniform_edges(target_bins);
-            break;
-        }
+        case DynamicBinningStrategy::EqualWeight:
         default: {
-            int target_bins = std::max(1, static_cast<int>(std::floor(neff_total / std::max(min_neff_per_bin, 1.0))));
+            int target_bins =
+                std::max(1, static_cast<int>(std::floor(neff_total / std::max(min_neff_per_bin, 1.0))));
 
             edges.reserve(static_cast<size_t>(target_bins) + 3);
             edges.push_back(xmin);


### PR DESCRIPTION
## Summary
- Simplify dynamic binning enum to only equal-weight, uniform width, and Bayesian blocks
- Adjust plugin configuration map and documentation for the reduced set of strategies

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcce2479f0832e937e70277921bec6