### PR TITLE
Fix compile error by updating plotBeamline signature

### DIFF
--- a/plot.cpp
+++ b/plot.cpp
@@ -17,7 +17,7 @@ static void plotBeamline(analysis::RunConfigRegistry &run_config_registry,
                          const std::string &beam,
                          const nlohmann::json &runs,
                          const nlohmann::json &plotting,
-                         const analysis::AnalysisResult::BeamResult &beam_result) {
+                         const analysis::AnalysisResult &beam_result) {
     std::vector<std::string> periods;
     periods.reserve(runs.size());
 


### PR DESCRIPTION
## Summary
- use `AnalysisResult` instead of non-existent `AnalysisResult::BeamResult` in `plotBeamline`

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOTConfig.cmake)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bcee74392c832ebb10866c9cd7a3c7