### PR TITLE
Fix indentation in SystematicBreakdownPlot

### DIFF
--- a/libplot/SystematicBreakdownPlot.h
+++ b/libplot/SystematicBreakdownPlot.h
@@ -35,64 +35,64 @@ class SystematicBreakdownPlot : public IHistogramPlot {
   private:
     void draw(TCanvas &canvas) override {
         canvas.cd();
+        
+        const auto &edges = variable_result_.binning_.getEdges();
+        const int nbins = variable_result_.binning_.getBinNumber();
 
-    const auto &edges = variable_result_.binning_.getEdges();
-    const int nbins = variable_result_.binning_.getBinNumber();
-
-    std::vector<double> bin_totals(nbins, 0.0);
-    for (const auto &[key, cov] : variable_result_.covariance_matrices_) {
-        const int n = cov.GetNrows();
-        for (int i = 0; i < nbins && i < n; ++i) {
-            double val = cov(i, i);
-            if (std::isfinite(val)) {
-                bin_totals[i] += val;
-            }
-        }
-    }
-
-    stack_ = new THStack("syst_stack", "");
-    const double x1 = 0.65;
-    const double y1 = 0.7;
-    const double x2 = 0.9;
-    const double y2 = 0.9;
-    const int border = 0;
-    const int fill = 0;
-    const int font_style = 42;
-    const int colour_offset = 1;
-    const int bin_offset = 1;
-    const double zero = 0.0;
-
-    legend_ = new TLegend(x1, y1, x2, y2);
-    legend_->SetBorderSize(border);
-    legend_->SetFillStyle(fill);
-    legend_->SetTextFont(font_style);
-
-    int colour = kRed + colour_offset;
-    for (const auto &[key, cov] : variable_result_.covariance_matrices_) {
-        TH1D *hist = new TH1D(key.str().c_str(), "", nbins, edges.data());
-        const int n = cov.GetNrows();
-        for (int i = 0; i < nbins && i < n; ++i) {
-            double val = cov(i, i);
-            if (std::isfinite(val)) {
-                if (normalise_ && bin_totals[i] > zero) {
-                    val /= bin_totals[i];
+        std::vector<double> bin_totals(nbins, 0.0);
+        for (const auto &[key, cov] : variable_result_.covariance_matrices_) {
+            const int n = cov.GetNrows();
+            for (int i = 0; i < nbins && i < n; ++i) {
+                double val = cov(i, i);
+                if (std::isfinite(val)) {
+                    bin_totals[i] += val;
                 }
-                hist->SetBinContent(i + bin_offset, val);
-            } else {
-                hist->SetBinContent(i + bin_offset, zero);
             }
         }
-        hist->SetFillColor(colour);
-        hist->SetLineColor(kBlack);
-        stack_->Add(hist);
-        legend_->AddEntry(hist, key.str().c_str(), "f");
-        histograms_.push_back(hist);
-        ++colour;
-    }
 
-    stack_->Draw("hist");
-    stack_->GetXaxis()->SetTitle(variable_result_.binning_.getTexLabel().c_str());
-    stack_->GetYaxis()->SetTitle(normalise_ ? "Fractional Contribution" : "Variance");
+        stack_ = new THStack("syst_stack", "");
+        const double x1 = 0.65;
+        const double y1 = 0.7;
+        const double x2 = 0.9;
+        const double y2 = 0.9;
+        const int border = 0;
+        const int fill = 0;
+        const int font_style = 42;
+        const int colour_offset = 1;
+        const int bin_offset = 1;
+        const double zero = 0.0;
+
+        legend_ = new TLegend(x1, y1, x2, y2);
+        legend_->SetBorderSize(border);
+        legend_->SetFillStyle(fill);
+        legend_->SetTextFont(font_style);
+
+        int colour = kRed + colour_offset;
+        for (const auto &[key, cov] : variable_result_.covariance_matrices_) {
+            TH1D *hist = new TH1D(key.str().c_str(), "", nbins, edges.data());
+            const int n = cov.GetNrows();
+            for (int i = 0; i < nbins && i < n; ++i) {
+                double val = cov(i, i);
+                if (std::isfinite(val)) {
+                    if (normalise_ && bin_totals[i] > zero) {
+                        val /= bin_totals[i];
+                    }
+                    hist->SetBinContent(i + bin_offset, val);
+                } else {
+                    hist->SetBinContent(i + bin_offset, zero);
+                }
+            }
+            hist->SetFillColor(colour);
+            hist->SetLineColor(kBlack);
+            stack_->Add(hist);
+            legend_->AddEntry(hist, key.str().c_str(), "f");
+            histograms_.push_back(hist);
+            ++colour;
+        }
+
+        stack_->Draw("hist");
+        stack_->GetXaxis()->SetTitle(variable_result_.binning_.getTexLabel().c_str());
+        stack_->GetYaxis()->SetTitle(normalise_ ? "Fractional Contribution" : "Variance");
         legend_->Draw();
     }
 


### PR DESCRIPTION
## Summary
- Correct indentation within `SystematicBreakdownPlot::draw` for consistent 4-space style

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bcdbeb699c832e9384ae0448143aab