### PR TITLE
Fix preset macro argument handling and plugin includes

### DIFF
--- a/libplug/plotting/CutFlowPlotPlugin.cc
+++ b/libplug/plotting/CutFlowPlotPlugin.cc
@@ -10,6 +10,7 @@
 #include "IPlotPlugin.h"
 #include "SelectionEfficiencyPlot.h"
 #include "StratifierRegistry.h"
+#include "AnalysisDataLoader.h"
 
 namespace analysis {
 

--- a/libplug/plotting/SystematicBreakdownPlugin.cc
+++ b/libplug/plotting/SystematicBreakdownPlugin.cc
@@ -8,6 +8,7 @@
 #include "Logger.h"
 #include "IPlotPlugin.h"
 #include "SystematicBreakdownPlot.h"
+#include "AnalysisDataLoader.h"
 
 namespace analysis {
 

--- a/src/presets/Presets_Standard.cpp
+++ b/src/presets/Presets_Standard.cpp
@@ -9,21 +9,21 @@ using namespace analysis;
 // in plugin code.  These presets can be expanded as needed by providing
 // PluginSpecLists constructed from the strongly typed PluginArgs structure.
 ANALYSIS_REGISTER_PRESET(BaselineAnalysis, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList { return {}; }
+  ([](const PluginArgs&) -> PluginSpecList { return {}; })
 )
 
 ANALYSIS_REGISTER_PRESET(TruthMetrics, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList { return {}; }
+  ([](const PluginArgs&) -> PluginSpecList { return {}; })
 )
 
 ANALYSIS_REGISTER_PRESET(StandardPlots, Target::Plot,
-  [](const PluginArgs&) -> PluginSpecList { return {}; }
+  ([](const PluginArgs&) -> PluginSpecList { return {}; })
 )
 
 // Presets defining common analysis regions.  Each preset configures the
 // RegionsPlugin with a single region tied to a selection rule.
 ANALYSIS_REGISTER_PRESET(EMPTY, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList {
+  ([](const PluginArgs&) -> PluginSpecList {
     nlohmann::json region = {
       {"region_key", "EMPTY"},
       {"label", "Empty Selection"},
@@ -31,11 +31,11 @@ ANALYSIS_REGISTER_PRESET(EMPTY, Target::Analysis,
     };
     PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
     return {{"RegionsPlugin", args}};
-  }
+  })
 )
 
 ANALYSIS_REGISTER_PRESET(QUALITY, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList {
+  ([](const PluginArgs&) -> PluginSpecList {
     nlohmann::json region = {
       {"region_key", "QUALITY"},
       {"label", "Quality Selection"},
@@ -43,11 +43,11 @@ ANALYSIS_REGISTER_PRESET(QUALITY, Target::Analysis,
     };
     PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
     return {{"RegionsPlugin", args}};
-  }
+  })
 )
 
 ANALYSIS_REGISTER_PRESET(MUON, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList {
+  ([](const PluginArgs&) -> PluginSpecList {
     nlohmann::json region = {
       {"region_key", "MUON"},
       {"label", "Muon Selection"},
@@ -55,11 +55,11 @@ ANALYSIS_REGISTER_PRESET(MUON, Target::Analysis,
     };
     PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
     return {{"RegionsPlugin", args}};
-  }
+  })
 )
 
 ANALYSIS_REGISTER_PRESET(NUMU_CC, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList {
+  ([](const PluginArgs&) -> PluginSpecList {
     nlohmann::json region = {
       {"region_key", "NUMU_CC"},
       {"label", "NuMu CC Selection"},
@@ -67,11 +67,11 @@ ANALYSIS_REGISTER_PRESET(NUMU_CC, Target::Analysis,
     };
     PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
     return {{"RegionsPlugin", args}};
-  }
+  })
 )
 
 ANALYSIS_REGISTER_PRESET(QUALITY_NUMU_CC, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList {
+  ([](const PluginArgs&) -> PluginSpecList {
     nlohmann::json region = {
       {"region_key", "QUALITY_NUMU_CC"},
       {"label", "Quality + NuMu CC Selection"},
@@ -79,17 +79,17 @@ ANALYSIS_REGISTER_PRESET(QUALITY_NUMU_CC, Target::Analysis,
     };
     PluginArgs args{{"analysis_configs", {{"regions", nlohmann::json::array({region})}}}};
     return {{"RegionsPlugin", args}};
-  }
+  })
 )
 
 // Preset to snapshot events passing the NuMu CC selection
 ANALYSIS_REGISTER_PRESET(NUMU_CC_SNAPSHOT, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList {
+  ([](const PluginArgs&) -> PluginSpecList {
     nlohmann::json snap = {
       {"selection_rule", "NUMU_CC"},
       {"output_directory", "snapshots"}
     };
     PluginArgs args{{"analysis_configs", {{"snapshots", nlohmann::json::array({snap})}}}};
     return {{"SnapshotPlugin", args}};
-  }
+  })
 )

--- a/src/presets/Presets_Vertices.cpp
+++ b/src/presets/Presets_Vertices.cpp
@@ -6,7 +6,7 @@ using namespace analysis;
 
 // Preset defining variables for the true neutrino interaction vertex.
 ANALYSIS_REGISTER_PRESET(TRUE_NEUTRINO_VERTEX, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList {
+  ([](const PluginArgs&) -> PluginSpecList {
     nlohmann::json vars = nlohmann::json::array({
       {
         {"name", "nu_vtx_x"},
@@ -32,12 +32,12 @@ ANALYSIS_REGISTER_PRESET(TRUE_NEUTRINO_VERTEX, Target::Analysis,
     });
     PluginArgs args{{"analysis_configs", {{"variables", vars}}}};
     return {{"VariablesPlugin", args}};
-  }
+  })
 )
 
 // Preset defining variables for the reconstructed neutrino interaction vertex.
 ANALYSIS_REGISTER_PRESET(RECO_NEUTRINO_VERTEX, Target::Analysis,
-  [](const PluginArgs&) -> PluginSpecList {
+  ([](const PluginArgs&) -> PluginSpecList {
     nlohmann::json vars = nlohmann::json::array({
       {
         {"name", "reco_nu_vtx_x"},
@@ -63,7 +63,7 @@ ANALYSIS_REGISTER_PRESET(RECO_NEUTRINO_VERTEX, Target::Analysis,
     });
     PluginArgs args{{"analysis_configs", {{"variables", vars}}}};
     return {{"VariablesPlugin", args}};
-  }
+  })
 )
 
 


### PR DESCRIPTION
## Summary
- Wrap Preset registration lambdas in parentheses so macros see a single argument
- Include `AnalysisDataLoader.h` in plot plugins to satisfy forward declarations

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68becf32e620832e8a69bddc7ba25d47