### PR TITLE
Add EventDisplay preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,27 @@ The `strategy` field accepts `equal_weight`, `uniform_width`, or `bayesian_block
 }
 ```
 
+The same configuration can be enabled via the `EVENT_DISPLAY` preset:
+
+```json
+{
+  "presets": [
+    {
+      "name": "EVENT_DISPLAY",
+      "vars": {
+        "plot_configs": {
+          "sample": "sample",
+          "region": "REGION_KEY",
+          "n_events": 5,
+          "image_size": 800,
+          "output_directory": "./plots"
+        }
+      }
+    }
+  ]
+}
+```
+
 ```json
 {
   "path": "build/PerformancePlotPlugin.so",

--- a/src/presets/Presets_Plots.cpp
+++ b/src/presets/Presets_Plots.cpp
@@ -14,3 +14,23 @@ ANALYSIS_REGISTER_PRESET(STACKED_PLOTS, Target::Plot,
   }
 )
 
+// Preset to configure the EventDisplay plugin with a single display request.
+// Values are taken from the provided variables or fall back to sensible
+// defaults matching the plugin's own choices.
+ANALYSIS_REGISTER_PRESET(EVENT_DISPLAY, Target::Plot,
+  [](const PluginArgs& vars) -> PluginSpecList {
+    auto cfg = vars.plot_configs;
+    nlohmann::json ed = {
+      {"sample", cfg.value("sample", std::string{})},
+      {"region", cfg.value("region", std::string{})},
+      {"n_events", cfg.value("n_events", 1)},
+      {"image_size", cfg.value("image_size", 800)},
+      {"output_directory",
+       cfg.value("output_directory", std::string{"./plots/event_displays"})}
+    };
+    PluginArgs args{{"plot_configs",
+                     {{"event_displays", nlohmann::json::array({ed})}}}};
+    return {{"EventDisplayPlugin", args}};
+  }
+)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,3 +18,9 @@ add_executable(test_quadtree_binning test_quadtree_binning.cpp)
 target_link_libraries(test_quadtree_binning PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
 catch_discover_tests(test_quadtree_binning)
 
+add_executable(test_event_display_preset
+  test_event_display_preset.cpp
+  ${CMAKE_SOURCE_DIR}/src/presets/Presets_Plots.cpp)
+target_link_libraries(test_event_display_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
+catch_discover_tests(test_event_display_preset)
+

--- a/tests/test_event_display_preset.cpp
+++ b/tests/test_event_display_preset.cpp
@@ -1,0 +1,24 @@
+#include "PresetRegistry.h"
+#include <catch2/catch_test_macros.hpp>
+
+using namespace analysis;
+
+TEST_CASE("event_display_preset_generates_plugin_spec") {
+    PluginArgs vars{{"plot_configs", {{"sample", "s"}, {"region", "R"}}}};
+    auto pr = PresetRegistry::instance().find("EVENT_DISPLAY");
+    REQUIRE(pr != nullptr);
+    auto list = pr->make(vars);
+    REQUIRE(list.size() == 1);
+    auto spec = list.front();
+    REQUIRE(spec.id == "EventDisplayPlugin");
+    REQUIRE(spec.args.plot_configs.contains("event_displays"));
+    auto eds = spec.args.plot_configs.at("event_displays");
+    REQUIRE(eds.is_array());
+    REQUIRE(eds.size() == 1);
+    auto ed = eds.at(0);
+    REQUIRE(ed.at("sample") == "s");
+    REQUIRE(ed.at("region") == "R");
+    REQUIRE(ed.at("n_events") == 1);
+    REQUIRE(ed.at("image_size") == 800);
+    REQUIRE(ed.at("output_directory") == "./plots/event_displays");
+}


### PR DESCRIPTION
## Summary
- add EVENT_DISPLAY preset to simplify configuring EventDisplayPlugin
- cover preset with unit test
- document new preset usage in README

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT"; please install ROOT and retry)*
- `apt-get update` *(fails: repository InRelease not signed / 403 Forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bec6ce3510832e8a8251fc6d2c9051