### PR TITLE
Map beams to software trigger branch

### DIFF
--- a/config/aggregate_samples.py
+++ b/config/aggregate_samples.py
@@ -13,10 +13,9 @@ import uproot
 
 from trigger_counts import get_trigger_counts_from_files_parallel
 
-# Map beamlines and run periods to the trigger branch to retain. Update as needed.
 TRIGGER_BRANCH_MAP: dict[str, dict[str, str]] = {
-    "numi": {},
-    "bnb": {},
+    "numi": {"run1": "software_trigger"},
+    "bnb": {"run1": "software_trigger"},
 }
 
 


### PR DESCRIPTION
## Summary
- map numi and bnb run1 trigger branches to `software_trigger`
- remove superfluous comments in `aggregate_samples`

## Testing
- `python -m py_compile config/aggregate_samples.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd8a2db718832ea3cc48d30e9a7148