### PR TITLE
refactor: improve libsyst readability

### DIFF
--- a/libsyst/DetectorSystematicStrategy.h
+++ b/libsyst/DetectorSystematicStrategy.h
@@ -20,39 +20,30 @@ class DetectorSystematicStrategy : public SystematicStrategy {
 
     TMatrixDSym computeCovariance(VariableResult &result, SystematicFutures &) override {
         const auto &nominal_hist = result.total_mc_hist_;
-
-        int n_bins = nominal_hist.getNumberOfBins();
+        const int n_bins = nominal_hist.getNumberOfBins();
 
         TMatrixDSym total_detvar_cov(n_bins);
-
         total_detvar_cov.Zero();
 
-        log::debug("DetectorSystematicStrategy::computeCovariance",
-                   "Raw detvar histograms:", result.raw_detvar_hists_.size());
+        log::debug("DetectorSystematicStrategy::computeCovariance", "Raw detvar histograms:",
+                   result.raw_detvar_hists_.size());
 
         if (result.raw_detvar_hists_.empty()) {
             log::info("DetectorSystematicStrategy::computeCovariance",
                       "No detector variation samples found. Skipping detector systematics.");
-
             return total_detvar_cov;
         }
 
-        auto total_detvar_hists = this->aggregateVariations(result);
-
-        auto h_det_cv_opt = this->sanitizeCvHistogram(total_detvar_hists);
-
-        if (!h_det_cv_opt)
-            return total_detvar_cov;
+        auto total_detvar_hists = aggregateVariations(result);
+        auto h_det_cv_opt = sanitizeCvHistogram(total_detvar_hists);
+        if (!h_det_cv_opt) return total_detvar_cov;
 
         auto h_det_cv = *h_det_cv_opt;
-
-        this->projectVariations(result, nominal_hist, h_det_cv, total_detvar_hists);
-
-        total_detvar_cov = this->accumulateCovariance(result, n_bins);
+        projectVariations(result, nominal_hist, h_det_cv, total_detvar_hists);
+        total_detvar_cov = accumulateCovariance(result, n_bins);
 
         log::debug("DetectorSystematicStrategy::computeCovariance", "Computed detector covariance with",
                    total_detvar_hists.size() - 1, "variations");
-
         return total_detvar_cov;
     }
 
@@ -65,39 +56,30 @@ class DetectorSystematicStrategy : public SystematicStrategy {
     std::map<SampleVariation, BinnedHistogram> aggregateVariations(const VariableResult &result) {
         std::map<SampleVariation, BinnedHistogram> total_detvar_hists;
 
-        for (const auto &[sample_key, var_map] : result.raw_detvar_hists_) {
+        for (const auto &[sample_key, variations] : result.raw_detvar_hists_) {
             log::debug("DetectorSystematicStrategy::computeCovariance", "Aggregating sample", sample_key.str());
-
-            for (const auto &[var_type, hist] : var_map) {
-                log::debug("DetectorSystematicStrategy::computeCovariance", "--> variation", variationToKey(var_type));
-
-                if (total_detvar_hists.find(var_type) == total_detvar_hists.end())
-                    total_detvar_hists[var_type] = hist;
-                else
-                    total_detvar_hists[var_type] = total_detvar_hists[var_type] + hist;
+            for (const auto &[variation, hist] : variations) {
+                log::debug("DetectorSystematicStrategy::computeCovariance", "--> variation",
+                           variationToKey(variation));
+                auto [it, inserted] = total_detvar_hists.try_emplace(variation, hist);
+                if (!inserted) it->second = it->second + hist;
             }
         }
-
         return total_detvar_hists;
     }
 
     std::optional<BinnedHistogram> sanitizeCvHistogram(std::map<SampleVariation, BinnedHistogram> &total_detvar_hists) {
         auto it = total_detvar_hists.find(SampleVariation::kCV);
-
         if (it == total_detvar_hists.end()) {
             log::warn("DetectorSystematicStrategy::computeCovariance",
                       "No detector variation CV histogram found. Skipping.");
-
             return std::nullopt;
         }
 
         auto h_det_cv = it->second;
-
-        int n_cv_bins = h_det_cv.getNumberOfBins();
-
+        const int n_cv_bins = h_det_cv.getNumberOfBins();
         for (int i = 0; i < n_cv_bins; ++i) {
-            double cv = h_det_cv.getBinContent(i);
-
+            const double cv = h_det_cv.getBinContent(i);
             if (!std::isfinite(cv) || cv == 0.0) {
                 h_det_cv.hist.counts[i] = 0.0;
                 h_det_cv.hist.shifts.row(i).setZero();
@@ -105,23 +87,19 @@ class DetectorSystematicStrategy : public SystematicStrategy {
         }
 
         it->second = h_det_cv;
-
         return h_det_cv;
     }
 
     void projectVariations(VariableResult &result, const BinnedHistogram &nominal_hist, const BinnedHistogram &h_det_cv,
                            const std::map<SampleVariation, BinnedHistogram> &total_detvar_hists) {
         for (const auto &[var_key, h_det_k] : total_detvar_hists) {
-            if (var_key == SampleVariation::kCV)
-                continue;
+            if (var_key == SampleVariation::kCV) continue;
 
             log::debug("DetectorSystematicStrategy::computeCovariance", "Projecting variation",
                        variationToKey(var_key));
 
             auto transfer_ratio = h_det_k / h_det_cv;
-
-            int n_tr_bins = transfer_ratio.getNumberOfBins();
-
+            const int n_tr_bins = transfer_ratio.getNumberOfBins();
             for (int i = 0; i < n_tr_bins; ++i) {
                 if (!std::isfinite(transfer_ratio.getBinContent(i))) {
                     transfer_ratio.hist.counts[i] = 0.0;
@@ -129,16 +107,11 @@ class DetectorSystematicStrategy : public SystematicStrategy {
                 }
             }
 
-            auto h_proj_k = transfer_ratio * nominal_hist;
-
-            auto delta = h_proj_k - nominal_hist;
-
-            SystematicKey syst_key(variationToKey(var_key));
-
+            const auto h_proj_k = transfer_ratio * nominal_hist;
+            const auto delta = h_proj_k - nominal_hist;
+            const SystematicKey syst_key(variationToKey(var_key));
             result.transfer_ratio_hists_[syst_key] = transfer_ratio;
-
             result.variation_hists_[syst_key] = h_proj_k;
-
             result.delta_hists_[syst_key] = delta;
         }
     }
@@ -150,15 +123,13 @@ class DetectorSystematicStrategy : public SystematicStrategy {
 
         for (const auto &[var_key, delta] : result.delta_hists_) {
             TMatrixDSym cov_k(n_bins);
-
             for (int i = 0; i < n_bins; ++i) {
-                for (int j = 0; j < n_bins; ++j)
+                for (int j = 0; j < n_bins; ++j) {
                     cov_k(i, j) = delta.getBinContent(i) * delta.getBinContent(j);
+                }
             }
-
             total_detvar_cov += cov_k;
         }
-
         return total_detvar_cov;
     }
 

--- a/libsyst/SystematicStrategy.h
+++ b/libsyst/SystematicStrategy.h
@@ -1,6 +1,7 @@
 #ifndef SYSTEMATIC_STRATEGY_H
 #define SYSTEMATIC_STRATEGY_H
 
+
 #include <functional>
 #include <map>
 #include <string>
@@ -19,16 +20,27 @@
 
 namespace analysis {
 
+// Convenience alias describing the futures returned by RDataFrame when booking
+// systematic variations.  The alias keeps the code in the derived strategy
+// classes concise and easier to read.
+using VariationFutures =
+    std::unordered_map<SystematicKey, std::map<SampleKey, ROOT::RDF::RResultPtr<TH1D>>>;
+
 struct SystematicFutures {
-    std::unordered_map<SystematicKey, std::map<SampleKey, ROOT::RDF::RResultPtr<TH1D>>> variations;
+    VariationFutures variations;
 };
 
+// Definition describing a multi-universe systematic.  `vector_name_` refers to
+// the column containing the per-universe weights.
 struct UniverseDef {
     std::string name_;
     std::string vector_name_;
-    unsigned n_universes_;
+    unsigned n_universes_{};
 };
 
+// Definition describing an up/down weight knob systematic.  The
+// `*_column_` members specify the column names holding the alternative
+// weights.
 struct KnobDef {
     std::string name_;
     std::string up_column_;

--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <TMatrixDSym.h>
 
@@ -16,35 +17,35 @@ namespace analysis {
 class UniverseSystematicStrategy : public SystematicStrategy {
   public:
     UniverseSystematicStrategy(UniverseDef universe_def, bool store_universe_hists = false)
-        : identifier_(std::move(universe_def.name_)), vector_name_(std::move(universe_def.vector_name_)),
-          n_universes_(universe_def.n_universes_), store_universe_hists_(store_universe_hists) {}
+        : identifier_(std::move(universe_def.name_)),
+          vector_name_(std::move(universe_def.vector_name_)),
+          n_universes_(universe_def.n_universes_),
+          store_universe_hists_(store_universe_hists) {}
 
     const std::string &getName() const override { return identifier_; }
 
     void bookVariations(const SampleKey &sample_key, ROOT::RDF::RNode &rnode, const BinningDefinition &binning,
                         const ROOT::RDF::TH1DModel &model, SystematicFutures &futures) override {
-        log::debug("UniverseSystematicStrategy::bookVariations", identifier_, "sample", sample_key.str(), "universes",
-                   n_universes_);
+        log::debug("UniverseSystematicStrategy::bookVariations", identifier_, "sample", sample_key.str(),
+                   "universes", n_universes_);
         for (unsigned u = 0; u < n_universes_; ++u) {
-            SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
-            auto weight = [u](const ROOT::RVec<unsigned short> &weights) {
-                if (u < weights.size()) {
-                    return static_cast<double>(weights[u]);
-                }
+            const SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
+            const auto weight = [u](const ROOT::RVec<unsigned short> &weights) {
+                if (u < weights.size()) return static_cast<double>(weights[u]);
                 return 1.0;
             };
 
-            auto uni_weight_name = "_uni_w_" + std::to_string(u);
+            const auto uni_weight_name = "_uni_w_" + std::to_string(u);
             auto node = rnode.Define(uni_weight_name, weight, {vector_name_});
-
-            futures.variations[uni_key][sample_key] = node.Histo1D(model, binning.getVariable(), uni_weight_name);
+            futures.variations[uni_key][sample_key] =
+                node.Histo1D(model, binning.getVariable(), uni_weight_name);
         }
     }
 
     TMatrixDSym computeCovariance(VariableResult &result, SystematicFutures &futures) override {
         const auto &nominal_hist = result.total_mc_hist_;
         const auto &binning = result.binning_;
-        int n = nominal_hist.getNumberOfBins();
+        const int n = nominal_hist.getNumberOfBins();
         TMatrixDSym cov(n);
         cov.Zero();
 
@@ -53,24 +54,23 @@ class UniverseSystematicStrategy : public SystematicStrategy {
                    "universes");
         unsigned processed_universes = 0;
         for (unsigned u = 0; u < n_universes_; ++u) {
-            SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
+            const SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
             if (!futures.variations.count(uni_key)) {
                 log::warn("UniverseSystematicStrategy::computeCovariance", "Missing universe", u, "for", identifier_);
                 continue;
             }
 
-            auto h_universe = this->buildUniverseHistogram(binning, n, uni_key, futures);
-
-            this->updateCovarianceMatrix(cov, nominal_hist, h_universe);
+            auto h_universe = buildUniverseHistogram(binning, n, uni_key, futures);
+            updateCovarianceMatrix(cov, nominal_hist, h_universe);
 
             ++processed_universes;
-            this->storeUniverseHistogram(stored_hists, std::move(h_universe));
+            storeUniverseHistogram(stored_hists, std::move(h_universe));
         }
 
-        double n_universes = static_cast<double>(processed_universes);
+        const double n_universes = static_cast<double>(processed_universes);
         for (int i = 0; i < n; ++i) {
             for (int j = 0; j <= i; ++j) {
-                double val = n_universes == 0 ? 0 : cov(i, j) / n_universes;
+                const double val = n_universes == 0 ? 0 : cov(i, j) / n_universes;
                 cov(i, j) = val;
                 cov(j, i) = val;
             }
@@ -99,29 +99,27 @@ class UniverseSystematicStrategy : public SystematicStrategy {
         BinnedHistogram h_universe(binning, std::vector<double>(n, 0.0), shifts_mat);
 
         for (auto &[sample_key, future] : futures.variations.at(key)) {
-            if (future.GetPtr())
+            if (future.GetPtr()) {
                 h_universe = h_universe + BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
+            }
         }
-
         return h_universe;
     }
 
     void updateCovarianceMatrix(TMatrixDSym &cov, const BinnedHistogram &nominal_hist,
                                 const BinnedHistogram &h_universe) {
-        int n = nominal_hist.getNumberOfBins();
-
+        const int n = nominal_hist.getNumberOfBins();
         for (int i = 0; i < n; ++i) {
-            double di = h_universe.getBinContent(i) - nominal_hist.getBinContent(i);
+            const double di = h_universe.getBinContent(i) - nominal_hist.getBinContent(i);
             for (int j = 0; j <= i; ++j) {
-                double dj = h_universe.getBinContent(j) - nominal_hist.getBinContent(j);
+                const double dj = h_universe.getBinContent(j) - nominal_hist.getBinContent(j);
                 cov(i, j) += di * dj;
             }
         }
     }
 
     void storeUniverseHistogram(std::vector<BinnedHistogram> &stored_hists, BinnedHistogram &&h_universe) {
-        if (store_universe_hists_)
-            stored_hists.push_back(std::move(h_universe));
+        if (store_universe_hists_) stored_hists.push_back(std::move(h_universe));
     }
 
     std::string identifier_;

--- a/libsyst/WeightSystematicStrategy.h
+++ b/libsyst/WeightSystematicStrategy.h
@@ -6,13 +6,15 @@
 #include <TMatrixDSym.h>
 #include <map>
 #include <string>
+#include <vector>
 
 namespace analysis {
 
 class WeightSystematicStrategy : public SystematicStrategy {
   public:
     WeightSystematicStrategy(KnobDef knob_def)
-        : identifier_(std::move(knob_def.name_)), up_column_(std::move(knob_def.up_column_)),
+        : identifier_(std::move(knob_def.name_)),
+          up_column_(std::move(knob_def.up_column_)),
           dn_column_(std::move(knob_def.dn_column_)) {}
 
     const std::string &getName() const override { return identifier_; }
@@ -20,8 +22,8 @@ class WeightSystematicStrategy : public SystematicStrategy {
     void bookVariations(const SampleKey &sample_key, ROOT::RDF::RNode &rnode, const BinningDefinition &binning,
                         const ROOT::RDF::TH1DModel &model, SystematicFutures &futures) override {
         log::debug("WeightSystematicStrategy::bookVariations", identifier_, "sample", sample_key.str());
-        SystematicKey up_key{identifier_ + "_up"};
-        SystematicKey dn_key{identifier_ + "_dn"};
+        const SystematicKey up_key{identifier_ + "_up"};
+        const SystematicKey dn_key{identifier_ + "_dn"};
         futures.variations[up_key][sample_key] = rnode.Histo1D(model, binning.getVariable(), up_column_);
         futures.variations[dn_key][sample_key] = rnode.Histo1D(model, binning.getVariable(), dn_column_);
     }
@@ -29,47 +31,24 @@ class WeightSystematicStrategy : public SystematicStrategy {
     TMatrixDSym computeCovariance(VariableResult &result, SystematicFutures &futures) override {
         const auto &nominal_hist = result.total_mc_hist_;
         const auto &binning = result.binning_;
-        int n = nominal_hist.getNumberOfBins();
+        const int n = nominal_hist.getNumberOfBins();
         TMatrixDSym cov(n);
         cov.Zero();
 
-        Eigen::VectorXd shifts = Eigen::VectorXd::Zero(n);
-        Eigen::MatrixXd shifts_mat = shifts;
-        BinnedHistogram hu(binning, std::vector<double>(n, 0.0), shifts_mat);
-        BinnedHistogram hd(binning, std::vector<double>(n, 0.0), shifts_mat);
+        const SystematicKey up_key{identifier_ + "_up"};
+        const SystematicKey dn_key{identifier_ + "_dn"};
 
-        SystematicKey up_key{identifier_ + "_up"};
-        SystematicKey dn_key{identifier_ + "_dn"};
-
-        log::debug("WeightSystematicStrategy::computeCovariance", identifier_, "bins", n);
-        if (futures.variations.count(up_key)) {
-            log::debug("WeightSystematicStrategy::computeCovariance", "Accumulating up variations for", identifier_);
-            for (auto &[sample_key, future] : futures.variations.at(up_key)) {
-                if (future.GetPtr())
-                    hu = hu + BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
-            }
-        } else {
-            log::warn("WeightSystematicStrategy::computeCovariance", "Missing up variation for", identifier_);
-        }
-        if (futures.variations.count(dn_key)) {
-            log::debug("WeightSystematicStrategy::computeCovariance", "Accumulating down variations for", identifier_);
-            for (auto &[sample_key, future] : futures.variations.at(dn_key)) {
-                if (future.GetPtr())
-                    hd = hd + BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
-            }
-        } else {
-            log::warn("WeightSystematicStrategy::computeCovariance", "Missing down variation for", identifier_);
-        }
+        const auto hu = accumulateVariation(binning, n, up_key, futures, "up");
+        const auto hd = accumulateVariation(binning, n, dn_key, futures, "down");
 
         result.variation_hists_[up_key] = hu;
         result.variation_hists_[dn_key] = hd;
 
         std::vector<double> diff(n);
-        for (int i = 0; i < n; ++i)
-            diff[i] = 0.5 * (hu.getBinContent(i) - hd.getBinContent(i));
         for (int i = 0; i < n; ++i) {
+            diff[i] = 0.5 * (hu.getBinContent(i) - hd.getBinContent(i));
             for (int j = 0; j <= i; ++j) {
-                double val = diff[i] * diff[j];
+                const double val = diff[i] * diff[j];
                 cov(i, j) = val;
                 cov(j, i) = val;
             }
@@ -85,8 +64,28 @@ class WeightSystematicStrategy : public SystematicStrategy {
     }
 
   private:
-    std::string identifier_;
+    BinnedHistogram accumulateVariation(const BinningDefinition &binning, int n, const SystematicKey &key,
+                                        SystematicFutures &futures, const std::string &direction) const {
+        Eigen::VectorXd shifts = Eigen::VectorXd::Zero(n);
+        Eigen::MatrixXd shifts_mat = shifts;
+        BinnedHistogram hist(binning, std::vector<double>(n, 0.0), shifts_mat);
+        if (!futures.variations.count(key)) {
+            log::warn("WeightSystematicStrategy::computeCovariance", "Missing", direction, "variation for",
+                      identifier_);
+            return hist;
+        }
 
+        log::debug("WeightSystematicStrategy::computeCovariance", "Accumulating", direction, "variations for",
+                   identifier_);
+        for (auto &[sample_key, future] : futures.variations.at(key)) {
+            if (future.GetPtr()) {
+                hist = hist + BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
+            }
+        }
+        return hist;
+    }
+
+    std::string identifier_;
     std::string up_column_;
     std::string dn_column_;
 };


### PR DESCRIPTION
## Summary
- clean up libsyst headers for clearer systematic handling
- streamline detector variation aggregation and projection logic
- refactor weight and universe strategies with helper utilities

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bcdd819820832eb693674e0699fc2c