### PR TITLE
Include POT and trigger counts for external samples

### DIFF
--- a/config/sample_processing.py
+++ b/config/sample_processing.py
@@ -127,10 +127,10 @@ def process_sample_entry(
     trigger_counts = get_trigger_counts_from_files_parallel(source_files)
     selected_triggers = select_trigger_count(trigger_counts, beam, run)
 
-    if sample_type == "mc" or is_detvar:
+    if sample_type in {"mc", "ext"} or is_detvar:
         entry["pot"] = get_total_pot_from_files_parallel(source_files)
         entry["triggers"] = selected_triggers
-        if entry["pot"] == 0.0:
+        if (sample_type == "mc" or is_detvar) and entry["pot"] == 0.0:
             entry["pot"] = nominal_pot
     elif sample_type == "data":
         entry["pot"] = nominal_pot

--- a/config/samples.json
+++ b/config/samples.json
@@ -59,7 +59,9 @@
                             "sample_key": "numu_fhc_ext",
                             "sample_type": "ext",
                             "active": true,
-                            "relative_path": "numu_fhc_ext.root"
+                            "relative_path": "numu_fhc_ext.root",
+                            "pot": 0.0,
+                            "triggers": 0
                         }
                     ]
                 }


### PR DESCRIPTION
## Summary
- Populate POT and trigger counts for `ext` samples by evaluating the ROOT files
- Record placeholder POT and trigger fields for `numu_fhc_ext` in the sample configuration

## Testing
- `ctest --output-on-failure` *(no tests found)*
- `bash .build.sh` *(fails: Could not find a package configuration file provided by ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bd931341e0832e8727b48b30500926