### PR TITLE
style: improve CutFlowCalculator readability

### DIFF
--- a/libapp/CutFlowCalculator.h
+++ b/libapp/CutFlowCalculator.h
@@ -14,104 +14,109 @@
 
 namespace analysis {
 
-template <typename Loader> class CutFlowCalculator {
+template <typename Loader>
+class CutFlowCalculator {
 public:
-  CutFlowCalculator(Loader &ldr, AnalysisDefinition &def)
-      : data_loader_(ldr), analysis_definition_(def) {}
+    CutFlowCalculator(Loader &ldr, AnalysisDefinition &def)
+        : data_loader_(ldr), analysis_definition_(def) {}
 
-  void compute(const RegionHandle &region_handle,
-               RegionAnalysis &region_analysis) {
-    auto &sample_frames = data_loader_.getSampleFrames();
+    void compute(const RegionHandle &region_handle,
+                 RegionAnalysis &region_analysis) {
+        auto &sample_frames = data_loader_.getSampleFrames();
+        auto clauses = analysis_definition_.regionClauses(region_handle.key_);
+        auto cumulative_filters = buildCumulativeFilters(clauses);
 
-    auto clauses = analysis_definition_.regionClauses(region_handle.key_);
+        std::vector<RegionAnalysis::StageCount> stage_counts(
+            cumulative_filters.size());
 
-    auto cumulative_filters = buildCumulativeFilters(clauses);
+        StratifierRegistry strat_reg;
+        const std::vector<std::string> schemes{
+            "inclusive_strange_channels", "exclusive_strange_channels"};
+        std::unordered_map<std::string, std::vector<int>> scheme_keys;
 
-    std::vector<RegionAnalysis::StageCount> stage_counts(
-        cumulative_filters.size());
+        for (const auto &scheme : schemes) {
+            for (const auto &key :
+                 strat_reg.getAllStratumKeysForScheme(scheme)) {
+                scheme_keys[scheme].push_back(std::stoi(key.str()));
+            }
+        }
 
-    StratifierRegistry strat_reg;
-    std::vector<std::string> schemes{"inclusive_strange_channels",
-                                     "exclusive_strange_channels"};
-    std::unordered_map<std::string, std::vector<int>> scheme_keys;
+        for (auto &[skey, sample_def] : sample_frames) {
+            if (!sample_def.isMc()) {
+                continue;
+            }
 
-    for (auto &s : schemes)
-      for (auto &k : strat_reg.getAllStratumKeysForScheme(s))
-        scheme_keys[s].push_back(std::stoi(k.str()));
+            auto base_df = sample_def.nominal_node_.Define(
+                "w2", "nominal_event_weight*nominal_event_weight");
 
-    for (auto &[skey, sample_def] : sample_frames) {
-      if (!sample_def.isMc())
-        continue;
+            calculateWeightsPerStage(base_df, cumulative_filters, stage_counts,
+                                     schemes, scheme_keys);
+        }
 
-      auto base_df = sample_def.nominal_node_.Define(
-          "w2", "nominal_event_weight*nominal_event_weight");
-
-      calculateWeightsPerStage(base_df, cumulative_filters, stage_counts,
-                               schemes, scheme_keys);
+        region_analysis.setCutFlow(std::move(stage_counts));
     }
 
-    region_analysis.setCutFlow(std::move(stage_counts));
-  }
+    static std::vector<std::string>
+    buildCumulativeFilters(const std::vector<std::string> &clauses) {
+        std::vector<std::string> filters{ "" };
+        std::string current;
 
-  static std::vector<std::string>
-  buildCumulativeFilters(const std::vector<std::string> &clauses) {
-    std::vector<std::string> filters{""};
+        for (const auto &clause : clauses) {
+            if (!current.empty()) {
+                current += " && ";
+            }
 
-    std::string current;
+            current += clause;
+            filters.push_back(current);
+        }
 
-    for (const auto &clause : clauses) {
-      if (!current.empty())
-        current += " && ";
-
-      current += clause;
-
-      filters.push_back(current);
+        return filters;
     }
-
-    return filters;
-  }
 
 private:
-  void updateSchemeTallies(
-      ROOT::RDF::RNode df, const std::vector<std::string> &schemes,
-      const std::unordered_map<std::string, std::vector<int>> &scheme_keys,
-      RegionAnalysis::StageCount &stage_count) {
-    for (auto &s : schemes)
-      for (int key : scheme_keys.at(s)) {
-        auto ch_df = df.Filter(s + " == " + std::to_string(key));
+    void updateSchemeTallies(
+        ROOT::RDF::RNode df,
+        const std::vector<std::string> &schemes,
+        const std::unordered_map<std::string, std::vector<int>> &scheme_keys,
+        RegionAnalysis::StageCount &stage_count) {
+        for (const auto &scheme : schemes) {
+            for (int key : scheme_keys.at(scheme)) {
+                auto ch_df = df.Filter(scheme + " == " + std::to_string(key));
 
-        auto ch_w = ch_df.Sum<double>("nominal_event_weight");
-        auto ch_w2 = ch_df.Sum<double>("w2");
+                auto ch_w = ch_df.Sum<double>("nominal_event_weight");
+                auto ch_w2 = ch_df.Sum<double>("w2");
 
-        stage_count.schemes[s][key].first += ch_w.GetValue();
-        stage_count.schemes[s][key].second += ch_w2.GetValue();
-      }
-  }
-
-  void calculateWeightsPerStage(
-      const ROOT::RDF::RNode &base_df,
-      const std::vector<std::string> &cumulative_filters,
-      std::vector<RegionAnalysis::StageCount> &stage_counts,
-      const std::vector<std::string> &schemes,
-      const std::unordered_map<std::string, std::vector<int>> &scheme_keys) {
-    for (size_t i = 0; i < cumulative_filters.size(); ++i) {
-      auto df = base_df;
-
-      if (!cumulative_filters[i].empty())
-        df = df.Filter(cumulative_filters[i]);
-
-      auto tot_w = df.Sum<double>("nominal_event_weight");
-      auto tot_w2 = df.Sum<double>("w2");
-
-      stage_counts[i].total += tot_w.GetValue();
-      stage_counts[i].total_w2 += tot_w2.GetValue();
-
-      updateSchemeTallies(df, schemes, scheme_keys, stage_counts[i]);
+                stage_count.schemes[scheme][key].first += ch_w.GetValue();
+                stage_count.schemes[scheme][key].second += ch_w2.GetValue();
+            }
+        }
     }
-  }
 
-  Loader &data_loader_;
-  AnalysisDefinition &analysis_definition_;
+    void calculateWeightsPerStage(
+        const ROOT::RDF::RNode &base_df,
+        const std::vector<std::string> &cumulative_filters,
+        std::vector<RegionAnalysis::StageCount> &stage_counts,
+        const std::vector<std::string> &schemes,
+        const std::unordered_map<std::string, std::vector<int>> &scheme_keys) {
+        for (size_t i = 0; i < cumulative_filters.size(); ++i) {
+            auto df = base_df;
+
+            if (!cumulative_filters[i].empty()) {
+                df = df.Filter(cumulative_filters[i]);
+            }
+
+            auto tot_w = df.Sum<double>("nominal_event_weight");
+            auto tot_w2 = df.Sum<double>("w2");
+
+            stage_counts[i].total += tot_w.GetValue();
+            stage_counts[i].total_w2 += tot_w2.GetValue();
+
+            updateSchemeTallies(df, schemes, scheme_keys, stage_counts[i]);
+        }
+    }
+
+    Loader &data_loader_;
+    AnalysisDefinition &analysis_definition_;
 };
 
 } // namespace analysis


### PR DESCRIPTION
## Summary
- refactor CutFlowCalculator for clarity and use four-space indentation

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bce77bf040832ea4663e6186761d85