### PR TITLE
Fix run/subrun collection for external samples

### DIFF
--- a/config/sample_processing.py
+++ b/config/sample_processing.py
@@ -73,9 +73,14 @@ def _collect_run_subrun_pairs(file_path: Path) -> set[tuple[int, int]]:
     pairs: set[tuple[int, int]] = set()
     try:
         with uproot.open(file_path) as root_file:
-            if "nuselection/SubRun" not in root_file:
+            tree = None
+            if "nuselection/SubRun" in root_file:
+                tree = root_file["nuselection/SubRun"]
+            elif "nuselection/BlipRecoAlg" in root_file:
+                tree = root_file["nuselection/BlipRecoAlg"]
+            if not tree:
                 return pairs
-            tree = root_file["nuselection/SubRun"]
+
             runs = tree["run"].array(library="np") if "run" in tree else None
             if "sub" in tree:
                 subruns = tree["sub"].array(library="np")

--- a/tests/test_sample_processing.py
+++ b/tests/test_sample_processing.py
@@ -1,0 +1,17 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+uproot = pytest.importorskip("uproot")
+
+from config.sample_processing import _collect_run_subrun_pairs
+
+
+def test_collect_run_subrun_pairs_from_event_tree(tmp_path):
+    root_path = tmp_path / "sample.root"
+    with uproot.recreate(root_path) as f:
+        f["nuselection/BlipRecoAlg"] = {
+            "run": np.array([1, 1], dtype=np.int32),
+            "subrun": np.array([2, 3], dtype=np.int32),
+        }
+    pairs = _collect_run_subrun_pairs(root_path)
+    assert pairs == {(1, 2), (1, 3)}


### PR DESCRIPTION
## Summary
- Allow sample processing to read run and subrun numbers from either `nuselection/SubRun` or `nuselection/BlipRecoAlg`
- Add unit test covering run/subrun extraction from the `BlipRecoAlg` tree

## Testing
- `pytest tests/test_sample_processing.py -q`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bdac7b14f8832ea1dc4ae58c83385a