### PR TITLE
refactor: rename variables and qualify internal calls

### DIFF
--- a/libdata/MuonSelectionProcessor.h
+++ b/libdata/MuonSelectionProcessor.h
@@ -16,13 +16,13 @@ class MuonSelectionProcessor : public IEventProcessor {
             return next_ ? next_->process(df, st) : df;
         }
 
-        auto df1 = computeAverageDedx(df);
+        auto dedx_df = this->computeAverageDedx(df);
 
-        auto df2 = buildMuonMask(df1);
+        auto muon_mask_df = this->buildMuonMask(dedx_df);
 
-        auto df3 = extractMuonFeatures(df2);
+        auto muon_features_df = this->extractMuonFeatures(muon_mask_df);
 
-        return next_ ? next_->process(df3, st) : df3;
+        return next_ ? next_->process(muon_features_df, st) : muon_features_df;
     }
 
   private:


### PR DESCRIPTION
## Summary
- clarify intermediate DataFrame variable names in `MuonSelectionProcessor`
- explicitly qualify internal method calls with `this->`

## Testing
- `bash .build.sh` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd515231c832e9264bfc4ad25d7fb