### PR TITLE
Fix PluginArgs array helper for nlohmann json

### DIFF
--- a/include/analysis/PluginArgs.h
+++ b/include/analysis/PluginArgs.h
@@ -31,11 +31,14 @@ struct PluginArgs {
     // Convenience helpers mirroring a subset of the old nlohmann::json API.
     static nlohmann::json object() { return nlohmann::json::object(); }
     static nlohmann::json array(std::initializer_list<nlohmann::json> init = {}) {
-        // nlohmann::json does not provide an insert overload that accepts
-        // iterators from a std::initializer_list.  Construct the array directly
-        // from the initializer list instead, which works for any mix of JSON
-        // values without requiring manual insertion.
-        return nlohmann::json::array(init);
+        // nlohmann::json::array(initializer_list) expects a list of json_ref
+        // objects, which cannot be constructed implicitly from a list of
+        // ``nlohmann::json`` values.  Build the array manually instead.
+        auto arr = nlohmann::json::array();
+        for (const auto &el : init) {
+            arr.push_back(el);
+        }
+        return arr;
     }
 };
 


### PR DESCRIPTION
## Summary
- manually build JSON arrays in `PluginArgs::array` to avoid `json_ref` incompatibility

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: 403 Forbidden for Ubuntu package sources)*

------
https://chatgpt.com/codex/tasks/task_e_68bece5fa034832eabb55be709d351b0