### PR TITLE
Add selection-region presets for analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ The `strategy` field accepts `equal_weight`, `uniform_width`, or `bayesian_block
 }
 ```
 
+## Region presets
+
+Common selection regions can be added via presets. The framework provides three
+basic options:
+
+- `EMPTY` – no event selection (`NONE` rule)
+- `QUALITY` – requires the `quality_event` preselection
+- `MUON` – selects events containing a reconstructed muon
+
+They are enabled in the `presets` block of the configuration:
+
+```json
+{
+  "presets": [
+    { "name": "QUALITY" },
+    { "name": "MUON" }
+  ]
+}
+```
+
+Each preset configures the `RegionsPlugin` with an analysis region matching the
+given selection rule.
+
 ## Run Periods
 
 1. Run 1 → October 2015 to July 2016

--- a/libapp/SelectionRegistry.h
+++ b/libapp/SelectionRegistry.h
@@ -57,6 +57,8 @@ class SelectionRegistry {
                "selection_pass",
                "optical_filter_pe_beam > 20"}}},
 
+            {"MUON", {"Muon Selection", {"has_muon"}}},
+
             {"NUMU_CC", {"NuMu CC Selection", {"has_muon", "n_pfps_gen2 > 1"}}},
 
             {"NUMU_CC_BREAKDOWN",

--- a/src/presets/Presets_Standard.cpp
+++ b/src/presets/Presets_Standard.cpp
@@ -1,5 +1,6 @@
 #include "PresetRegistry.h"
 #include "PluginSpec.h"
+#include <nlohmann/json.hpp>
 
 using namespace analysis;
 
@@ -17,4 +18,42 @@ ANALYSIS_REGISTER_PRESET(TruthMetrics, Target::Analysis,
 
 ANALYSIS_REGISTER_PRESET(StandardPlots, Target::Plot,
   [](const PluginArgs&) -> PluginSpecList { return {}; }
+)
+
+// Presets defining common analysis regions.  Each preset configures the
+// RegionsPlugin with a single region tied to a selection rule.
+ANALYSIS_REGISTER_PRESET(EMPTY, Target::Analysis,
+  [](const PluginArgs&) -> PluginSpecList {
+    nlohmann::json region = {
+      {"region_key", "EMPTY"},
+      {"label", "Empty Selection"},
+      {"selection_rule", "NONE"}
+    };
+    PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
+    return {{"RegionsPlugin", args}};
+  }
+)
+
+ANALYSIS_REGISTER_PRESET(QUALITY, Target::Analysis,
+  [](const PluginArgs&) -> PluginSpecList {
+    nlohmann::json region = {
+      {"region_key", "QUALITY"},
+      {"label", "Quality Selection"},
+      {"selection_rule", "QUALITY"}
+    };
+    PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
+    return {{"RegionsPlugin", args}};
+  }
+)
+
+ANALYSIS_REGISTER_PRESET(MUON, Target::Analysis,
+  [](const PluginArgs&) -> PluginSpecList {
+    nlohmann::json region = {
+      {"region_key", "MUON"},
+      {"label", "Muon Selection"},
+      {"selection_rule", "MUON"}
+    };
+    PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
+    return {{"RegionsPlugin", args}};
+  }
 )


### PR DESCRIPTION
## Summary
- Add MUON selection rule to SelectionRegistry
- Register EMPTY, QUALITY and MUON region presets
- Document region presets usage in README

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be9dbe2a94832eb03ca09fdb4da416