### PR TITLE
Fix plugin registry macro and json helper

### DIFF
--- a/include/analysis/PluginArgs.h
+++ b/include/analysis/PluginArgs.h
@@ -31,9 +31,11 @@ struct PluginArgs {
     // Convenience helpers mirroring a subset of the old nlohmann::json API.
     static nlohmann::json object() { return nlohmann::json::object(); }
     static nlohmann::json array(std::initializer_list<nlohmann::json> init = {}) {
-        nlohmann::json arr = nlohmann::json::array();
-        arr.insert(arr.end(), init.begin(), init.end());
-        return arr;
+        // nlohmann::json does not provide an insert overload that accepts
+        // iterators from a std::initializer_list.  Construct the array directly
+        // from the initializer list instead, which works for any mix of JSON
+        // values without requiring manual insertion.
+        return nlohmann::json::array(init);
     }
 };
 

--- a/include/analysis/PluginRegistry.h
+++ b/include/analysis/PluginRegistry.h
@@ -42,8 +42,14 @@ private:
 
 #define ANALYSIS_REGISTER_PLUGIN(Interface, Ctx, NameStr, Concrete)           \
   namespace {                                                                 \
-  struct Concrete##_Registrar {                                               \
-    Concrete##_Registrar() {                                                  \
+  /*
+   * Use a generic registrar name inside an anonymous namespace so that the
+   * macro works even when Concrete is a fully qualified type (e.g.
+   * analysis::Foo).  The anonymous namespace ensures each translation unit
+   * gets its own instance without symbol clashes.
+   */                                                                        \
+  struct Registrar {                                                          \
+    Registrar() {                                                             \
       ::analysis::Registry<Interface, Ctx>::instance().registerFactory(       \
         NameStr,                                                              \
         [](const ::analysis::PluginArgs& args, Ctx* ctx) {                    \
@@ -52,7 +58,7 @@ private:
       );                                                                      \
     }                                                                         \
   };                                                                          \
-  static Concrete##_Registrar Concrete##_Registrar_Instance;                  \
+  static Registrar registrar_instance;                                        \
   }
 
 } // namespace analysis


### PR DESCRIPTION
## Summary
- fix PluginArgs::array to construct array from initializer list correctly
- simplify plugin registration macro to handle qualified class names

## Testing
- `cmake -S . -B build` (fails: Could not find package ROOT)
- `apt-get update` (fails: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_68becd6f3554832e8787e7d12da99876