### PR TITLE
Trim whitespace in TruthChannelProcessor

### DIFF
--- a/libdata/TruthChannelProcessor.h
+++ b/libdata/TruthChannelProcessor.h
@@ -19,11 +19,8 @@ class TruthChannelProcessor : public IEventProcessor {
         }
 
         auto counts_df = this->defineCounts(df);
-
         auto incl_df = this->assignInclusiveChannels(counts_df);
-
         auto excl_df = this->assignExclusiveChannels(incl_df);
-
         return next_ ? next_->process(excl_df, st) : excl_df;
     }
 


### PR DESCRIPTION
## Summary
- Consolidate channel assignment lines in `TruthChannelProcessor::process` to remove superfluous vertical spacing.

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd58e68d0832e9cf817d9eb53a488