### PR TITLE
Qualify member function calls with this

### DIFF
--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -370,7 +370,7 @@ class StackedHistogramPlot : public IHistogramPlot {
 
         TPad *p_main;
         TPad *p_legend;
-        setupPads(canvas, p_main, p_legend);
+        this->setupPads(canvas, p_main, p_legend);
 
         std::vector<std::pair<ChannelKey, BinnedHistogram>> mc_hists;
         double total_mc_events;
@@ -379,17 +379,17 @@ class StackedHistogramPlot : public IHistogramPlot {
         double min_edge;
         double max_edge;
         std::vector<double> orig_edges =
-            prepareHistograms(mc_hists, total_mc_events, left_edge, right_edge, min_edge, max_edge);
+            this->prepareHistograms(mc_hists, total_mc_events, left_edge, right_edge, min_edge, max_edge);
 
-        buildLegend(p_legend, mc_hists);
+        this->buildLegend(p_legend, mc_hists);
 
-        double max_y = drawStack(p_main, mc_hists, orig_edges);
+        double max_y = this->drawStack(p_main, mc_hists, orig_edges);
 
-        renderCuts(max_y);
+        this->renderCuts(max_y);
 
-        configureAxes(orig_edges, left_edge, right_edge, min_edge, max_edge, max_y);
+        this->configureAxes(orig_edges, left_edge, right_edge, min_edge, max_edge, max_y);
 
-        drawWatermark(p_main, total_mc_events);
+        this->drawWatermark(p_main, total_mc_events);
 
         p_main->RedrawAxis();
         canvas.Update();

--- a/libplot/UnstackedHistogramPlot.h
+++ b/libplot/UnstackedHistogramPlot.h
@@ -336,19 +336,19 @@ class UnstackedHistogramPlot : public IHistogramPlot {
         log::info("UnstackedHistogramPlot::draw",
                   "X-axis label from result:", variable_result_.binning_.getTexLabel().c_str());
 
-        auto [p_main, p_legend] = setupPads(canvas);
+        auto [p_main, p_legend] = this->setupPads(canvas);
 
-        auto [mc_hists, total_mc_events] = collectHistograms();
+        auto [mc_hists, total_mc_events] = this->collectHistograms();
 
-        buildLegend(p_legend, mc_hists);
+        this->buildLegend(p_legend, mc_hists);
 
-        double max_y = drawHistograms(p_main, mc_hists);
+        double max_y = this->drawHistograms(p_main, mc_hists);
 
-        renderCuts(max_y);
+        this->renderCuts(max_y);
 
-        configureAxes();
+        this->configureAxes();
 
-        drawWatermark(p_main, total_mc_events);
+        this->drawWatermark(p_main, total_mc_events);
 
         p_main->RedrawAxis();
         canvas.Update();


### PR DESCRIPTION
## Summary
- Qualify internal function calls with `this->` in StackedHistogramPlot::draw
- Qualify internal function calls with `this->` in UnstackedHistogramPlot::draw

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bce60aa31c832e9c1945b95b5a6d29