### PR TITLE
docs: relocate run periods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # rarexsec_analysis
 
-## Run Periods
-
-1. Run 1 ⇒ 2015-10 to 2016-07
-2. Run 2 ⇒ 2016-10 to 2017-07
-3. Run 3 ⇒ 2017-10 to 2018-07
-4. Run 4 ⇒ 2018-10 to 2019-07
-5. Run 5 ⇒ 2019-10 to 2020-03
-
 ## Building
 ```bash
 source .container.sh
@@ -77,6 +69,14 @@ The `strategy` field accepts `equal_weight`, `uniform_width`, or `bayesian_block
   ]
 }
 ```
+
+## Run Periods
+
+1. Run 1 → October 2015 to July 2016
+2. Run 2 → October 2016 to July 2017
+3. Run 3 → October 2017 to July 2018
+4. Run 4 → October 2018 to July 2019
+5. Run 5 → October 2019 to March 2020
 
 ## Testing
 ```bash


### PR DESCRIPTION
## Summary
- move run period details near the end of README
- replace double arrows with single arrows and switch to British date style

## Testing
- `ctest --output-on-failure` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68bdad26767c832ebb2340a0efef4120