### PR TITLE
Ensure sample configs match loader expectations

### DIFF
--- a/config/aggregate_samples.py
+++ b/config/aggregate_samples.py
@@ -79,8 +79,9 @@ def main() -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     samples_cfg = {
         "samples": {
-            "ntuple_directory": config["ntuple_base_directory"],
+            "ntupledir": config["ntuple_base_directory"],
             "beamlines": config["run_configurations"],
+            "run_configurations": config["run_configurations"],
         }
     }
     with open(output_path, "w") as f:

--- a/config/samples.json
+++ b/config/samples.json
@@ -1,7 +1,67 @@
 {
     "samples": {
-        "ntuple_directory": "/exp/uboone/data/users/nlane/ntuples",
         "beamlines": {
+            "numi_fhc": {
+                "run1": {
+                    "nominal_pot": 1e+20,
+                    "samples": [
+                        {
+                            "sample_key": "mc_inclusive_run1_fhc",
+                            "sample_type": "mc",
+                            "active": true,
+                            "exclusion_truth_filters": [
+                                "mc_strangeness_run1_fhc"
+                            ],
+                            "detector_variations": [
+                                {
+                                    "sample_key": "mc_inclusive_run1_fhc_detvar_cv",
+                                    "variation_type": "cv",
+                                    "active": true,
+                                    "relative_path": "mc_inclusive_run1_fhc_detvar_cv.root",
+                                    "pot": 3.603503124989346e+18
+                                }
+                            ],
+                            "relative_path": "mc_inclusive_run1_fhc.root",
+                            "pot": 8.795198459547641e+19
+                        },
+                        {
+                            "sample_key": "mc_strangeness_run1_fhc",
+                            "sample_type": "mc",
+                            "active": true,
+                            "truth_filter": "(mc_n_strange > 0)",
+                            "detector_variations": [
+                                {
+                                    "sample_key": "mc_strangeness_run1_fhc_detvar_cv",
+                                    "variation_type": "cv",
+                                    "active": true,
+                                    "relative_path": "mc_strangeness_run1_fhc_detvar_cv.root",
+                                    "pot": 3.603503124989346e+18
+                                }
+                            ],
+                            "relative_path": "mc_strangeness_run1_fhc.root",
+                            "pot": 1.1750366557570312e+22
+                        },
+                        {
+                            "sample_key": "mc_dirt_run1_fhc",
+                            "sample_type": "mc",
+                            "active": true,
+                            "relative_path": "mc_dirt_run1_fhc.root",
+                            "pot": 1.3691716923392262e+19
+                        },
+                        {
+                            "sample_key": "numu_fhc_ext",
+                            "sample_type": "ext",
+                            "active": true,
+                            "relative_path": "numu_fhc_ext.root",
+                            "pot": 0.0,
+                            "ext_triggers_db": 0
+                        }
+                    ]
+                }
+            }
+        },
+        "ntupledir": "/exp/uboone/data/users/nlane/ntuples",
+        "run_configurations": {
             "numi_fhc": {
                 "run1": {
                     "nominal_pot": 1e+20,


### PR DESCRIPTION
## Summary
- Update aggregate_samples.py to save `ntupledir` and include `run_configurations` alongside `beamlines`
- Refresh example config/samples.json to use the new fields

## Testing
- `python -m py_compile config/aggregate_samples.py`
- `pytest tests/test_sample_processing.py -q` *(skipped: missing numpy and uproot)*

------
https://chatgpt.com/codex/tasks/task_e_68bdad993530832eb9ba756e310c36a1