### PR TITLE
Use 4-space indentation in MatrixPlot

### DIFF
--- a/libplot/MatrixPlot.h
+++ b/libplot/MatrixPlot.h
@@ -21,207 +21,210 @@
 namespace analysis {
 
 class MatrixPlot : public IHistogramPlot {
-public:
-  MatrixPlot(std::string plot_name, const VariableResult &x_res,
-             const VariableResult &y_res, AnalysisDataLoader &loader,
-             const SelectionQuery &selection, std::string output_directory = "plots",
-             const std::vector<Cut> &x_cuts = {},
-             const std::vector<Cut> &y_cuts = {})
-      : IHistogramPlot(std::move(plot_name), std::move(output_directory)) {
-    auto edges = determineEdges(loader, x_res, y_res);
-    hist_ = new TH2F(plot_name_.c_str(), plot_name_.c_str(),
-                     edges.first.size() - 1, edges.first.data(),
-                     edges.second.size() - 1, edges.second.data());
-    hist_->GetXaxis()->SetTitle(x_res.binning_.getTexLabel().c_str());
-    hist_->GetYaxis()->SetTitle(y_res.binning_.getTexLabel().c_str());
+    public:
+    MatrixPlot(std::string plot_name, const VariableResult &x_res,
+               const VariableResult &y_res, AnalysisDataLoader &loader,
+               const SelectionQuery &selection,
+               std::string output_directory = "plots",
+               const std::vector<Cut> &x_cuts = {},
+               const std::vector<Cut> &y_cuts = {})
+        : IHistogramPlot(std::move(plot_name), std::move(output_directory)) {
+        auto edges = determineEdges(loader, x_res, y_res);
+        hist_ = new TH2F(plot_name_.c_str(), plot_name_.c_str(),
+                         edges.first.size() - 1, edges.first.data(),
+                         edges.second.size() - 1, edges.second.data());
+        hist_->GetXaxis()->SetTitle(x_res.binning_.getTexLabel().c_str());
+        hist_->GetYaxis()->SetTitle(y_res.binning_.getTexLabel().c_str());
 
-    std::string filter = selection.str();
+        std::string filter = selection.str();
 
-    for (auto &kv : loader.getSampleFrames()) {
-      auto df = kv.second.nominal_node_;
-      df = applySelectionFilters(df, x_res, y_res, filter, x_cuts, y_cuts);
-      auto data = extractValues(df, x_res, y_res);
-      fillHistogram(hist_, data);
-    }
-  }
-
-  ~MatrixPlot() override { delete hist_; }
-
-private:
-  static std::pair<std::vector<double>, std::vector<double>>
-  determineEdges(AnalysisDataLoader &loader, const VariableResult &x_res,
-                 const VariableResult &y_res) {
-    auto x_edges = x_res.binning_.getEdges();
-    auto y_edges = y_res.binning_.getEdges();
-
-    std::vector<ROOT::RDF::RNode> mc_nodes;
-    for (auto &[key, sample] : loader.getSampleFrames())
-      if (sample.isMc())
-        mc_nodes.emplace_back(sample.nominal_node_);
-    if (!mc_nodes.empty()) {
-      auto bins = QuadTreeBinning::calculate(mc_nodes, x_res.binning_,
-                                             y_res.binning_);
-      x_edges = bins.first.getEdges();
-      y_edges = bins.second.getEdges();
+        for (auto &kv : loader.getSampleFrames()) {
+            auto df = kv.second.nominal_node_;
+            df =
+                applySelectionFilters(df, x_res, y_res, filter, x_cuts, y_cuts);
+            auto data = extractValues(df, x_res, y_res);
+            fillHistogram(hist_, data);
+        }
     }
 
-    return {x_edges, y_edges};
-  }
+    ~MatrixPlot() override { delete hist_; }
 
-  static ROOT::RDF::RNode
-  applySelectionFilters(ROOT::RDF::RNode df, const VariableResult &x_res,
-                        const VariableResult &y_res, const std::string &filter,
-                        const std::vector<Cut> &x_cuts,
-                        const std::vector<Cut> &y_cuts) {
-    if (filter.find_first_not_of(" \t\n\r") != std::string::npos)
-      df = df.Filter(filter);
+    private:
+    static std::pair<std::vector<double>, std::vector<double>>
+    determineEdges(AnalysisDataLoader &loader, const VariableResult &x_res,
+                   const VariableResult &y_res) {
+        auto x_edges = x_res.binning_.getEdges();
+        auto y_edges = y_res.binning_.getEdges();
 
-    for (auto const &c : x_cuts) {
-      std::string expr =
-          x_res.binning_.getVariable() +
-          (c.direction == CutDirection::GreaterThan ? ">" : "<") +
-          std::to_string(c.threshold);
-      df = df.Filter(expr);
+        std::vector<ROOT::RDF::RNode> mc_nodes;
+        for (auto &[key, sample] : loader.getSampleFrames())
+            if (sample.isMc())
+                mc_nodes.emplace_back(sample.nominal_node_);
+        if (!mc_nodes.empty()) {
+            auto bins = QuadTreeBinning::calculate(mc_nodes, x_res.binning_,
+                                                   y_res.binning_);
+            x_edges = bins.first.getEdges();
+            y_edges = bins.second.getEdges();
+        }
+
+        return {x_edges, y_edges};
     }
 
-    for (auto const &c : y_cuts) {
-      std::string expr =
-          y_res.binning_.getVariable() +
-          (c.direction == CutDirection::GreaterThan ? ">" : "<") +
-          std::to_string(c.threshold);
-      df = df.Filter(expr);
+    static ROOT::RDF::RNode applySelectionFilters(
+        ROOT::RDF::RNode df, const VariableResult &x_res,
+        const VariableResult &y_res, const std::string &filter,
+        const std::vector<Cut> &x_cuts, const std::vector<Cut> &y_cuts) {
+        if (filter.find_first_not_of(" \t\n\r") != std::string::npos)
+            df = df.Filter(filter);
+
+        for (auto const &c : x_cuts) {
+            std::string expr =
+                x_res.binning_.getVariable() +
+                (c.direction == CutDirection::GreaterThan ? ">" : "<") +
+                std::to_string(c.threshold);
+            df = df.Filter(expr);
+        }
+
+        for (auto const &c : y_cuts) {
+            std::string expr =
+                y_res.binning_.getVariable() +
+                (c.direction == CutDirection::GreaterThan ? ">" : "<") +
+                std::to_string(c.threshold);
+            df = df.Filter(expr);
+        }
+
+        return df;
     }
 
-    return df;
-  }
-
-  struct SampleData {
-    bool x_is_vec;
-    bool y_is_vec;
-    std::vector<double> ws;
-    std::vector<double> xs;
-    std::vector<double> ys;
-    std::vector<std::vector<double>> xs_vec;
-    std::vector<std::vector<double>> ys_vec;
-  };
-
-  static SampleData extractValues(ROOT::RDF::RNode df,
-                                  const VariableResult &x_res,
-                                  const VariableResult &y_res) {
-    SampleData data;
-
-    bool has_w = df.HasColumn("nominal_event_weight");
-    const auto &x_col = x_res.binning_.getVariable();
-    const auto &y_col = y_res.binning_.getVariable();
-
-    auto x_type = df.GetColumnType(x_col);
-    auto y_type = df.GetColumnType(y_col);
-    data.x_is_vec = x_type.find("vector") != std::string::npos ||
-                    x_type.find("RVec") != std::string::npos;
-    data.y_is_vec = y_type.find("vector") != std::string::npos ||
-                    y_type.find("RVec") != std::string::npos;
-
-    size_t n_events = df.Count().GetValue();
-    if (has_w) {
-      auto w_type = df.GetColumnType("nominal_event_weight");
-      if (w_type.find("float") != std::string::npos) {
-        auto wv = df.Take<float>("nominal_event_weight").GetValue();
-        data.ws.assign(wv.begin(), wv.end());
-      } else {
-        data.ws = df.Take<double>("nominal_event_weight").GetValue();
-      }
-    } else {
-      data.ws.assign(n_events, 1.0);
-    }
-
-    auto get_scalar = [&](const std::string &col, const std::string &type) {
-      std::vector<double> vals;
-      if (type.find("float") != std::string::npos) {
-        auto v = df.Take<float>(col).GetValue();
-        vals.assign(v.begin(), v.end());
-      } else if (type.find("int") != std::string::npos ||
-                 type.find("unsigned") != std::string::npos) {
-        auto v = df.Take<int>(col).GetValue();
-        vals.assign(v.begin(), v.end());
-      } else {
-        vals = df.Take<double>(col).GetValue();
-      }
-      return vals;
+    struct SampleData {
+        bool x_is_vec;
+        bool y_is_vec;
+        std::vector<double> ws;
+        std::vector<double> xs;
+        std::vector<double> ys;
+        std::vector<std::vector<double>> xs_vec;
+        std::vector<std::vector<double>> ys_vec;
     };
 
-    auto get_vector = [&](const std::string &col, const std::string &type) {
-      std::vector<std::vector<double>> vals;
-      if (type.find("float") != std::string::npos) {
-        auto v = df.Take<std::vector<float>>(col).GetValue();
-        for (auto &inner : v)
-          vals.emplace_back(inner.begin(), inner.end());
-      } else if (type.find("int") != std::string::npos ||
-                 type.find("unsigned") != std::string::npos) {
-        auto v = df.Take<std::vector<int>>(col).GetValue();
-        for (auto &inner : v)
-          vals.emplace_back(inner.begin(), inner.end());
-      } else {
-        vals = df.Take<std::vector<double>>(col).GetValue();
-      }
-      return vals;
-    };
+    static SampleData extractValues(ROOT::RDF::RNode df,
+                                    const VariableResult &x_res,
+                                    const VariableResult &y_res) {
+        SampleData data;
 
-    if (!data.x_is_vec)
-      data.xs = get_scalar(x_col, x_type);
-    else
-      data.xs_vec = get_vector(x_col, x_type);
+        bool has_w = df.HasColumn("nominal_event_weight");
+        const auto &x_col = x_res.binning_.getVariable();
+        const auto &y_col = y_res.binning_.getVariable();
 
-    if (!data.y_is_vec)
-      data.ys = get_scalar(y_col, y_type);
-    else
-      data.ys_vec = get_vector(y_col, y_type);
+        auto x_type = df.GetColumnType(x_col);
+        auto y_type = df.GetColumnType(y_col);
+        data.x_is_vec = x_type.find("vector") != std::string::npos ||
+                        x_type.find("RVec") != std::string::npos;
+        data.y_is_vec = y_type.find("vector") != std::string::npos ||
+                        y_type.find("RVec") != std::string::npos;
 
-    return data;
-  }
+        size_t n_events = df.Count().GetValue();
+        if (has_w) {
+            auto w_type = df.GetColumnType("nominal_event_weight");
+            if (w_type.find("float") != std::string::npos) {
+                auto wv = df.Take<float>("nominal_event_weight").GetValue();
+                data.ws.assign(wv.begin(), wv.end());
+            } else {
+                data.ws = df.Take<double>("nominal_event_weight").GetValue();
+            }
+        } else {
+            data.ws.assign(n_events, 1.0);
+        }
 
-  static void fillHistogram(TH2F *hist, const SampleData &data) {
-    if (!data.x_is_vec && !data.y_is_vec) {
-      for (size_t i = 0; i < data.xs.size(); ++i)
-        hist->Fill(data.xs[i], data.ys[i], data.ws[i]);
-    } else if (data.x_is_vec && !data.y_is_vec) {
-      for (size_t i = 0; i < data.xs_vec.size(); ++i)
-        for (double xv : data.xs_vec[i])
-          hist->Fill(xv, data.ys[i], data.ws[i]);
-    } else if (!data.x_is_vec && data.y_is_vec) {
-      for (size_t i = 0; i < data.ys_vec.size(); ++i)
-        for (double yv : data.ys_vec[i])
-          hist->Fill(data.xs[i], yv, data.ws[i]);
-    } else {
-      for (size_t i = 0; i < data.xs_vec.size(); ++i) {
-        size_t lim = std::min(data.xs_vec[i].size(), data.ys_vec[i].size());
-        for (size_t j = 0; j < lim; ++j)
-          hist->Fill(data.xs_vec[i][j], data.ys_vec[i][j], data.ws[i]);
-      }
+        auto get_scalar = [&](const std::string &col, const std::string &type) {
+            std::vector<double> vals;
+            if (type.find("float") != std::string::npos) {
+                auto v = df.Take<float>(col).GetValue();
+                vals.assign(v.begin(), v.end());
+            } else if (type.find("int") != std::string::npos ||
+                       type.find("unsigned") != std::string::npos) {
+                auto v = df.Take<int>(col).GetValue();
+                vals.assign(v.begin(), v.end());
+            } else {
+                vals = df.Take<double>(col).GetValue();
+            }
+            return vals;
+        };
+
+        auto get_vector = [&](const std::string &col, const std::string &type) {
+            std::vector<std::vector<double>> vals;
+            if (type.find("float") != std::string::npos) {
+                auto v = df.Take<std::vector<float>>(col).GetValue();
+                for (auto &inner : v)
+                    vals.emplace_back(inner.begin(), inner.end());
+            } else if (type.find("int") != std::string::npos ||
+                       type.find("unsigned") != std::string::npos) {
+                auto v = df.Take<std::vector<int>>(col).GetValue();
+                for (auto &inner : v)
+                    vals.emplace_back(inner.begin(), inner.end());
+            } else {
+                vals = df.Take<std::vector<double>>(col).GetValue();
+            }
+            return vals;
+        };
+
+        if (!data.x_is_vec)
+            data.xs = get_scalar(x_col, x_type);
+        else
+            data.xs_vec = get_vector(x_col, x_type);
+
+        if (!data.y_is_vec)
+            data.ys = get_scalar(y_col, y_type);
+        else
+            data.ys_vec = get_vector(y_col, y_type);
+
+        return data;
     }
-  }
 
-  void draw(TCanvas &canvas) override {
-    canvas.cd();
-    const int stats_off = 0;
-    const int contour_count = 255;
-    const double margin = 0.15;
-    const double title_offset = 1.2;
+    static void fillHistogram(TH2F *hist, const SampleData &data) {
+        if (!data.x_is_vec && !data.y_is_vec) {
+            for (size_t i = 0; i < data.xs.size(); ++i)
+                hist->Fill(data.xs[i], data.ys[i], data.ws[i]);
+        } else if (data.x_is_vec && !data.y_is_vec) {
+            for (size_t i = 0; i < data.xs_vec.size(); ++i)
+                for (double xv : data.xs_vec[i])
+                    hist->Fill(xv, data.ys[i], data.ws[i]);
+        } else if (!data.x_is_vec && data.y_is_vec) {
+            for (size_t i = 0; i < data.ys_vec.size(); ++i)
+                for (double yv : data.ys_vec[i])
+                    hist->Fill(data.xs[i], yv, data.ws[i]);
+        } else {
+            for (size_t i = 0; i < data.xs_vec.size(); ++i) {
+                size_t lim =
+                    std::min(data.xs_vec[i].size(), data.ys_vec[i].size());
+                for (size_t j = 0; j < lim; ++j)
+                    hist->Fill(data.xs_vec[i][j], data.ys_vec[i][j],
+                               data.ws[i]);
+            }
+        }
+    }
 
-    gStyle->SetOptStat(stats_off);
-    gStyle->SetNumberContours(contour_count);
+    void draw(TCanvas &canvas) override {
+        canvas.cd();
+        const int stats_off = 0;
+        const int contour_count = 255;
+        const double margin = 0.15;
+        const double title_offset = 1.2;
 
-    canvas.SetLogz();
-    canvas.SetLeftMargin(margin);
-    canvas.SetRightMargin(margin);
+        gStyle->SetOptStat(stats_off);
+        gStyle->SetNumberContours(contour_count);
 
-    hist_->SetTitle("");
-    hist_->GetZaxis()->SetTitleOffset(title_offset);
-    hist_->Draw("COLZ");
-  }
+        canvas.SetLogz();
+        canvas.SetLeftMargin(margin);
+        canvas.SetRightMargin(margin);
 
-  TH2F *hist_;
+        hist_->SetTitle("");
+        hist_->GetZaxis()->SetTitleOffset(title_offset);
+        hist_->Draw("COLZ");
+    }
+
+    TH2F *hist_;
 };
 
-}
+} // namespace analysis
 
 #endif


### PR DESCRIPTION
## Summary
- reindent MatrixPlot to use 4 spaces for improved consistency

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bcda9e9db0832eb6f323f2af2435d6