### PR TITLE
Remove redundant DynamicBinningStrategy declaration

### DIFF
--- a/libapp/AnalysisDefinition.h
+++ b/libapp/AnalysisDefinition.h
@@ -20,10 +20,6 @@
 #include "VariableRegistry.h"
 
 namespace analysis {
-enum class DynamicBinningStrategy;
-}
-
-namespace analysis {
 
 class AnalysisDefinition {
   public:


### PR DESCRIPTION
## Summary
- clean up AnalysisDefinition header

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: CMake couldn't find ROOT)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd15fcd68832eb36b647a73bf4265