### PR TITLE
Remove Python fallback for merging, require hadd

### DIFF
--- a/tests/test_sample_processing.py
+++ b/tests/test_sample_processing.py
@@ -27,32 +27,7 @@ def test_collect_run_subrun_pairs_from_generic_tree(tmp_path):
     pairs = sp._collect_run_subrun_pairs(root_path)
     assert pairs == {(4, 5), (4, 6)}
 
-
-def test_run_command_hadd_fallback(tmp_path, monkeypatch):
-    f1 = tmp_path / "a.root"
-    f2 = tmp_path / "b.root"
-    with uproot.recreate(f1) as f:
-        f["tree"] = {"run": np.array([1], dtype=np.int32)}
-    with uproot.recreate(f2) as f:
-        f["tree"] = {"run": np.array([2], dtype=np.int32)}
-    out = tmp_path / "out.root"
+def test_run_command_missing_hadd(monkeypatch, tmp_path):
     monkeypatch.setattr(sp.shutil, "which", lambda cmd: None)
-    assert sp.run_command(["hadd", "-f", str(out), str(f1), str(f2)], True)
-    with uproot.open(out) as f:
-        arr = f["tree"]["run"].array(library="np")
-    assert list(arr) == [1, 2]
-
-
-def test_run_command_hadd_fallback_with_directory(tmp_path, monkeypatch):
-    f1 = tmp_path / "a.root"
-    f2 = tmp_path / "b.root"
-    with uproot.recreate(f1) as f:
-        f["BlipRecoAlg/tree"] = {"run": np.array([1], dtype=np.int32)}
-    with uproot.recreate(f2) as f:
-        f["BlipRecoAlg/tree"] = {"run": np.array([2], dtype=np.int32)}
     out = tmp_path / "out.root"
-    monkeypatch.setattr(sp.shutil, "which", lambda cmd: None)
-    assert sp.run_command(["hadd", "-f", str(out), str(f1), str(f2)], True)
-    with uproot.open(out) as f:
-        arr = f["BlipRecoAlg/tree"]["run"].array(library="np")
-    assert list(arr) == [1, 2]
+    assert not sp.run_command(["hadd", "-f", str(out), "a.root"], True)


### PR DESCRIPTION
## Summary
- drop Python-based ROOT file merge fallback
- ensure `run_command` requires `hadd` to be available
- update tests for new behavior

## Testing
- `pip install numpy uproot` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbf9d82a4832ea50cdce3b103646e