### PR TITLE
Standardize plot header style

### DIFF
--- a/libplot/DetectorDisplay.h
+++ b/libplot/DetectorDisplay.h
@@ -1,9 +1,13 @@
 #ifndef DETECTORDISPLAY_H
 #define DETECTORDISPLAY_H
 
-#include "IEventDisplay.h"
-#include "TH2F.h"
+#include <string>
 #include <vector>
+
+#include "TCanvas.h"
+#include "TH2F.h"
+
+#include "IEventDisplay.h"
 
 namespace analysis {
 

--- a/libplot/IEventDisplay.h
+++ b/libplot/IEventDisplay.h
@@ -1,11 +1,13 @@
 #ifndef IEVENTDISPLAY_H
 #define IEVENTDISPLAY_H
 
-#include "Logger.h"
-#include "TCanvas.h"
-#include "TSystem.h"
 #include <string>
 #include <utility>
+
+#include "TCanvas.h"
+#include "TSystem.h"
+
+#include "Logger.h"
 
 namespace analysis {
 

--- a/libplot/IHistogramPlot.h
+++ b/libplot/IHistogramPlot.h
@@ -1,19 +1,21 @@
 #ifndef IHISTOGRAMPLOT_H
 #define IHISTOGRAMPLOT_H
 
-#include "BinnedHistogram.h"
+#include <string>
+#include <sys/stat.h>
+
 #include "TCanvas.h"
 #include "TColor.h"
 #include "TROOT.h"
 #include "TStyle.h"
 #include "TSystem.h"
-#include <string>
-#include <sys/stat.h>
+
+#include "BinnedHistogram.h"
 
 namespace analysis {
 
 class IHistogramPlot {
-public:
+  public:
     IHistogramPlot(std::string plot_name, std::string output_directory = "plots")
         : plot_name_(std::move(plot_name)),
           output_directory_(std::move(output_directory)) {
@@ -38,7 +40,7 @@ public:
         return s;
     }
 
-protected:
+  protected:
     virtual void setGlobalStyle() const {
         const int font_style = 42;
         TStyle *style = new TStyle("PlotterStyle", "Plotter Style");

--- a/libplot/MatrixPlot.h
+++ b/libplot/MatrixPlot.h
@@ -6,22 +6,21 @@
 #include <utility>
 #include <vector>
 
-#include "AnalysisDataLoader.h"
-#include "AnalysisResult.h"
-#include "HistogramCut.h"
-#include "QuadTreeBinning.h"
-#include "SelectionQuery.h"
-
 #include "TCanvas.h"
 #include "TH2F.h"
 #include "TStyle.h"
 
+#include "AnalysisDataLoader.h"
+#include "AnalysisResult.h"
+#include "HistogramCut.h"
 #include "IHistogramPlot.h"
+#include "QuadTreeBinning.h"
+#include "SelectionQuery.h"
 
 namespace analysis {
 
 class MatrixPlot : public IHistogramPlot {
-public:
+  public:
     MatrixPlot(std::string plot_name, const VariableResult &x_res,
                const VariableResult &y_res, AnalysisDataLoader &loader,
                const SelectionQuery &selection,
@@ -49,7 +48,7 @@ public:
 
     ~MatrixPlot() override { delete hist_; }
 
-    private:
+  private:
     static std::pair<std::vector<double>, std::vector<double>>
     determineEdges(AnalysisDataLoader &loader, const VariableResult &x_res,
                    const VariableResult &y_res) {

--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -19,7 +19,7 @@
 namespace analysis {
 
 class PlotCatalog {
-public:
+  public:
     PlotCatalog(AnalysisDataLoader &loader, int image_size,
                 const std::string &output_directory = "./plots")
         : loader_(loader), image_size_(image_size) {
@@ -29,12 +29,12 @@ public:
     }
 
     void generateStackedPlot(const AnalysisResult &res,
-                                const std::string &variable,
-                                const std::string &region,
-                                const std::string &category_column,
-                                bool overlay_signal = true,
-                                const std::vector<Cut> &cut_list = {},
-                                bool annotate_numbers = true) const {
+                             const std::string &variable,
+                             const std::string &region,
+                             const std::string &category_column,
+                             bool overlay_signal = true,
+                             const std::vector<Cut> &cut_list = {},
+                             bool annotate_numbers = true) const {
         const auto &result = this->fetchResult(res, variable, region);
         std::string name =
             "stacked_" + IHistogramPlot::sanitise(variable) + "_" +
@@ -73,7 +73,8 @@ public:
     void generateMatrixPlot(const AnalysisResult &res,
                             const std::string &x_variable,
                             const std::string &y_variable,
-                            const std::string &region, const SelectionQuery &selection,
+                            const std::string &region,
+                            const SelectionQuery &selection,
                             const std::vector<Cut> &x_cuts = {},
                             const std::vector<Cut> &y_cuts = {}) const {
         const auto &x_res = this->fetchResult(res, x_variable, region);
@@ -89,10 +90,10 @@ public:
         plot.drawAndSave();
     }
 
-private:
+  private:
     const VariableResult &fetchResult(const AnalysisResult &res,
-                                        const std::string &variable,
-                                        const std::string &region) const {
+                                      const std::string &variable,
+                                      const std::string &region) const {
         RegionKey rkey{region};
         VariableKey vkey{variable};
         if (res.hasResult(rkey, vkey)) {

--- a/libplot/SelectionEfficiencyPlot.h
+++ b/libplot/SelectionEfficiencyPlot.h
@@ -2,8 +2,8 @@
 #define SELECTIONEFFICIENCYPLOT_H
 
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "TGraphErrors.h"
 #include "TH1F.h"
@@ -16,7 +16,7 @@
 namespace analysis {
 
 class SelectionEfficiencyPlot : public IHistogramPlot {
-public:
+  public:
     SelectionEfficiencyPlot(std::string plot_name, std::vector<std::string> stages, std::vector<double> efficiencies,
                             std::vector<double> efficiency_errors, std::vector<double> purities,
                             std::vector<double> purity_errors, std::string output_directory = "plots",
@@ -25,7 +25,7 @@ public:
             efficiencies_(std::move(efficiencies)), efficiency_errors_(std::move(efficiency_errors)),
             purities_(std::move(purities)), purity_errors_(std::move(purity_errors)), use_log_y_(use_log_y) {}
 
-private:
+  private:
     void draw(TCanvas &canvas) override {
         int n = stages_.size();
         TH1F frame("frame", "", n, 0, n);

--- a/libplot/SemanticDisplay.h
+++ b/libplot/SemanticDisplay.h
@@ -1,21 +1,25 @@
 #ifndef SEMANTICDISPLAY_H
 #define SEMANTICDISPLAY_H
 
-#include "IEventDisplay.h"
+#include <string>
+#include <vector>
+
+#include "TCanvas.h"
 #include "TColor.h"
 #include "TH2F.h"
 #include "TStyle.h"
-#include <vector>
+
+#include "IEventDisplay.h"
 
 namespace analysis {
 
 class SemanticDisplay : public IEventDisplay {
-    public:
-        SemanticDisplay(std::string tag, std::vector<int> data, int image_size, std::string output_directory)
-            : IEventDisplay(std::move(tag), image_size, std::move(output_directory)), data_(std::move(data)) {}
+  public:
+    SemanticDisplay(std::string tag, std::vector<int> data, int image_size, std::string output_directory)
+        : IEventDisplay(std::move(tag), image_size, std::move(output_directory)), data_(std::move(data)) {}
 
-    protected:
-        void draw(TCanvas &) override {
+  protected:
+    void draw(TCanvas &) override {
             const int palette_size = 10;
             const int palette_step = 2;
             const int bin_offset = 1;
@@ -43,8 +47,8 @@ class SemanticDisplay : public IEventDisplay {
             hist.Draw("COL");
         }
 
-    private:
-        std::vector<int> data_;
+  private:
+    std::vector<int> data_;
 };
 
 }

--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -6,7 +6,9 @@
 #include <map>
 #include <numeric>
 #include <sstream>
+#include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "TArrow.h"
@@ -18,13 +20,14 @@
 #include "TLine.h"
 #include "TPad.h"
 
-#include "VariableResult.h"
 #include "HistogramCut.h"
 #include "IHistogramPlot.h"
 #include "RegionAnalysis.h"
 #include "StratifierRegistry.h"
+#include "VariableResult.h"
 
 namespace analysis {
+
 class StackedHistogramPlot : public IHistogramPlot {
   public:
     StackedHistogramPlot(std::string plot_name, const VariableResult &var_result, const RegionAnalysis &region_info,

--- a/libplot/SystematicBreakdownPlot.h
+++ b/libplot/SystematicBreakdownPlot.h
@@ -1,19 +1,19 @@
 #ifndef SYSTEMATICBREAKDOWNPLOT_H
 #define SYSTEMATICBREAKDOWNPLOT_H
 
-#include <string>
-#include <vector>
 #include <algorithm>
 #include <cmath>
+#include <string>
+#include <vector>
 
+#include "TCanvas.h"
+#include "TColor.h"
 #include "TH1D.h"
 #include "THStack.h"
 #include "TLegend.h"
-#include "TCanvas.h"
-#include "TColor.h"
 
-#include "VariableResult.h"
 #include "IHistogramPlot.h"
+#include "VariableResult.h"
 
 namespace analysis {
 

--- a/libplot/UnstackedHistogramPlot.h
+++ b/libplot/UnstackedHistogramPlot.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <numeric>
 #include <sstream>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -20,11 +21,11 @@
 #include "TLine.h"
 #include "TPad.h"
 
-#include "VariableResult.h"
 #include "HistogramCut.h"
 #include "IHistogramPlot.h"
 #include "RegionAnalysis.h"
 #include "StratifierRegistry.h"
+#include "VariableResult.h"
 
 namespace analysis {
 


### PR DESCRIPTION
## Summary
- Group standard, ROOT, and project includes in a consistent order across all plot headers
- Add missing header dependencies and apply uniform access-specifier indentation

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bce3cd7d08832e8d7298f9176959a5