### PR TITLE
Handle missing hadd via uproot merge

### DIFF
--- a/config/sample_processing.py
+++ b/config/sample_processing.py
@@ -12,6 +12,31 @@ from pathlib import Path
 import numpy as np
 import uproot
 
+def merge_root_files(output_file: str, input_files: list[str]) -> bool:
+    """Merge ROOT files using uproot as a fallback when hadd is unavailable."""
+    try:
+        if not input_files:
+            return False
+        with uproot.recreate(output_file) as fout:
+            # Copy structure from the first file
+            with uproot.open(input_files[0]) as first:
+                for path, obj in first.items(recursive=True):
+                    if isinstance(obj, uproot.behaviors.TTree.TTree):
+                        fout[path] = obj.arrays(library="np")
+                    else:
+                        fout[path] = obj
+            # Extend TTrees with remaining files
+            for fname in input_files[1:]:
+                with uproot.open(fname) as fin:
+                    for path, obj in fin.items(recursive=True):
+                        if isinstance(obj, uproot.behaviors.TTree.TTree) and path in fout:
+                            fout[path].extend(obj.arrays(library="np"))
+        print("[STATUS] Python merge via uproot successful.")
+        return True
+    except Exception as exc:
+        print(f"[ERROR] Python merge failed: {exc}", file=sys.stderr)
+        return False
+
 def get_xml_entities(xml_path: Path) -> dict[str, str]:
     content = xml_path.read_text()
     entity_regex = re.compile(r"<!ENTITY\s+([^\s]+)\s+\"([^\"]+)\">")
@@ -24,6 +49,12 @@ def run_command(command: list[str], execute: bool) -> bool:
         return True
 
     if shutil.which(command[0]) is None:
+        if command[0] == "hadd":
+            print("[INFO] 'hadd' not found. Using Python-based merge via uproot.")
+            output_idx = 2 if len(command) > 2 and command[1] == "-f" else 1
+            output_file = command[output_idx]
+            input_files = command[output_idx + 1 :]
+            return merge_root_files(output_file, input_files)
         print(
             f"[ERROR] Command '{command[0]}' not found. Ensure ROOT is set up by running:\n"
             "             source /cvmfs/larsoft.opensciencegrid.org/products/common/etc/setups\n"

--- a/tests/test_sample_processing.py
+++ b/tests/test_sample_processing.py
@@ -3,7 +3,7 @@ import pytest
 np = pytest.importorskip("numpy")
 uproot = pytest.importorskip("uproot")
 
-from config.sample_processing import _collect_run_subrun_pairs
+import config.sample_processing as sp
 
 
 def test_collect_run_subrun_pairs_from_subrun_tree(tmp_path):
@@ -13,7 +13,7 @@ def test_collect_run_subrun_pairs_from_subrun_tree(tmp_path):
             "run": np.array([1, 1], dtype=np.int32),
             "subRun": np.array([2, 3], dtype=np.int32),
         }
-    pairs = _collect_run_subrun_pairs(root_path)
+    pairs = sp._collect_run_subrun_pairs(root_path)
     assert pairs == {(1, 2), (1, 3)}
 
 
@@ -24,5 +24,20 @@ def test_collect_run_subrun_pairs_from_generic_tree(tmp_path):
             "run": np.array([4, 4], dtype=np.int32),
             "subRun": np.array([5, 6], dtype=np.int32),
         }
-    pairs = _collect_run_subrun_pairs(root_path)
+    pairs = sp._collect_run_subrun_pairs(root_path)
     assert pairs == {(4, 5), (4, 6)}
+
+
+def test_run_command_hadd_fallback(tmp_path, monkeypatch):
+    f1 = tmp_path / "a.root"
+    f2 = tmp_path / "b.root"
+    with uproot.recreate(f1) as f:
+        f["tree"] = {"run": np.array([1], dtype=np.int32)}
+    with uproot.recreate(f2) as f:
+        f["tree"] = {"run": np.array([2], dtype=np.int32)}
+    out = tmp_path / "out.root"
+    monkeypatch.setattr(sp.shutil, "which", lambda cmd: None)
+    assert sp.run_command(["hadd", "-f", str(out), str(f1), str(f2)], True)
+    with uproot.open(out) as f:
+        arr = f["tree"]["run"].array(library="np")
+    assert list(arr) == [1, 2]


### PR DESCRIPTION
## Summary
- Merge ROOT files with uproot when `hadd` is unavailable
- Add regression test exercising Python fallback merging

## Testing
- `pytest -q` *(fails: 1 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68bdbb72ca88832ea7d56b737ddcc4b2