### PR TITLE
Refactor SampleProcessorFactory for clarity

### DIFF
--- a/libapp/SampleProcessorFactory.h
+++ b/libapp/SampleProcessorFactory.h
@@ -21,115 +21,120 @@ namespace analysis {
 
 template <typename Loader> class SampleProcessorFactory {
 public:
-  explicit SampleProcessorFactory(Loader &ldr) : data_loader_(ldr) {}
+    explicit SampleProcessorFactory(Loader &ldr) : data_loader_(ldr) {}
 
-  auto create(const RegionHandle &region_handle,
-              RegionAnalysis &region_analysis)
-      -> std::pair<
-          std::unordered_map<SampleKey, std::unique_ptr<ISampleProcessor>>,
-          std::unordered_map<SampleKey, ROOT::RDF::RNode>> {
-    std::unordered_map<SampleKey, std::unique_ptr<ISampleProcessor>>
-        sample_processors;
-    std::unordered_map<SampleKey, ROOT::RDF::RNode> monte_carlo_nodes;
+    auto create(const RegionHandle &region_handle,
+                RegionAnalysis &region_analysis)
+        -> std::pair<
+            std::unordered_map<SampleKey, std::unique_ptr<ISampleProcessor>>,
+            std::unordered_map<SampleKey, ROOT::RDF::RNode>> {
+        std::unordered_map<SampleKey, std::unique_ptr<ISampleProcessor>>
+            sample_processors;
+        std::unordered_map<SampleKey, ROOT::RDF::RNode> monte_carlo_nodes;
 
-    log::info("SampleProcessorFactory::create",
-              "Processing sample ensemble...");
-    auto &sample_frames = data_loader_.getSampleFrames();
+        log::info("SampleProcessorFactory::create",
+                  "Processing sample ensemble...");
+        const auto &sample_frames = data_loader_.getSampleFrames();
 
-    const std::string region_beam = region_analysis.beamConfig();
-    const auto &region_runs = region_analysis.runNumbers();
+        const std::string region_beam = region_analysis.beamConfig();
+        const auto &region_runs = region_analysis.runNumbers();
+        const auto selection_expr = region_handle.selection().str();
 
-    size_t sample_total = 0;
-    for (auto &[sample_key, _] : sample_frames) {
-      const auto *run_config =
-          data_loader_.getRunConfigForSample(sample_key);
-      if (!isSampleEligible(sample_key, run_config, region_beam,
-                            region_runs))
-        continue;
-      ++sample_total;
-    }
+        const std::size_t sample_total = static_cast<std::size_t>(
+            std::count_if(sample_frames.begin(), sample_frames.end(),
+                          [this, &region_beam, &region_runs](
+                              const auto &entry) {
+                              const auto *run_config =
+                                  data_loader_.getRunConfigForSample(
+                                      entry.first);
+                              return isSampleEligible(entry.first, run_config,
+                                                      region_beam,
+                                                      region_runs);
+                          }));
 
-    size_t sample_index = 0;
-    std::set<std::string> accounted_runs;
-    for (auto &[sample_key, sample_def] : sample_frames) {
-      const auto *run_config =
-          data_loader_.getRunConfigForSample(sample_key);
-      if (!isSampleEligible(sample_key, run_config, region_beam,
-                            region_runs))
-        continue;
-      ++sample_index;
+        const auto applySelection = [&](auto df) {
+            return selection_expr.empty() ? df : df.Filter(selection_expr);
+        };
 
-      if (accounted_runs.insert(run_config->label()).second) {
-        region_analysis.addProtonsOnTarget(run_config->nominal_pot);
-      }
-      log::info("SampleProcessorFactory::create",
-                "--> Conditioning sample (", sample_index, "/",
-                sample_total, "):", sample_key.str());
+        std::size_t sample_index = 0;
+        std::set<std::string> accounted_runs;
+        for (auto &[sample_key, sample_def] : sample_frames) {
+            const auto *run_config =
+                data_loader_.getRunConfigForSample(sample_key);
+            if (!isSampleEligible(sample_key, run_config, region_beam,
+                                  region_runs)) {
+                continue;
+            }
+            ++sample_index;
 
-      auto region_df = sample_def.nominal_node_;
-      auto selection_expr = region_handle.selection().str();
-      if (!selection_expr.empty()) {
-        region_df = region_df.Filter(selection_expr);
-      }
+            if (accounted_runs.insert(run_config->label()).second) {
+                region_analysis.addProtonsOnTarget(run_config->nominal_pot);
+            }
+            log::info("SampleProcessorFactory::create",
+                      "--> Conditioning sample (", sample_index, "/",
+                      sample_total, "):", sample_key.str());
 
-      log::info("SampleProcessorFactory::create",
-                "Configuring systematic variations...");
-      std::unordered_map<SampleVariation, SampleDataset> variation_datasets;
-      for (auto &[variation_type, variation_node] :
-           sample_def.variation_nodes_) {
-        auto variation_df = variation_node;
-        if (!selection_expr.empty()) {
-          variation_df = variation_df.Filter(selection_expr);
+            auto region_df = applySelection(sample_def.nominal_node_);
+
+            log::info("SampleProcessorFactory::create",
+                      "Configuring systematic variations...");
+            std::unordered_map<SampleVariation, SampleDataset>
+                variation_datasets;
+            for (auto &[variation_type, variation_node] :
+                 sample_def.variation_nodes_) {
+                variation_datasets.emplace(
+                    variation_type,
+                    SampleDataset{sample_def.sample_origin_,
+                                  AnalysisRole::kVariation,
+                                  applySelection(variation_node)});
+            }
+
+            SampleDataset nominal_dataset{sample_def.sample_origin_,
+                                          AnalysisRole::kNominal, region_df};
+            SampleDatasetGroup ensemble{std::move(nominal_dataset),
+                                        std::move(variation_datasets)};
+
+            if (sample_def.isData()) {
+                sample_processors[sample_key] =
+                    std::make_unique<DataProcessor>(
+                        std::move(ensemble.nominal_));
+            } else {
+                monte_carlo_nodes.emplace(sample_key, region_df);
+                sample_processors[sample_key] =
+                    std::make_unique<MonteCarloProcessor>(
+                        sample_key, std::move(ensemble));
+            }
         }
-        variation_datasets.emplace(variation_type,
-                                   SampleDataset{sample_def.sample_origin_,
-                                                 AnalysisRole::kVariation,
-                                                 variation_df});
-      }
 
-      SampleDataset nominal_dataset{sample_def.sample_origin_,
-                                    AnalysisRole::kNominal, region_df};
-      SampleDatasetGroup ensemble{std::move(nominal_dataset),
-                                  std::move(variation_datasets)};
+        log::info("SampleProcessorFactory::create",
+                  "Sample processing sequence complete.");
 
-      if (sample_def.isData()) {
-        sample_processors[sample_key] =
-            std::make_unique<DataProcessor>(
-                std::move(ensemble.nominal_));
-      } else {
-        monte_carlo_nodes.emplace(sample_key, region_df);
-        sample_processors[sample_key] =
-            std::make_unique<MonteCarloProcessor>(sample_key,
-                                                 std::move(ensemble));
-      }
+        return {std::move(sample_processors), std::move(monte_carlo_nodes)};
     }
 
-    log::info("SampleProcessorFactory::create",
-              "Sample processing sequence complete.");
+    static bool isSampleEligible(const SampleKey &sample_key,
+                                 const RunConfig *run_config,
+                                 const std::string &region_beam,
+                                 const std::vector<std::string> &region_runs) {
+        static_cast<void>(sample_key);
 
-    return {std::move(sample_processors), std::move(monte_carlo_nodes)};
-  }
+        if (!run_config) {
+            return false;
+        }
+        if (!region_beam.empty() && run_config->beam_mode != region_beam) {
+            return false;
+        }
+        if (!region_runs.empty() &&
+            std::find(region_runs.begin(), region_runs.end(),
+                      run_config->run_period) == region_runs.end()) {
+            return false;
+        }
 
-  static bool isSampleEligible(const SampleKey &sample_key,
-                               const RunConfig *run_config,
-                               const std::string &region_beam,
-                               const std::vector<std::string> &region_runs) {
-    static_cast<void>(sample_key);
-
-    if (!run_config)
-      return false;
-    if (!region_beam.empty() && run_config->beam_mode != region_beam)
-      return false;
-    if (!region_runs.empty() &&
-        std::find(region_runs.begin(), region_runs.end(),
-                  run_config->run_period) == region_runs.end())
-      return false;
-
-    return true;
-  }
+        return true;
+    }
 
 private:
-  Loader &data_loader_;
+    Loader &data_loader_;
 };
 
 } // namespace analysis


### PR DESCRIPTION
## Summary
- Refactor SampleProcessorFactory to use explicit lambda capture and typed counts for clearer iteration
- Apply const references and 4-space indentation throughout for improved readability

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: command not found)*
- `source .build.sh` *(fails: Could not find ROOTConfig.cmake)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bce6f986cc832e96396cbf81ce700c