### PR TITLE
Add preset for true neutrino vertex variables

### DIFF
--- a/src/presets/Presets_Standard.cpp
+++ b/src/presets/Presets_Standard.cpp
@@ -57,3 +57,34 @@ ANALYSIS_REGISTER_PRESET(MUON, Target::Analysis,
     return {{"RegionsPlugin", args}};
   }
 )
+
+// Preset defining variables for the true neutrino interaction vertex.
+ANALYSIS_REGISTER_PRESET(TRUE_NEUTRINO_VERTEX, Target::Analysis,
+  [](const PluginArgs&) -> PluginSpecList {
+    nlohmann::json vars = nlohmann::json::array({
+      {
+        {"name", "nu_vtx_x"},
+        {"branch", "neutrino_vertex_x"},
+        {"label", "True #nu Vertex X [cm]"},
+        {"stratum", "event"},
+        {"bins", {{"n", 26}, {"min", 0.0}, {"max", 260.0}}}
+      },
+      {
+        {"name", "nu_vtx_y"},
+        {"branch", "neutrino_vertex_y"},
+        {"label", "True #nu Vertex Y [cm]"},
+        {"stratum", "event"},
+        {"bins", {{"n", 24}, {"min", -120.0}, {"max", 120.0}}}
+      },
+      {
+        {"name", "nu_vtx_z"},
+        {"branch", "neutrino_vertex_z"},
+        {"label", "True #nu Vertex Z [cm]"},
+        {"stratum", "event"},
+        {"bins", {{"n", 52}, {"min", 0.0}, {"max", 1040.0}}}
+      }
+    });
+    PluginArgs args{{"analysis_configs", {{"variables", vars}}}};
+    return {{"VariablesPlugin", args}};
+  }
+)


### PR DESCRIPTION
## Summary
- Provide `TRUE_NEUTRINO_VERTEX` preset defining variables for true neutrino interaction vertex coordinates

## Testing
- `cmake .. && make -j2 && ctest --output-on-failure` *(fails: could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68be9fc8e4d0832e8cee47501897efe3