### PR TITLE
feat: support separate core and detvar xmls

### DIFF
--- a/config/aggregate_samples.py
+++ b/config/aggregate_samples.py
@@ -165,7 +165,8 @@ def process_sample_entry(
 def main() -> None:
     DEFINITIONS_PATH = "config/data.json"
     XML_PATHS = [
-        "/exp/uboone/app/users/nlane/production/strangeness_mcc9/srcs/ubana/ubana/searchingforstrangeness/xml/numi_fhc_workflow.xml"
+        "/exp/uboone/app/users/nlane/production/strangeness_mcc9/srcs/ubana/ubana/searchingforstrangeness/xml/numi_fhc_workflow_core.xml",
+        "/exp/uboone/app/users/nlane/production/strangeness_mcc9/srcs/ubana/ubana/searchingforstrangeness/xml/numi_fhc_workflow_detvar.xml",
     ]
     CONFIG_PATH = "config/samples.json"
     RUNS_PROCESS = ["run1"]

--- a/config/aggregate_xml.py
+++ b/config/aggregate_xml.py
@@ -1,0 +1,4 @@
+from aggregate_samples import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- handle core and detvar workflow xmls when aggregating sample metadata
- add small wrapper script `aggregate_xml.py` for convenience

## Testing
- `python -m pytest`
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bcfbffc7a8832e98a22ee4d579f58b