### PR TITLE
Fix sanitiseMatrix parameter usage

### DIFF
--- a/libsyst/SystematicsProcessor.h
+++ b/libsyst/SystematicsProcessor.h
@@ -72,7 +72,7 @@ class SystematicsProcessor {
     void clearFutures() { systematic_futures_.variations.clear(); }
 
   private:
-    static void sanitiseMatrix(TMatrixDSym &m) {
+    static void sanitiseMatrix(TMatrixDSym &matrix) {
         const int rows = matrix.GetNrows();
         const int cols = matrix.GetNcols();
         for (int i = 0; i < rows; ++i) {


### PR DESCRIPTION
## Summary
- Fix `sanitiseMatrix` to use the correct matrix parameter

## Testing
- `cmake -S . -B build` *(fails: FindROOT.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bce060d30c832ea134aac3a66300ae