### PR TITLE
Remove namespace std comments

### DIFF
--- a/libapp/AnalysisKey.h
+++ b/libapp/AnalysisKey.h
@@ -48,4 +48,4 @@ namespace std {
 template <class Tag> struct hash<analysis::AnalysisKey<Tag>> {
     size_t operator()(const analysis::AnalysisKey<Tag> &k) const noexcept { return std::hash<std::string>()(k.str()); }
 };
-} // namespace std
+}


### PR DESCRIPTION
## Summary
- remove extraneous namespace std comment in AnalysisKey hash specialization

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: command not found / missing setup scripts)*
- `source .build.sh` *(fails: missing ROOT package configuration)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd8637d04832e8e00fe169a9a7ee5