### PR TITLE
Add preset for neutrino vertex stacked plots

### DIFF
--- a/libplug/plotting/StackedHistogramPlugin.cc
+++ b/libplug/plotting/StackedHistogramPlugin.cc
@@ -14,9 +14,9 @@ namespace analysis {
 class StackedHistogramPlugin : public IPlotPlugin {
   public:
     struct PlotConfig {
-        std::string variable;
-        std::string region;
-        std::string category_column;
+        std::string variable{};               // optional variable name
+        std::string region{};                 // optional region key
+        std::string category_column{"inclusive"};
         std::string output_directory = "plots";
         bool overlay_signal = true;
         std::vector<Cut> cut_list;
@@ -31,49 +31,76 @@ class StackedHistogramPlugin : public IPlotPlugin {
 
     StackedHistogramPlugin(const PluginArgs &args, AnalysisDataLoader *) {
         const auto &cfg = args.plot_configs;
-        if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::runtime_error("StackedHistogramPlugin missing plots");
-        for (auto const &p : cfg.at("plots")) {
-            PlotConfig pc;
-            pc.variable = p.at("variable").get<std::string>();
-            pc.region = p.at("region").get<std::string>();
-            pc.category_column = p.value("category_column", std::string());
-            pc.output_directory = p.value("output_directory", std::string("plots"));
-            pc.overlay_signal = p.value("overlay_signal", true);
-            pc.annotate_numbers = p.value("annotate_numbers", true);
-            pc.use_log_y = p.value("log_y", false);
-            pc.y_axis_label = p.value("y_axis_label", "Events");
-            pc.selection_cuts = p.value("selection_cuts", false);
-            pc.n_bins = p.value("n_bins", -1);
-            pc.min = p.value("min", 0.0);
-            pc.max = p.value("max", 0.0);
-            if (p.contains("cuts")) {
-                for (auto const &c : p.at("cuts")) {
-                    auto dir = c.at("direction").get<std::string>() == "GreaterThan" ? CutDirection::GreaterThan
-                                                                                     : CutDirection::LessThan;
-                    pc.cut_list.push_back({c.at("threshold").get<double>(), dir});
+        if (cfg.contains("plots") && cfg.at("plots").is_array() && !cfg.at("plots").empty()) {
+            for (auto const &p : cfg.at("plots")) {
+                PlotConfig pc;
+                pc.variable = p.value("variable", std::string());
+                pc.region = p.value("region", std::string());
+                pc.category_column = p.value("category_column", std::string("inclusive"));
+                pc.output_directory = p.value("output_directory", std::string("plots"));
+                pc.overlay_signal = p.value("overlay_signal", true);
+                pc.annotate_numbers = p.value("annotate_numbers", true);
+                pc.use_log_y = p.value("log_y", false);
+                pc.y_axis_label = p.value("y_axis_label", "Events");
+                pc.selection_cuts = p.value("selection_cuts", false);
+                pc.n_bins = p.value("n_bins", -1);
+                pc.min = p.value("min", 0.0);
+                pc.max = p.value("max", 0.0);
+                if (p.contains("cuts")) {
+                    for (auto const &c : p.at("cuts")) {
+                        auto dir = c.at("direction").get<std::string>() == "GreaterThan"
+                                        ? CutDirection::GreaterThan
+                                        : CutDirection::LessThan;
+                        pc.cut_list.push_back({c.at("threshold").get<double>(), dir});
+                    }
                 }
+                plots_.push_back(std::move(pc));
             }
-            plots_.push_back(std::move(pc));
+        } else {
+            // No explicit plot configuration provided; use defaults.
+            plots_.push_back(PlotConfig{});
         }
     }
 
     void onPlot(const AnalysisResult &result) override {
         gSystem->mkdir("plots", true);
         for (auto const &pc : plots_) {
-            RegionKey rkey{pc.region};
-            VariableKey vkey{pc.variable};
-            if (!result.hasResult(rkey, vkey)) {
-                log::error("StackedHistogramPlugin::onPlot", "Could not find variable", vkey.str(), "in region",
-                           rkey.str());
-                continue;
+            std::vector<RegionKey> regions;
+            if (pc.region.empty()) {
+                for (const auto &kv : result.regions())
+                    regions.emplace_back(kv.first);
+            } else {
+                regions.emplace_back(pc.region);
             }
-            const auto &region_analysis = result.region(rkey);
-            const auto &variable_result = result.result(rkey, vkey);
-            StackedHistogramPlot plot("stack_" + pc.variable + "_" + pc.region, variable_result, region_analysis,
-                                      pc.category_column, pc.output_directory, pc.overlay_signal, pc.cut_list,
-                                      pc.annotate_numbers, pc.use_log_y, pc.y_axis_label, pc.n_bins, pc.min, pc.max);
-            plot.drawAndSave("pdf");
+
+            for (const auto &rkey : regions) {
+                if (!result.regions().count(rkey)) {
+                    log::error("StackedHistogramPlugin::onPlot", "Could not find region", rkey.str());
+                    continue;
+                }
+                const auto &region_analysis = result.region(rkey);
+
+                std::vector<VariableKey> variables;
+                if (pc.variable.empty()) {
+                    variables = region_analysis.getAvailableVariables();
+                } else {
+                    variables.emplace_back(pc.variable);
+                }
+
+                for (const auto &vkey : variables) {
+                    if (!result.hasResult(rkey, vkey)) {
+                        log::error("StackedHistogramPlugin::onPlot", "Could not find variable", vkey.str(),
+                                   "in region", rkey.str());
+                        continue;
+                    }
+                    const auto &variable_result = result.result(rkey, vkey);
+                    StackedHistogramPlot plot("stack_" + vkey.str() + "_" + rkey.str(), variable_result,
+                                              region_analysis, pc.category_column, pc.output_directory,
+                                              pc.overlay_signal, pc.cut_list, pc.annotate_numbers, pc.use_log_y,
+                                              pc.y_axis_label, pc.n_bins, pc.min, pc.max);
+                    plot.drawAndSave("pdf");
+                }
+            }
         }
     }
 

--- a/src/presets/Presets_Vertices.cpp
+++ b/src/presets/Presets_Vertices.cpp
@@ -66,3 +66,16 @@ ANALYSIS_REGISTER_PRESET(RECO_NEUTRINO_VERTEX, Target::Analysis,
   }
 )
 
+// Preset configuring stacked histogram plots for both true and reconstructed
+// neutrino vertices using the regions supplied by other presets.  Combine this
+// with TRUE_NEUTRINO_VERTEX and RECO_NEUTRINO_VERTEX along with a region preset
+// such as EMPTY to automatically generate stacked histograms stratified by the
+// inclusive category scheme without specifying variables or regions here.
+ANALYSIS_REGISTER_PRESET(NEUTRINO_VERTEX_STACKED_PLOTS, Target::Plot,
+  [](const PluginArgs&) -> PluginSpecList {
+    nlohmann::json plot = {{"category_column", "inclusive"}};
+    PluginArgs args{{"plot_configs", {{"plots", nlohmann::json::array({plot})}}}};
+    return {{"StackedHistogramPlugin", args}};
+  }
+)
+


### PR DESCRIPTION
## Summary
- allow StackedHistogramPlugin to default to plotting all variables across available regions with inclusive categories
- simplify NEUTRINO_VERTEX_STACKED_PLOTS preset to rely on other presets for variables and regions

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bea2e3308c832e814f9ba39f94df3e