### PR TITLE
Remove redundant namespace comments

### DIFF
--- a/libapp/AnalysisKey.h
+++ b/libapp/AnalysisKey.h
@@ -42,7 +42,7 @@ using StratifierKey = AnalysisKey<StratifierKeyTag>;
 using StratumKey = AnalysisKey<StratumKeyTag>;
 using SelectionKey = AnalysisKey<SelectionKeyTag>;
 
-} // namespace analysis
+}
 
 namespace std {
 template <class Tag> struct hash<analysis::AnalysisKey<Tag>> {

--- a/libapp/VariableResult.h
+++ b/libapp/VariableResult.h
@@ -34,6 +34,6 @@ struct VariableResult {
     std::map<SystematicKey, std::vector<BinnedHistogram>> universe_projected_hists_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libdata/SampleDataset.h
+++ b/libdata/SampleDataset.h
@@ -23,6 +23,6 @@ struct SampleDatasetGroup {
 
 using SampleDatasetGroupMap = std::unordered_map<SampleKey, SampleDatasetGroup>;
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/ScalarStratifier.h
+++ b/libhist/ScalarStratifier.h
@@ -37,6 +37,6 @@ inline std::unique_ptr<IHistogramStratifier> makeScalarStratifier(const Stratifi
     return std::make_unique<ScalarStratifier>(key, registry);
 }
 
-} // namespace analysis
+}
 
 #endif

--- a/libhist/VectorStratifier.h
+++ b/libhist/VectorStratifier.h
@@ -47,6 +47,6 @@ makeVectorStratifier(const StratifierKey &key, StratifierRegistry &registry) {
     return std::make_unique<VectorStratifier>(key, registry);
 }
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/DetectorDisplay.h
+++ b/libplot/DetectorDisplay.h
@@ -33,13 +33,13 @@ class DetectorDisplay : public IEventDisplay {
         hist.SetMaximum(max_val);
         hist.GetXaxis()->SetTitle("Wire");
         hist.GetYaxis()->SetTitle("Time");
-        hist.Draw("COL");
+    hist.Draw("COL");
     }
 
   private:
     std::vector<float> data_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/IEventDisplay.h
+++ b/libplot/IEventDisplay.h
@@ -34,6 +34,6 @@ class IEventDisplay {
     std::string output_directory_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/IHistogramPlot.h
+++ b/libplot/IHistogramPlot.h
@@ -82,6 +82,6 @@ protected:
   std::string output_directory_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/MatrixPlot.h
+++ b/libplot/MatrixPlot.h
@@ -222,6 +222,6 @@ private:
   TH2F *hist_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -109,6 +109,6 @@ private:
   std::filesystem::path output_directory_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/SemanticDisplay.h
+++ b/libplot/SemanticDisplay.h
@@ -47,6 +47,6 @@ class SemanticDisplay : public IEventDisplay {
     std::vector<int> data_;
 };
 
-} // namespace analysis
+}
 
 #endif

--- a/libplot/SlipStackingIntensityPlot.h
+++ b/libplot/SlipStackingIntensityPlot.h
@@ -87,6 +87,6 @@ class SlipStackingIntensityPlot {
   std::string output_directory_;
 };
 
-} // namespace analysis
+}
 
 #endif


### PR DESCRIPTION
## Summary
- Remove trailing `// namespace analysis` comments across headers

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: CMake couldn't find ROOT)*
- `ctest --output-on-failure` *(build incomplete: no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd5473cf4832ea0e9a0cacdade931