### PR TITLE
chore: fix indentation in PerformancePlot

### DIFF
--- a/libplot/PerformancePlot.h
+++ b/libplot/PerformancePlot.h
@@ -12,39 +12,39 @@
 namespace analysis {
 
 class PerformancePlot : public IHistogramPlot {
-  public:
-    PerformancePlot(std::string plot_name, std::vector<double> signal_eff, std::vector<double> background_rej,
-                    std::string output_directory = "plots")
-        : IHistogramPlot(std::move(plot_name), std::move(output_directory)), signal_eff_(std::move(signal_eff)),
-          background_rej_(std::move(background_rej)) {}
+    public:
+        PerformancePlot(std::string plot_name, std::vector<double> signal_eff, std::vector<double> background_rej,
+                        std::string output_directory = "plots")
+            : IHistogramPlot(std::move(plot_name), std::move(output_directory)), signal_eff_(std::move(signal_eff)),
+              background_rej_(std::move(background_rej)) {}
 
-  private:
-    void draw(TCanvas &canvas) override {
-        canvas.cd();
-        int n = signal_eff_.size();
-        TGraph graph(n);
-        for (int i = 0; i < n; ++i)
-            graph.SetPoint(i, signal_eff_[i], background_rej_[i]);
+    private:
+        void draw(TCanvas &canvas) override {
+            canvas.cd();
+            int n = signal_eff_.size();
+            TGraph graph(n);
+            for (int i = 0; i < n; ++i)
+                graph.SetPoint(i, signal_eff_[i], background_rej_[i]);
 
-        const int colour_offset = 1;
-        const int line_width = 2;
-        const int marker_style = 20;
-        const double axis_min = 0.0;
-        const double axis_max = 1.0;
+            const int colour_offset = 1;
+            const int line_width = 2;
+            const int marker_style = 20;
+            const double axis_min = 0.0;
+            const double axis_max = 1.0;
 
-        graph.SetLineColor(kBlue + colour_offset);
-        graph.SetLineWidth(line_width);
-        graph.SetMarkerColor(kBlue + colour_offset);
-        graph.SetMarkerStyle(marker_style);
-        graph.GetXaxis()->SetTitle("Signal Efficiency");
-        graph.GetYaxis()->SetTitle("Background Rejection");
-        graph.GetXaxis()->SetLimits(axis_min, axis_max);
-        graph.GetYaxis()->SetRangeUser(axis_min, axis_max);
-        graph.DrawClone("ALP");
-    }
+            graph.SetLineColor(kBlue + colour_offset);
+            graph.SetLineWidth(line_width);
+            graph.SetMarkerColor(kBlue + colour_offset);
+            graph.SetMarkerStyle(marker_style);
+            graph.GetXaxis()->SetTitle("Signal Efficiency");
+            graph.GetYaxis()->SetTitle("Background Rejection");
+            graph.GetXaxis()->SetLimits(axis_min, axis_max);
+            graph.GetYaxis()->SetRangeUser(axis_min, axis_max);
+            graph.DrawClone("ALP");
+        }
 
-    std::vector<double> signal_eff_;
-    std::vector<double> background_rej_;
+        std::vector<double> signal_eff_;
+        std::vector<double> background_rej_;
 };
 
 }


### PR DESCRIPTION
## Summary
- use 4-space indentation for PerformancePlot header to align with project style

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bce26ff59c832ebb4c3dbc23df38d1