### PR TITLE
feat: support new workflow stage names

### DIFF
--- a/config/aggregate_samples.py
+++ b/config/aggregate_samples.py
@@ -66,9 +66,13 @@ def get_total_pot_from_files_parallel(file_paths: list[str]) -> float:
 
 
 def resolve_input_dir(stage_name: str | None, stage_outdirs: dict, entities: dict) -> str | None:
-    if not stage_name or stage_name not in stage_outdirs:
+    if not stage_name:
         return None
-    input_dir = stage_outdirs[stage_name]
+
+    input_dir = stage_outdirs.get(stage_name)
+    if not input_dir:
+        return None
+
     for name, value in entities.items():
         input_dir = input_dir.replace(f"&{name};", value)
     return input_dir


### PR DESCRIPTION
## Summary
- resolve input directories using stage names and outdirs defined in XML

## Testing
- `python -m py_compile config/aggregate_samples.py`
- `source .container.sh` *(fails: No such file or directory)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8a7b5640832e82b4b436188745ef