### PR TITLE
Expand default region presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,14 @@ The `strategy` field accepts `equal_weight`, `uniform_width`, or `bayesian_block
 
 ## Region presets
 
-Common selection regions can be added via presets. The framework provides three
-basic options:
+Common selection regions can be added via presets. The framework provides a
+number of built‑in options:
 
 - `EMPTY` – no event selection (`NONE` rule)
 - `QUALITY` – requires the `quality_event` preselection
 - `MUON` – selects events containing a reconstructed muon
+- `NUMU_CC` – selects charged-current νµ events
+- `QUALITY_NUMU_CC` – combines the quality preselection with the νµ CC rule
 
 They are enabled in the `presets` block of the configuration:
 
@@ -85,7 +87,7 @@ They are enabled in the `presets` block of the configuration:
 {
   "presets": [
     { "name": "QUALITY" },
-    { "name": "MUON" }
+    { "name": "NUMU_CC" }
   ]
 }
 ```

--- a/src/presets/Presets_Standard.cpp
+++ b/src/presets/Presets_Standard.cpp
@@ -57,3 +57,27 @@ ANALYSIS_REGISTER_PRESET(MUON, Target::Analysis,
     return {{"RegionsPlugin", args}};
   }
 )
+
+ANALYSIS_REGISTER_PRESET(NUMU_CC, Target::Analysis,
+  [](const PluginArgs&) -> PluginSpecList {
+    nlohmann::json region = {
+      {"region_key", "NUMU_CC"},
+      {"label", "NuMu CC Selection"},
+      {"selection_rule", "NUMU_CC"}
+    };
+    PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
+    return {{"RegionsPlugin", args}};
+  }
+)
+
+ANALYSIS_REGISTER_PRESET(QUALITY_NUMU_CC, Target::Analysis,
+  [](const PluginArgs&) -> PluginSpecList {
+    nlohmann::json region = {
+      {"region_key", "QUALITY_NUMU_CC"},
+      {"label", "Quality + NuMu CC Selection"},
+      {"selection_rule", "QUALITY_NUMU_CC"}
+    };
+    PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
+    return {{"RegionsPlugin", args}};
+  }
+)


### PR DESCRIPTION
## Summary
- Add `NUMU_CC` and `QUALITY_NUMU_CC` region presets
- Document the new presets in the README

## Testing
- `cmake -S . -B build` *(fails: could not find package configuration file provided by "ROOT" )*


------
https://chatgpt.com/codex/tasks/task_e_68bec4ff47a8832e9cb09aef5f110a49