### PR TITLE
Add EXT trigger retrieval and beam-aware POT parsing

### DIFF
--- a/config/data.json
+++ b/config/data.json
@@ -4,7 +4,6 @@
         "numi_fhc": {
             "run1": {
                 "nominal_pot": 1.0e+20,
-                "nominal_triggers": 1.0e+6,
                 "samples": [
                     {
                         "sample_key": "mc_inclusive_run1_fhc",

--- a/config/samples.json
+++ b/config/samples.json
@@ -5,7 +5,6 @@
             "numi_fhc": {
                 "run1": {
                     "nominal_pot": 1e+20,
-                    "nominal_triggers": 1000000.0,
                     "samples": [
                         {
                             "sample_key": "mc_inclusive_run1_fhc",
@@ -20,13 +19,11 @@
                                     "variation_type": "cv",
                                     "active": true,
                                     "relative_path": "mc_inclusive_run1_fhc_detvar_cv.root",
-                                    "pot": 3.603503124989346e+18,
-                                    "triggers": 1255
+                                    "pot": 3.603503124989346e+18
                                 }
                             ],
                             "relative_path": "mc_inclusive_run1_fhc.root",
-                            "pot": 8.795198459547641e+19,
-                            "triggers": 23210
+                            "pot": 8.795198459547641e+19
                         },
                         {
                             "sample_key": "mc_strangeness_run1_fhc",
@@ -39,21 +36,18 @@
                                     "variation_type": "cv",
                                     "active": true,
                                     "relative_path": "mc_strangeness_run1_fhc_detvar_cv.root",
-                                    "pot": 3.603503124989346e+18,
-                                    "triggers": 1255
+                                    "pot": 3.603503124989346e+18
                                 }
                             ],
                             "relative_path": "mc_strangeness_run1_fhc.root",
-                            "pot": 1.1750366557570312e+22,
-                            "triggers": 13544
+                            "pot": 1.1750366557570312e+22
                         },
                         {
                             "sample_key": "mc_dirt_run1_fhc",
                             "sample_type": "mc",
                             "active": true,
                             "relative_path": "mc_dirt_run1_fhc.root",
-                            "pot": 1.3691716923392262e+19,
-                            "triggers": 820
+                            "pot": 1.3691716923392262e+19
                         },
                         {
                             "sample_key": "numu_fhc_ext",
@@ -61,7 +55,7 @@
                             "active": true,
                             "relative_path": "numu_fhc_ext.root",
                             "pot": 0.0,
-                            "triggers": 0
+                            "ext_triggers_db": 0
                         }
                     ]
                 }


### PR DESCRIPTION
## Summary
- Add helper utilities to query EXT trigger counts from getDataInfo
- Extend POT extraction to be beam and horn-current aware
- Record database EXT trigger counts for data and EXT samples
- Remove software trigger fields so only database EXT triggers are stored

## Testing
- `python -m py_compile config/sample_processing.py`
- `python -m py_compile config/aggregate_samples.py`
- `python -m json.tool config/samples.json`


------
https://chatgpt.com/codex/tasks/task_e_68bda80768c4832ebad83b220095220d