### PR TITLE
Handle POT for data and ext samples

### DIFF
--- a/config/sample_processing.py
+++ b/config/sample_processing.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import numpy as np
@@ -47,10 +48,11 @@ def get_total_pot_from_single_file(file_path: Path) -> float:
         return 0.0
     try:
         with uproot.open(file_path) as root_file:
-            if "nuselection/SubRun" in root_file:
-                subrun_tree = root_file["nuselection/SubRun"]
-                if "pot" in subrun_tree:
-                    return float(subrun_tree["pot"].array(library="np").sum())
+            if "nuselection/SubRun" not in root_file:
+                return 0.0
+            subrun_tree = root_file["nuselection/SubRun"]
+            if "pot" in subrun_tree:
+                return float(subrun_tree["pot"].array(library="np").sum())
     except Exception as exc:
         print(f"    Warning: Could not read POT from {file_path}: {exc}", file=sys.stderr)
     return 0.0
@@ -66,6 +68,72 @@ def resolve_input_dir(stage_name: str | None, stage_outdirs: dict, entities: dic
     for name, value in entities.items():
         input_dir = input_dir.replace(f"&{name};", value)
     return input_dir
+
+def _collect_run_subrun_pairs(file_path: Path) -> set[tuple[int, int]]:
+    pairs: set[tuple[int, int]] = set()
+    try:
+        with uproot.open(file_path) as root_file:
+            if "nuselection/SubRun" not in root_file:
+                return pairs
+            tree = root_file["nuselection/SubRun"]
+            runs = tree["run"].array(library="np") if "run" in tree else None
+            subruns = tree["sub"].array(library="np") if "sub" in tree else None
+            if runs is not None and subruns is not None:
+                for r, s in zip(runs, subruns):
+                    pairs.add((int(r), int(s)))
+    except Exception as exc:
+        print(f"    Warning: Could not read run/subrun from {file_path}: {exc}", file=sys.stderr)
+    return pairs
+
+def _get_pot_from_getdatainfo(tmp_path: Path, sample_type: str) -> float:
+    script_path = Path("/exp/uboone/app/users/guzowski/slip_stacking/getDataInfo.py")
+    command = [str(script_path), "-v3", "--format-numi", "--prescale", "--run-subrun-list", str(tmp_path)]
+    if sample_type == "data":
+        command.append("--slip")
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        lines = result.stdout.strip().splitlines()
+        if len(lines) < 2:
+            return 0.0
+        header = lines[-2].split()
+        values = lines[-1].split()
+        pot_fields = [
+            "tortgt_wcut",
+            "tor875_wcut",
+            "tor101_wcut",
+            "tortgt",
+            "tor875",
+            "tor101",
+        ]
+        for field in pot_fields:
+            if field in header:
+                idx = header.index(field)
+                try:
+                    return float(values[idx])
+                except (ValueError, IndexError):
+                    return 0.0
+        return 0.0
+    except Exception as exc:
+        print(f"    Warning: getDataInfo.py failed: {exc}", file=sys.stderr)
+        return 0.0
+
+def get_data_ext_pot_from_files(file_paths: list[str], sample_type: str) -> float:
+    pairs: set[tuple[int, int]] = set()
+    for file_path in map(Path, file_paths):
+        pairs.update(_collect_run_subrun_pairs(file_path))
+    if not pairs:
+        return 0.0
+    with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+        for run, subrun in sorted(pairs):
+            tmp.write(f"{run} {subrun}\n")
+        tmp_path = Path(tmp.name)
+    try:
+        return _get_pot_from_getdatainfo(tmp_path, sample_type)
+    finally:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
 
 def process_sample_entry(
     entry: dict,
@@ -127,14 +195,16 @@ def process_sample_entry(
     trigger_counts = get_trigger_counts_from_files_parallel(source_files)
     selected_triggers = select_trigger_count(trigger_counts, beam, run)
 
-    if sample_type in {"mc", "ext"} or is_detvar:
+    if sample_type == "mc" or is_detvar:
         entry["pot"] = get_total_pot_from_files_parallel(source_files)
         entry["triggers"] = selected_triggers
-        if (sample_type == "mc" or is_detvar) and entry["pot"] == 0.0:
+        if entry["pot"] == 0.0:
             entry["pot"] = nominal_pot
-    elif sample_type == "data":
-        entry["pot"] = nominal_pot
+    elif sample_type in {"data", "ext"}:
+        entry["pot"] = get_data_ext_pot_from_files(source_files, sample_type)
         entry["triggers"] = selected_triggers
+        if entry["pot"] == 0.0:
+            entry["pot"] = nominal_pot
 
     entry.pop("stage_name", None)
     return True


### PR DESCRIPTION
## Summary
- Remove FlashValidate fallback; read run/sub and POT only from `nuselection/SubRun`
- Call `/exp/uboone/app/users/guzowski/slip_stacking/getDataInfo.py` for POT, adding `--slip` for data samples

## Testing
- `python -m py_compile config/sample_processing.py config/aggregate_samples.py`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bda07786c8832ead23d0804b23dfed