### PR TITLE
Update run1 sample definitions

### DIFF
--- a/config/data.json
+++ b/config/data.json
@@ -8,7 +8,7 @@
                 "samples": [
                     {
                         "sample_key": "mc_inclusive_run1_fhc",
-                        "stage_name": "selection_numi_fhc_run1_beam",
+                        "stage_name": "selection_beam",
                         "sample_type": "mc",
                         "active": true,
                         "do_hadd": true,
@@ -20,14 +20,14 @@
                                 "sample_key": "mc_inclusive_run1_fhc_detvar_cv",
                                 "variation_type": "cv",
                                 "stage_name": "selection_detvar_cv",
-                                "active": false,
-                                "do_hadd": false
+                                "active": true,
+                                "do_hadd": true
                             }
                         ]
                     },
                     {
                         "sample_key": "mc_strangeness_run1_fhc",
-                        "stage_name": "selection_numi_fhc_run1_strangeness",
+                        "stage_name": "selection_strangeness",
                         "sample_type": "mc",
                         "active": true,
                         "do_hadd": true,
@@ -36,18 +36,25 @@
                             {
                                 "sample_key": "mc_strangeness_run1_fhc_detvar_cv",
                                 "variation_type": "cv",
-                                "stage_name": "selection_detvar_cv_strangeness",
-                                "active": false,
-                                "do_hadd": false
+                                "stage_name": "selection_detvar_cv",
+                                "active": true,
+                                "do_hadd": true
                             }
                         ]
                     },
                     {
+                        "sample_key": "mc_dirt_run1_fhc",
+                        "stage_name": "selection_dirt",
+                        "sample_type": "mc",
+                        "active": true,
+                        "do_hadd": true
+                    },
+                    {
                         "sample_key": "numu_fhc_ext",
-                        "stage_name": "selection_numi_fhc_run1_ext",
+                        "stage_name": "selection_ext",
                         "sample_type": "ext",
-                        "active": false,
-                        "do_hadd": false
+                        "active": true,
+                        "do_hadd": true
                     }
                 ]
             }


### PR DESCRIPTION
## Summary
- revise run1 configuration to use simplified stage names and enable detector variations
- add dedicated dirt sample and activate external data sample

## Testing
- `cmake .. && cmake --build . && ctest` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8d956494832eba7317376cd1e3f2