### PR TITLE
Save analysis output to user scratch directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ python scripts/generate_analysis_config.py
 
 ## Running
 ```bash
-./build/analyse config/config.json output.root
 ./build/analyse config/config.json config/plugins/selection_efficiency.json output.root
-./build/plot output.root config/config.json
+# The ROOT file is written to /pnfs/uboone/scratch/users/$USER/output.root
+./build/plot /pnfs/uboone/scratch/users/$USER/output.root config/config.json
 ```
 `analyse` executes the analysis and optional plug-ins. `plot` renders figures using the produced ROOT file.
 

--- a/analyse.cpp
+++ b/analyse.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cstdlib>
 
 #include <ROOT/RDataFrame.hxx>
 #include <nlohmann/json.hpp>
@@ -83,10 +84,19 @@ int main(int argc, char *argv[]) {
     try {
         nlohmann::json cfg = analysis::loadJson(argv[1]);
         nlohmann::json plg = analysis::loadJson(argv[2]);
-        const char *output_path = argv[3];
+
+        const char *user_env = std::getenv("USER");
+        std::string scratch_dir = "/pnfs/uboone/scratch/users/";
+        if (user_env) {
+            scratch_dir += user_env;
+        } else {
+            scratch_dir += "unknown";
+        }
+        scratch_dir += "/";
+        std::string output_path = scratch_dir + argv[3];
 
         auto result = runAnalysis(cfg.at("samples"), plg.at("analysis"));
-        result.saveToFile(output_path);
+        result.saveToFile(output_path.c_str());
     } catch (const std::exception &e) {
         analysis::log::fatal("analyse::main", "An error occurred:", e.what());
         return 1;


### PR DESCRIPTION
## Summary
- Store analysis results in `/pnfs/uboone/scratch/users/$USER/`, auto-generating the full path from the user's environment.
- Document the new default output location and plotting usage in README.

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: could not find package ROOT)*
- `ctest --output-on-failure` *(no tests found, build not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf7720288832eb9a1473e6f553de5