### PR TITLE
Add NUMU_CC snapshot preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ They are enabled in the `presets` block of the configuration:
 Each preset configures the `RegionsPlugin` with an analysis region matching the
 given selection rule.
 
+## Snapshot preset
+
+To write out events that satisfy the νµ charged‑current selection, enable the
+`NUMU_CC_SNAPSHOT` preset. It wires the `SnapshotPlugin` to dump the selected
+events to a ROOT file in the `snapshots` directory:
+
+```json
+{
+  "presets": [
+    { "name": "NUMU_CC_SNAPSHOT" }
+  ]
+}
+```
+
+The output file is named `<beam>_<periods>_NUMU_CC_snapshot.root`.
+
 ## Run Periods
 
 1. Run 1 → October 2015 to July 2016

--- a/src/presets/Presets_Standard.cpp
+++ b/src/presets/Presets_Standard.cpp
@@ -81,3 +81,15 @@ ANALYSIS_REGISTER_PRESET(QUALITY_NUMU_CC, Target::Analysis,
     return {{"RegionsPlugin", args}};
   }
 )
+
+// Preset to snapshot events passing the NuMu CC selection
+ANALYSIS_REGISTER_PRESET(NUMU_CC_SNAPSHOT, Target::Analysis,
+  [](const PluginArgs&) -> PluginSpecList {
+    nlohmann::json snap = {
+      {"selection_rule", "NUMU_CC"},
+      {"output_directory", "snapshots"}
+    };
+    PluginArgs args{{"analysis_configs", {{"snapshots", nlohmann::json::array({snap})}}}};
+    return {{"SnapshotPlugin", args}};
+  }
+)


### PR DESCRIPTION
## Summary
- Add NUMU_CC_SNAPSHOT preset to dump events passing the NuMu CC selection with SnapshotPlugin
- Document how to enable the NuMu snapshot preset in analysis configuration

## Testing
- `cmake -S . -B build` *(fails: could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68bec53b186c832e8aee625195b1df08