### PR TITLE
Fix JSON run1 closure in pot summary

### DIFF
--- a/tools/pot_summary.json
+++ b/tools/pot_summary.json
@@ -16,10 +16,10 @@
       "NuMI": {
         "TOTAL": { "EXT": 40062895, "Gate": 13944482, "Cnt": 14158579, "TorA": 4.59302012734855e+20, "TorB_Target": 4.58153785082265e+20, "Cnt_wcut": 13419751, "TorA_wcut": 4.5776199217314e+20, "TorB_Target_wcut": 4.56528963240262e+20 },
         "FHC":   { "EXT": 0, "Gate": 0, "Cnt": 0, "TorA": 0, "TorB_Target": 0, "Cnt_wcut": 11843834, "TorA_wcut": 3.93394401547457e+20, "TorB_Target_wcut": 3.92213108360349e+20 },
-        "RHC":   { "EXT": 0, "Gate": 0, "Cnt": 0, "TorA": 0, "TorB_Target": 0, "Cnt_wcut": 1509648, "TorA_wcut": 6.27262221626911e+19, "TorB_Target_wcut": 6.26786807437761e+19 }
+      "RHC":   { "EXT": 0, "Gate": 0, "Cnt": 0, "TorA": 0, "TorB_Target": 0, "Cnt_wcut": 1509648, "TorA_wcut": 6.27262221626911e+19, "TorB_Target_wcut": 6.26786807437761e+19 }
       }
     }
-,
+  },
     { "index": 2, "start": "2016-10-01T00:00:00", "end": "2017-07-31T23:59:59", "beams": {
       "BNB": {
         "TOTAL": { "EXT": 165820967, "Gate": 75426832, "Cnt": 82583987, "TorA": 3.13471878034212e+20, "TorB_Target": 3.13089048474962e+20, "Cnt_wcut": 72891077, "TorA_wcut": 3.06107689145972e+20, "TorB_Target_wcut": 3.05733789719907e+20 }


### PR DESCRIPTION
## Summary
- fix missing closing sequence for run 1 beams in tools/pot_summary.json

## Testing
- `python config/aggregate_samples.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Cannot connect to proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfbd10b70832e85a79f033262f3c2