### PR TITLE
Simplify dynamic binning strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ The configuration files contain analysis and plotting directives.
     "min": 0.0,
     "max": 3000.0,
     "include_out_of_range_bins": true,
-    "strategy": "freedman_diaconis"
+    "strategy": "uniform_width"
   }
 }
 ```
 
-The `strategy` field accepts `equal_weight`, `freedman_diaconis`, `scott`, `sturges`, `rice`, or `sqrt`.
+The `strategy` field accepts `equal_weight`, `uniform_width`, or `bayesian_blocks`.
 
 ```json
 {

--- a/libplug/analytics/VariablesPlugin.cc
+++ b/libplug/analytics/VariablesPlugin.cc
@@ -41,11 +41,7 @@ class VariablesPlugin : public IAnalysisPlugin {
                 std::string strat_mode = bins_cfg.value("strategy", std::string("equal_weight"));
                 static const std::unordered_map<std::string, DynamicBinningStrategy> strategy_map = {
                     {"equal_weight", DynamicBinningStrategy::EqualWeight},
-                    {"freedman_diaconis", DynamicBinningStrategy::FreedmanDiaconis},
-                    {"scott", DynamicBinningStrategy::Scott},
-                    {"sturges", DynamicBinningStrategy::Sturges},
-                    {"rice", DynamicBinningStrategy::Rice},
-                    {"sqrt", DynamicBinningStrategy::Sqrt},
+                    {"uniform_width", DynamicBinningStrategy::UniformWidth},
                     {"bayesian_blocks", DynamicBinningStrategy::BayesianBlocks}};
                 DynamicBinningStrategy strategy = DynamicBinningStrategy::EqualWeight;
                 auto it = strategy_map.find(strat_mode);


### PR DESCRIPTION
## Summary
- reduce dynamic binning options to equal-weight, uniform width, and Bayesian blocks
- update plugin configuration map and README for new strategies

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bccf380ec0832e825b29b6e3f5c123