### PR TITLE
Fix run-object closure in pot summary script

### DIFF
--- a/tools/allruns_pot.sh
+++ b/tools/allruns_pot.sh
@@ -127,9 +127,6 @@ bar
 for r in 1 2 3 4 5; do
   S="${RUN_START[$r]}"; E="${RUN_END[$r]}"
 
-  # comma between run objects in JSON
-  [[ $r -gt 1 ]] && echo ',' >> "$OUTPUT_JSON"
-
   # open run object + beams
   {
     printf '    { "index": %d, "start": "%s", "end": "%s", "beams": {\n' "$r" "$S" "$E"
@@ -182,6 +179,11 @@ for r in 1 2 3 4 5; do
   {
     echo   '      }'
     echo   '    }'
+    if [[ $r -lt 5 ]]; then
+      echo   '    },'
+    else
+      echo   '    }'
+    fi
   } >> "$OUTPUT_JSON"
 
   echo


### PR DESCRIPTION
## Summary
- ensure `allruns_pot.sh` closes run entries and adds commas only between runs
- revert manual edits to generated `pot_summary.json`

## Testing
- `bash tools/allruns_pot.sh tools/pot_summary.json` *(fails: setup_uboone.sh missing and databases unavailable)*
- `python config/aggregate_samples.py` *(fails: No module named 'numpy')*
- `pytest tests/test_sample_processing.py` *(skipped: no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf3934980832e9dc3aeeab7eae7a4