### PR TITLE
Add script for querying NuMI Run 1 EXT and POT

### DIFF
--- a/tools/run1_numi_ext_pot.sh
+++ b/tools/run1_numi_ext_pot.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Query total EXT triggers and POT for NuMI FHC Run 1 (Oct 2015 - Jul 2016)
+# Uses tools in this repository which depend on python2
+
+START="2015-10-01T00:00:00"
+END="2016-07-31T23:59:59"
+
+python2 "$(dirname "$0")/getDataInfo.py" \
+  --format EXT:tor101 \
+  --where "begin_time > '${START}' AND end_time < '${END}'" \
+  "$@"


### PR DESCRIPTION
## Summary
- Add helper script to report total EXT triggers and POT for NuMI FHC Run 1 (Oct 2015-Jul 2016) using existing tooling

## Testing
- `ctest --output-on-failure` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68bdd7b465bc832e814fb7b5465887b6