### PR TITLE
Remove defunct aggregate_xml wrapper

### DIFF
--- a/config/aggregate_xml.py
+++ b/config/aggregate_xml.py
@@ -1,4 +1,0 @@
-from aggregate_samples import main
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- remove obsolete `config/aggregate_xml.py` wrapper that just re-exported `aggregate_samples.main`

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bd8a3d2574832ebc1b0ae99512a50d