### PR TITLE
Enable programmatic plugin configuration for AnalysisRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,20 @@ builder.variable("EMPTY");
 builder.preset("NEUTRINO_VERTEX_STACKED_PLOTS");
 ```
 
+The resulting specification lists can be supplied directly to `AnalysisRunner`
+without writing intermediate JSON:
+
+```cpp
+auto analysis_specs = builder.analysisSpecs();
+// configure data_loader, histogram_factory, and syst_processor
+AnalysisRunner runner(data_loader, std::move(histogram_factory),
+                      syst_processor, analysis_specs);
+auto result = runner.run();
+```
+
+See [`examples/analysis_runner_example.cpp`](examples/analysis_runner_example.cpp)
+for a more complete demonstration.
+
 ## Run Periods
 
 1. Run 1 → October 2015 to July 2016

--- a/analysis.cpp
+++ b/analysis.cpp
@@ -34,21 +34,6 @@ using analysis::PluginArgs;
 using analysis::PluginSpecList;
 using analysis::Target;
 
-// Convert a list of plugin specifications to the JSON format
-// consumed by AnalysisRunner's constructor.
-static nlohmann::json specsToJson(const PluginSpecList &specs) {
-    nlohmann::json arr = nlohmann::json::array();
-    for (auto const &s : specs) {
-        nlohmann::json arg = nlohmann::json::object();
-        if (!s.args.analysis_configs.is_null() && !s.args.analysis_configs.empty())
-            arg["analysis_configs"] = s.args.analysis_configs;
-        if (!s.args.plot_configs.is_null() && !s.args.plot_configs.empty())
-            arg["plot_configs"] = s.args.plot_configs;
-        arr.push_back({{"id", s.id}, {"args", arg}});
-    }
-    return nlohmann::json{{"plugins", arr}};
-}
-
 // Build separate analysis and plot plugin specification lists using
 // the PipelineBuilder. This supports presets and explicit plugins in
 // the configuration.
@@ -130,9 +115,8 @@ processBeamline(analysis::RunConfigRegistry &run_config_registry,
     auto histogram_factory =
         std::make_unique<analysis::HistogramFactory>();
 
-    nlohmann::json plugin_cfg = specsToJson(analysis_specs);
     analysis::AnalysisRunner runner(data_loader, std::move(histogram_factory),
-                                    systematics_processor, plugin_cfg);
+                                    systematics_processor, analysis_specs);
 
     return runner.run();
 }

--- a/examples/analysis_runner_example.cpp
+++ b/examples/analysis_runner_example.cpp
@@ -1,0 +1,51 @@
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <vector>
+
+#include "AnalysisDataLoader.h"
+#include "AnalysisRunner.h"
+#include "HistogramFactory.h"
+#include "PipelineBuilder.h"
+#include "PresetRegistry.h"
+#include "RunConfigLoader.h"
+#include "RunConfigRegistry.h"
+#include "SystematicsProcessor.h"
+#include "VariableRegistry.h"
+
+// Demonstrates constructing plugin specifications programmatically and
+// passing them directly to AnalysisRunner.
+int main() {
+  using namespace analysis;
+
+  AnalysisPluginHost analysis_host;
+  PlotPluginHost plot_host;
+  PipelineBuilder builder(analysis_host, plot_host);
+
+  builder.region("TRUE_NEUTRINO_VERTEX");
+  builder.region("RECO_NEUTRINO_VERTEX");
+  builder.variable("EMPTY");
+  builder.preset("STACKED_PLOTS");
+  builder.uniqueById();
+
+  auto analysis_specs = builder.analysisSpecs();
+
+  nlohmann::json samples = {{"ntupledir", "/path/to/ntuples"},
+                            {"beamlines", {{"bnb", {{"run1", {}}}}}}};
+
+  RunConfigRegistry run_config_registry;
+  RunConfigLoader::loadFromJson(samples, run_config_registry);
+
+  VariableRegistry variable_registry;
+  SystematicsProcessor syst_processor(variable_registry);
+
+  AnalysisDataLoader data_loader(run_config_registry, variable_registry, "bnb",
+                                 {"run1"}, "/path/to/ntuples", true);
+
+  auto histogram_factory = std::make_unique<HistogramFactory>();
+
+  AnalysisRunner runner(data_loader, std::move(histogram_factory),
+                        syst_processor, analysis_specs);
+  auto result = runner.run();
+  (void)result;
+  return 0;
+}

--- a/libapp/AnalysisRunner.h
+++ b/libapp/AnalysisRunner.h
@@ -8,8 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include <nlohmann/json.hpp>
-
 #include "AnalysisDataLoader.h"
 #include "AnalysisDefinition.h"
 #include "AnalysisKey.h"
@@ -26,8 +24,8 @@
 #include "CutFlowCalculator.h"
 #include "VariableProcessor.h"
 
-// NEW
 #include "PluginAliases.h"
+#include "PluginSpec.h"
 
 namespace analysis {
 
@@ -36,7 +34,7 @@ public:
   AnalysisRunner(AnalysisDataLoader &ldr,
                  std::unique_ptr<HistogramFactory> factory,
                  SystematicsProcessor &sys_proc,
-                 const nlohmann::json &plgn_cfg)
+                 const PluginSpecList &specs)
     : a_host_(&ldr),
       p_host_(&ldr),
       data_loader_(ldr),
@@ -51,18 +49,8 @@ public:
     // const char* dir = std::getenv("ANALYSIS_PLUGIN_DIR");
     // if (dir) a_host_.loadDirectory(dir, /*recurse=*/false);
 
-    // Load plugin specs (new format) into analysis host
-    if (plgn_cfg.contains("plugins")) {
-      for (const auto& p : plgn_cfg.at("plugins")) {
-        std::string id = p.at("id").get<std::string>();
-        PluginArgs args;
-        if (p.contains("args")) {
-          const auto& jargs = p.at("args");
-          if (jargs.contains("analysis_configs")) args.analysis_configs = jargs.at("analysis_configs");
-          if (jargs.contains("plot_configs")) args.plot_configs = jargs.at("plot_configs");
-        }
-        a_host_.add(id, args);
-      }
+    for (const auto &s : specs) {
+      a_host_.add(s.id, s.args);
     }
   }
 


### PR DESCRIPTION
## Summary
- Accept plugin spec lists in AnalysisRunner instead of JSON config
- Build analysis pipeline programmatically and pass specs to AnalysisRunner
- Document programmatic AnalysisRunner usage with example and README

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68becb804fe8832ea3b078d99c6615e7