### PR TITLE
style: space out RegionAnalysis accessors

### DIFF
--- a/libapp/RegionAnalysis.h
+++ b/libapp/RegionAnalysis.h
@@ -21,14 +21,19 @@ class RegionAnalysis {
     ~RegionAnalysis() = default;
 
     const RegionKey &regionKey() const noexcept { return region_key_; }
+
     const std::string &regionLabel() const noexcept {
         return region_label_.empty() ? region_key_.str() : region_label_;
     }
+
     double protonsOnTarget() const noexcept { return protons_on_target_; }
     void setProtonsOnTarget(double pot) noexcept { protons_on_target_ = pot; }
     void addProtonsOnTarget(double pot) noexcept { protons_on_target_ += pot; }
+
     bool isBlinded() const noexcept { return is_blinded_; }
+
     const std::string &beamConfig() const noexcept { return beam_config_; }
+
     const std::vector<std::string> &runNumbers() const noexcept { return run_numbers_; }
 
     void addFinalVariable(VariableKey v, VariableResult r) {


### PR DESCRIPTION
## Summary
- add vertical whitespace around RegionAnalysis accessors for readability

## Testing
- `cmake -S . -B build` *(fails: could not find ROOT package)*
- `ctest --output-on-failure` *(fails: no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd3444184832e814b180aa5c235ca