### PR TITLE
refactor: reformat VariableProcessor

### DIFF
--- a/libapp/VariableProcessor.h
+++ b/libapp/VariableProcessor.h
@@ -18,74 +18,83 @@
 
 namespace analysis {
 
-template <typename SysProc> class VariableProcessor {
-public:
-  VariableProcessor(AnalysisDefinition &def, SysProc &sys_proc,
-                    HistogramFactory &factory)
-      : analysis_definition_(def), systematics_processor_(sys_proc),
-        histogram_factory_(factory) {}
+    template <typename SysProc>
+    class VariableProcessor {
+    public:
+        VariableProcessor(AnalysisDefinition& def, SysProc& sys_proc,
+                          HistogramFactory& factory)
+            : analysis_definition_(def),
+              systematics_processor_(sys_proc),
+              histogram_factory_(factory) {}
 
-  void process(
-      const RegionHandle &region_handle, RegionAnalysis &region_analysis,
-      std::unordered_map<SampleKey, std::unique_ptr<ISampleProcessor>>
-          &sample_processors,
-      std::unordered_map<SampleKey, ROOT::RDF::RNode> &monte_carlo_nodes) {
-    log::info("VariableProcessor::process",
-              "Iterating across observable variables...");
-    const auto &vars = region_handle.vars();
-    size_t var_total = vars.size();
-    size_t var_index = 0;
-    for (const auto &var_key : vars) {
-      ++var_index;
-      const auto &variable_handle = analysis_definition_.variable(var_key);
-      const auto &binning = variable_handle.binning();
-      auto model = binning.toTH1DModel();
+        void process(
+            const RegionHandle& region_handle,
+            RegionAnalysis& region_analysis,
+            std::unordered_map<SampleKey, std::unique_ptr<ISampleProcessor>>& sample_processors,
+            std::unordered_map<SampleKey, ROOT::RDF::RNode>& monte_carlo_nodes) {
+            log::info("VariableProcessor::process",
+                      "Iterating across observable variables...");
 
-      VariableResult result;
-      result.binning_ = binning;
+            const auto& vars = region_handle.vars();
+            const auto total_vars = vars.size();
 
-      log::info("VariableProcessor::process",
-                "Deploying variable pipeline (", var_index, "/", var_total,
-                "):", var_key.str());
-      log::info("VariableProcessor::process",
-                "Executing sample processors...");
-      tbb::parallel_for_each(
-          sample_processors.begin(), sample_processors.end(), [&](auto &p) {
-            p.second->book(histogram_factory_, binning, model);
-          });
+            for (std::size_t index = 0; index < total_vars; ++index) {
+                const auto& var_key = vars[index];
+                const auto& variable_handle = analysis_definition_.variable(var_key);
+                const auto& binning = variable_handle.binning();
+                const auto model = binning.toTH1DModel();
 
-      log::info("VariableProcessor::process",
-                "Registering systematic variations...");
-      tbb::parallel_for_each(monte_carlo_nodes.begin(), monte_carlo_nodes.end(),
-                             [&](auto &p) {
-                               systematics_processor_.bookSystematics(
-                                   p.first, p.second, binning, model);
-                             });
+                VariableResult result;
+                result.binning_ = binning;
 
-      log::info("VariableProcessor::process", "Persisting results...");
-      tbb::parallel_for_each(sample_processors.begin(), sample_processors.end(),
-                             [&](auto &p) { p.second->contributeTo(result); });
+                log::info("VariableProcessor::process",
+                          "Deploying variable pipeline (", index + 1, "/", total_vars,
+                          "):", var_key.str());
 
-      log::info("VariableProcessor::process",
-                "Computing systematic covariances");
-      systematics_processor_.processSystematics(result);
-      systematics_processor_.clearFutures();
+                log::info("VariableProcessor::process", "Executing sample processors...");
+                tbb::parallel_for_each(
+                    sample_processors.begin(),
+                    sample_processors.end(),
+                    [&](auto& entry) {
+                        entry.second->book(histogram_factory_, binning, model);
+                    });
 
-      AnalysisResult::printSummary(result);
+                log::info("VariableProcessor::process", "Registering systematic variations...");
+                tbb::parallel_for_each(
+                    monte_carlo_nodes.begin(),
+                    monte_carlo_nodes.end(),
+                    [&](auto& entry) {
+                        systematics_processor_.bookSystematics(
+                            entry.first, entry.second, binning, model);
+                    });
 
-      region_analysis.addFinalVariable(var_key, std::move(result));
+                log::info("VariableProcessor::process", "Persisting results...");
+                tbb::parallel_for_each(
+                    sample_processors.begin(),
+                    sample_processors.end(),
+                    [&](auto& entry) {
+                        entry.second->contributeTo(result);
+                    });
 
-      log::info("VariableProcessor::process",
-                "Variable pipeline concluded (", var_index, "/", var_total,
-                "):", var_key.str());
-    }
-  }
+                log::info("VariableProcessor::process",
+                          "Computing systematic covariances");
+                systematics_processor_.processSystematics(result);
+                systematics_processor_.clearFutures();
 
-private:
-  AnalysisDefinition &analysis_definition_;
-  SysProc &systematics_processor_;
-  HistogramFactory &histogram_factory_;
-};
+                AnalysisResult::printSummary(result);
+                region_analysis.addFinalVariable(var_key, std::move(result));
+
+                log::info("VariableProcessor::process",
+                          "Variable pipeline concluded (", index + 1, "/", total_vars,
+                          "):", var_key.str());
+            }
+        }
+
+    private:
+        AnalysisDefinition& analysis_definition_;
+        SysProc& systematics_processor_;
+        HistogramFactory& histogram_factory_;
+    };
 
 } // namespace analysis
 


### PR DESCRIPTION
## Summary
- improve readability of `VariableProcessor` with consistent 4-space indentation
- streamline variable loop and parallel actions for samples and systematics

## Testing
- `cmake .. && make -j2 && ctest` *(fails: Could not find package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bce7288904832e83ef18af0f870baf