### PR TITLE
Handle invalid POT summary JSON

### DIFF
--- a/config/aggregate_samples.py
+++ b/config/aggregate_samples.py
@@ -22,8 +22,16 @@ def main() -> None:
     with open(input_definitions_path) as f:
         config = json.load(f)
 
-    with open(Path(POT_SUMMARY_PATH)) as f:
-        pot_summary = json.load(f)
+    try:
+        with open(Path(POT_SUMMARY_PATH)) as f:
+            pot_summary = json.load(f)
+    except json.JSONDecodeError:
+        print(
+            f"Error: Failed to decode JSON from '{POT_SUMMARY_PATH}'. "
+            "Try running tools/allruns_pot.sh again or verify the JSON file.",
+            file=sys.stderr,
+        )
+        raise
 
     entities: dict[str, str] = {}
     stage_outdirs: dict[str, str] = {}


### PR DESCRIPTION
## Summary
- handle JSON decode errors when reading POT summary

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdfbcfc3d4832ea3fca8c5cc18675b