### PR TITLE
refactor: group AnalysisDefinition methods logically

### DIFF
--- a/libapp/AnalysisDefinition.h
+++ b/libapp/AnalysisDefinition.h
@@ -104,27 +104,6 @@ class AnalysisDefinition {
         region_variables_[region_key].emplace_back(variable_key);
     }
 
-    bool isDynamic(const VariableKey &key) const {
-        auto it = is_dynamic_.find(key);
-        return it != is_dynamic_.end() && it->second;
-    }
-
-    bool includeOutOfRangeBins(const VariableKey &key) const {
-        auto it = include_out_of_range_.find(key);
-        return it != include_out_of_range_.end() && it->second;
-    }
-
-    DynamicBinningStrategy dynamicBinningStrategy(const VariableKey &key) const {
-        auto it = dynamic_strategy_.find(key);
-        return it != dynamic_strategy_.end() ? it->second : DynamicBinningStrategy::EqualWeight;
-    }
-
-    void setBinning(const VariableKey &key, BinningDefinition &&bdef) { variable_binning_[key] = std::move(bdef); }
-
-    VariableHandle variable(const VariableKey &key) const {
-        return VariableHandle{key, variable_expressions_, variable_labels_, variable_binning_, variable_stratifiers_};
-    }
-
     RegionHandle region(const RegionKey &key) const {
         return RegionHandle{key, region_names_, region_selections_, region_analyses_, region_variables_};
     }
@@ -133,6 +112,22 @@ class AnalysisDefinition {
         static const std::vector<std::string> empty;
         auto it = region_clauses_.find(key);
         return it != region_clauses_.end() ? it->second : empty;
+    }
+
+    std::vector<RegionHandle> regions() const {
+        std::vector<RegionHandle> result;
+        result.reserve(region_names_.size());
+
+        for (const auto &entry : region_names_)
+            result.emplace_back(entry.first, region_names_, region_selections_, region_analyses_, region_variables_);
+
+        return result;
+    }
+
+    void setBinning(const VariableKey &key, BinningDefinition &&bdef) { variable_binning_[key] = std::move(bdef); }
+
+    VariableHandle variable(const VariableKey &key) const {
+        return VariableHandle{key, variable_expressions_, variable_labels_, variable_binning_, variable_stratifiers_};
     }
 
     std::vector<VariableHandle> variables() const {
@@ -146,14 +141,19 @@ class AnalysisDefinition {
         return result;
     }
 
-    std::vector<RegionHandle> regions() const {
-        std::vector<RegionHandle> result;
-        result.reserve(region_names_.size());
+    bool isDynamic(const VariableKey &key) const {
+        auto it = is_dynamic_.find(key);
+        return it != is_dynamic_.end() && it->second;
+    }
 
-        for (const auto &entry : region_names_)
-            result.emplace_back(entry.first, region_names_, region_selections_, region_analyses_, region_variables_);
+    bool includeOutOfRangeBins(const VariableKey &key) const {
+        auto it = include_out_of_range_.find(key);
+        return it != include_out_of_range_.end() && it->second;
+    }
 
-        return result;
+    DynamicBinningStrategy dynamicBinningStrategy(const VariableKey &key) const {
+        auto it = dynamic_strategy_.find(key);
+        return it != dynamic_strategy_.end() ? it->second : DynamicBinningStrategy::EqualWeight;
     }
 
     void resolveDynamicBinning(AnalysisDataLoader &loader) {


### PR DESCRIPTION
## Summary
- group region helper methods together in `AnalysisDefinition`
- move variable and dynamic binning helpers into their own block

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2b03e2c832e9cc33aea0f24b8df