### PR TITLE
Support external sample scaling and fix sample config

### DIFF
--- a/config/sample_processing.py
+++ b/config/sample_processing.py
@@ -126,7 +126,7 @@ def process_sample_entry(
             entry["pot"] = run_pot
     elif sample_type in {"data", "ext"}:
         entry["pot"] = run_pot
-        entry["ext_triggers_db"] = ext_triggers
+        entry["triggers"] = ext_triggers
 
     entry.pop("stage_name", None)
     return True

--- a/config/samples.json
+++ b/config/samples.json
@@ -4,8 +4,8 @@
         "beamlines": {
             "numi_fhc": {
                 "run1": {
-                    "torb_target_pot_wcut": 3.922e+20,
-                    "ext_triggers": 40062895.0,
+                    "nominal_pot": 3.922e+20,
+                    "nominal_triggers": 40062895,
                     "samples": [
                         {
                             "sample_key": "mc_inclusive_run1_fhc",
@@ -56,7 +56,7 @@
                             "active": true,
                             "relative_path": "numu_fhc_ext.root",
                             "pot": 3.922e+20,
-                            "ext_triggers_db": 40062895
+                            "triggers": 40062895
                         }
                     ]
                 }

--- a/libdata/AnalysisDataLoader.h
+++ b/libdata/AnalysisDataLoader.h
@@ -123,8 +123,9 @@ class AnalysisDataLoader {
             }
 
             auto pipeline = this->chainEventProcessors(
-                std::make_unique<WeightProcessor>(sample_json, total_pot_), std::make_unique<TruthChannelProcessor>(),
-                std::make_unique<BlipProcessor>(), std::make_unique<MuonSelectionProcessor>(),
+                std::make_unique<WeightProcessor>(sample_json, total_pot_, total_triggers_),
+                std::make_unique<TruthChannelProcessor>(), std::make_unique<BlipProcessor>(),
+                std::make_unique<MuonSelectionProcessor>(),
                 std::make_unique<ReconstructionProcessor>());
             processors_.push_back(std::move(pipeline));
 

--- a/libdata/RunConfigLoader.h
+++ b/libdata/RunConfigLoader.h
@@ -15,7 +15,8 @@ namespace analysis {
 class RunConfigLoader {
   public:
     static inline void loadFromJson(const nlohmann::json &data, RunConfigRegistry &registry) {
-        for (auto const &[beam, run_configs] : data.at("run_configurations").items()) {
+        const std::string top_key = data.contains("run_configurations") ? "run_configurations" : "beamlines";
+        for (auto const &[beam, run_configs] : data.at(top_key).items()) {
             for (auto const &[run_period, run_details] : run_configs.items()) {
                 RunConfig config(run_details, beam, run_period);
                 config.validate();

--- a/libdata/WeightProcessor.h
+++ b/libdata/WeightProcessor.h
@@ -13,11 +13,16 @@ namespace analysis {
 
 class WeightProcessor : public IEventProcessor {
   public:
-    WeightProcessor(const nlohmann::json &cfg, double total_run_pot)
-        : sample_pot_(cfg.value("pot", 0.0)), total_run_pot_(total_run_pot) {
-        if (sample_pot_ <= 0.0) {
-            log::warn("WeightProcessor::WeightProcessor", "sample JSON has no or invalid 'pot';"
-                                                          "base_event_weight will default to 1");
+    WeightProcessor(const nlohmann::json &cfg, double total_run_pot,
+                    long total_run_triggers)
+        : sample_pot_(cfg.value("pot", 0.0)),
+          sample_triggers_(cfg.value("triggers", 0L)),
+          total_run_pot_(total_run_pot),
+          total_run_triggers_(total_run_triggers) {
+        if (sample_pot_ <= 0.0 && sample_triggers_ <= 0L) {
+            log::warn("WeightProcessor::WeightProcessor",
+                      "sample JSON has no or invalid 'pot' or 'triggers';",
+                      "base_event_weight will default to 1");
         }
     }
 
@@ -29,25 +34,33 @@ class WeightProcessor : public IEventProcessor {
             }
             df = df.Define("base_event_weight", [scale]() { return scale; });
 
-            df = df.Define("nominal_event_weight",
-                           [](double w, float w_spline, float w_tune) {
-                               double final_weight = w;
-                               if (std::isfinite(w_spline) && w_spline > 0)
-                                   final_weight *= w_spline;
-                               if (std::isfinite(w_tune) && w_tune > 0)
-                                   final_weight *= w_tune;
-                               if (!std::isfinite(final_weight) || final_weight < 0)
-                                   return 1.0;
-                               return final_weight;
-                           },
-                           {"base_event_weight", "weightSpline", "weightTune"});
-        } else {
-            if (!df.HasColumn("nominal_event_weight")) {
-                if (df.HasColumn("base_event_weight")) {
-                    df = df.Alias("nominal_event_weight", "base_event_weight");
-                } else {
-                    df = df.Define("nominal_event_weight", []() { return 1.0; });
-                }
+            df = df.Define(
+                "nominal_event_weight",
+                [](double w, float w_spline, float w_tune) {
+                    double final_weight = w;
+                    if (std::isfinite(w_spline) && w_spline > 0)
+                        final_weight *= w_spline;
+                    if (std::isfinite(w_tune) && w_tune > 0)
+                        final_weight *= w_tune;
+                    if (!std::isfinite(final_weight) || final_weight < 0)
+                        return 1.0;
+                    return final_weight;
+                },
+                {"base_event_weight", "weightSpline", "weightTune"});
+        } else if (st == SampleOrigin::kExternal) {
+            double scale = 1.0;
+            if (sample_triggers_ > 0 && total_run_triggers_ > 0) {
+                scale = static_cast<double>(total_run_triggers_) /
+                        static_cast<double>(sample_triggers_);
+            }
+            df = df.Define("base_event_weight", [scale]() { return scale; });
+        }
+
+        if (!df.HasColumn("nominal_event_weight")) {
+            if (df.HasColumn("base_event_weight")) {
+                df = df.Alias("nominal_event_weight", "base_event_weight");
+            } else {
+                df = df.Define("nominal_event_weight", []() { return 1.0; });
             }
         }
 
@@ -59,9 +72,12 @@ class WeightProcessor : public IEventProcessor {
 
   private:
     double sample_pot_;
+    long sample_triggers_;
     double total_run_pot_;
+    long total_run_triggers_;
 };
 
-}
+}  // namespace analysis
 
 #endif
+


### PR DESCRIPTION
## Summary
- Scale external samples by trigger rates in `WeightProcessor`
- Pass total trigger counts through `AnalysisDataLoader`
- Allow `RunConfigLoader` to read `beamlines` configs
- Update sample configuration and processing scripts for new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be0749895c832e81dafb197cefbf0a