### PR TITLE
Enforce region and variable inputs in PipelineBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ They are enabled in the `presets` block of the configuration:
 Each preset configures the `RegionsPlugin` with an analysis region matching the
 given selection rule.
 
+## PipelineBuilder usage
+
+When constructing a pipeline with presets, the `PipelineBuilder` now requires
+at least one variable and one region preset before adding plot presets. Region
+and variable presets are added with dedicated calls to make the intended
+structure explicit:
+
+```cpp
+PipelineBuilder builder(analysis_host, plot_host);
+builder.region("TRUE_NEUTRINO_VERTEX");
+builder.region("RECO_NEUTRINO_VERTEX");
+builder.variable("EMPTY");
+builder.preset("NEUTRINO_VERTEX_STACKED_PLOTS");
+```
+
 ## Run Periods
 
 1. Run 1 → October 2015 to July 2016

--- a/analysis.cpp
+++ b/analysis.cpp
@@ -74,7 +74,13 @@ buildPipeline(const nlohmann::json &cfg) {
                                                     {"plot_configs", v.value("plot_configs", PluginArgs::object())}});
                 }
             }
-            builder.use(name, vars, overrides);
+            std::string kind = p.value("kind", std::string("region"));
+            if (kind == "variable")
+                builder.variable(name, vars, overrides);
+            else if (kind == "preset")
+                builder.preset(name, vars, overrides);
+            else
+                builder.region(name, vars, overrides);
         }
     }
 

--- a/examples/neutrino_vertex_stacked_plots.cpp
+++ b/examples/neutrino_vertex_stacked_plots.cpp
@@ -11,10 +11,10 @@ int main() {
     PipelineBuilder builder(analysis_host, plot_host);
 
     // Mix variable and region presets with the stacked histogram preset
-    builder.use("TRUE_NEUTRINO_VERTEX");
-    builder.use("RECO_NEUTRINO_VERTEX");
-    builder.use("EMPTY");
-    builder.use("NEUTRINO_VERTEX_STACKED_PLOTS");
+    builder.region("TRUE_NEUTRINO_VERTEX");
+    builder.region("RECO_NEUTRINO_VERTEX");
+    builder.variable("EMPTY");
+    builder.preset("NEUTRINO_VERTEX_STACKED_PLOTS");
 
     builder.uniqueById();
 

--- a/include/analysis/PipelineBuilder.h
+++ b/include/analysis/PipelineBuilder.h
@@ -19,12 +19,55 @@ public:
       case Target::Plot:     p_.push_back({id, std::move(args)}); break;
       case Target::Both:     a_.push_back({id, args}); p_.push_back({id, std::move(args)}); break;
     }
+    if (id == "RegionsPlugin") has_region_ = true;
+    if (id == "VariablesPlugin") has_variable_ = true;
     return *this;
   }
 
-  PipelineBuilder& use(const std::string& preset,
-                       const PluginArgs& vars = {},
-                       const std::unordered_map<std::string, PluginArgs>& perPluginOverrides = {}) {
+  PipelineBuilder& preset(const std::string& name,
+                         const PluginArgs& vars = {},
+                         const std::unordered_map<std::string, PluginArgs>& perPluginOverrides = {}) {
+    return usePreset(name, vars, perPluginOverrides);
+  }
+
+  PipelineBuilder& region(const std::string& name,
+                         const PluginArgs& vars = {},
+                         const std::unordered_map<std::string, PluginArgs>& perPluginOverrides = {}) {
+    has_region_ = true;
+    return usePreset(name, vars, perPluginOverrides);
+  }
+
+  PipelineBuilder& variable(const std::string& name,
+                           const PluginArgs& vars = {},
+                           const std::unordered_map<std::string, PluginArgs>& perPluginOverrides = {}) {
+    has_variable_ = true;
+    return usePreset(name, vars, perPluginOverrides);
+  }
+
+  PipelineBuilder& uniqueById() {
+    auto uniq = [](PluginSpecList& v) {
+      std::unordered_set<std::string> seen;
+      PluginSpecList out; out.reserve(v.size());
+      for (auto& s : v) if (seen.insert(s.id).second) out.push_back(std::move(s));
+      v.swap(out);
+    };
+    uniq(a_); uniq(p_);
+    return *this;
+  }
+
+  void apply() {
+    ensureRequirements();
+    for (auto& s : a_) a_host_.add(s.id, s.args);
+    for (auto& s : p_) p_host_.add(s.id, s.args);
+  }
+
+  const PluginSpecList& analysisSpecs() const { ensureRequirements(); return a_; }
+  const PluginSpecList& plotSpecs() const { ensureRequirements(); return p_; }
+
+private:
+  PipelineBuilder& usePreset(const std::string& preset,
+                             const PluginArgs& vars,
+                             const std::unordered_map<std::string, PluginArgs>& perPluginOverrides) {
     auto pr = PresetRegistry::instance().find(preset);
     if (!pr) throw std::runtime_error("Unknown preset: " + preset);
     auto list = pr->make(vars);
@@ -42,29 +85,17 @@ public:
     return *this;
   }
 
-  PipelineBuilder& uniqueById() {
-    auto uniq = [](PluginSpecList& v) {
-      std::unordered_set<std::string> seen;
-      PluginSpecList out; out.reserve(v.size());
-      for (auto& s : v) if (seen.insert(s.id).second) out.push_back(std::move(s));
-      v.swap(out);
-    };
-    uniq(a_); uniq(p_);
-    return *this;
+  void ensureRequirements() const {
+    if (!has_region_)
+      throw std::runtime_error("PipelineBuilder requires at least one region preset");
+    if (!has_variable_)
+      throw std::runtime_error("PipelineBuilder requires at least one variable preset");
   }
-
-  void apply() {
-    for (auto& s : a_) a_host_.add(s.id, s.args);
-    for (auto& s : p_) p_host_.add(s.id, s.args);
-  }
-
-  const PluginSpecList& analysisSpecs() const { return a_; }
-  const PluginSpecList& plotSpecs() const { return p_; }
-
-private:
   AnalysisPluginHost& a_host_;
   PlotPluginHost& p_host_;
   PluginSpecList a_, p_;
+  bool has_region_ = false;
+  bool has_variable_ = false;
 };
 
 } // namespace analysis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,3 +18,7 @@ add_executable(test_quadtree_binning test_quadtree_binning.cpp)
 target_link_libraries(test_quadtree_binning PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
 catch_discover_tests(test_quadtree_binning)
 
+add_executable(test_pipeline_builder test_pipeline_builder.cpp)
+target_link_libraries(test_pipeline_builder PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
+catch_discover_tests(test_pipeline_builder)
+

--- a/tests/test_pipeline_builder.cpp
+++ b/tests/test_pipeline_builder.cpp
@@ -1,0 +1,17 @@
+#include "PipelineBuilder.h"
+#include "PresetRegistry.h"
+#include <catch2/catch_test_macros.hpp>
+
+using namespace analysis;
+
+TEST_CASE("pipeline_builder_requires_region_and_variable") {
+    AnalysisPluginHost a_host;
+    PlotPluginHost p_host;
+    PipelineBuilder builder(a_host, p_host);
+
+    builder.region("TRUE_NEUTRINO_VERTEX");
+    REQUIRE_THROWS(builder.analysisSpecs());
+
+    builder.variable("EMPTY");
+    REQUIRE_NOTHROW(builder.analysisSpecs());
+}


### PR DESCRIPTION
## Summary
- introduce `region`, `variable`, and generic `preset` helpers in PipelineBuilder for structured pipeline setup
- route configuration presets through the appropriate helper based on optional `kind`
- update docs, examples, and tests for the new structured API

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec4a5a344832e862cf08d9bbca36f