### PR TITLE
Add programmable analysis runner scripts

### DIFF
--- a/scripts/programmable/run_stacked_plots.py
+++ b/scripts/programmable/run_stacked_plots.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Run the analysis runner using preset-based specifications only.
+
+This script builds a minimal pipeline composed of region, variable,
+and plot presets and executes the analysis runner. The path to the
+sample configuration is hardcoded to ``sample.json`` within this
+directory.
+"""
+
+import json
+import os
+import subprocess
+from typing import Optional, Dict, Any
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+SAMPLE_CFG = os.path.join(ROOT_DIR, "sample.json")
+
+
+def build_pipeline(preset: str, preset_vars: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    block: Dict[str, Any] = {"name": preset, "kind": "preset"}
+    if preset_vars:
+        block["vars"] = preset_vars
+    return {
+        "pipeline": {
+            "presets": [
+                {"name": "TRUE_NEUTRINO_VERTEX", "kind": "region"},
+                {"name": "RECO_NEUTRINO_VERTEX", "kind": "region"},
+                {"name": "EMPTY", "kind": "variable"},
+                block,
+            ]
+        }
+    }
+
+
+def run(preset: str = "STACKED_PLOTS", preset_vars: Optional[Dict[str, Any]] = None) -> None:
+    pipeline = build_pipeline(preset, preset_vars)
+    pipeline_path = os.path.join(ROOT_DIR, "pipeline.json")
+    with open(pipeline_path, "w", encoding="utf-8") as handle:
+        json.dump(pipeline, handle, indent=2)
+
+    subprocess.run(
+        ["./build/analyse", SAMPLE_CFG, pipeline_path],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/programmable/run_with_override.py
+++ b/scripts/programmable/run_with_override.py
@@ -1,0 +1,41 @@
+import json
+import os
+import subprocess
+from typing import Dict, Any
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+SAMPLE_CFG = os.path.join(ROOT_DIR, "sample.json")
+
+
+def build_pipeline() -> Dict[str, Any]:
+    return {
+        "pipeline": {
+            "presets": [
+                {"name": "TRUE_NEUTRINO_VERTEX", "kind": "region"},
+                {"name": "RECO_NEUTRINO_VERTEX", "kind": "region"},
+                {"name": "EMPTY", "kind": "variable"},
+                {
+                    "name": "STACKED_PLOTS",
+                    "kind": "preset",
+                    "overrides": {
+                        "StackedHistogramPlugin": {
+                            "plot_configs": {"output_directory": "./alt_plots"}
+                        }
+                    },
+                },
+            ]
+        }
+    }
+
+
+def run() -> None:
+    pipeline = build_pipeline()
+    pipeline_path = os.path.join(ROOT_DIR, "pipeline_override.json")
+    with open(pipeline_path, "w", encoding="utf-8") as handle:
+        json.dump(pipeline, handle, indent=2)
+
+    subprocess.run(["./build/analyse", SAMPLE_CFG, pipeline_path], check=True)
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/programmable/sample.json
+++ b/scripts/programmable/sample.json
@@ -1,0 +1,8 @@
+{
+  "ntupledir": "/path/to/ntuples",
+  "beamlines": {
+    "bnb": {
+      "run1": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add example scripts for programmatic AnalysisRunner invocation using presets
- Demonstrate overriding plugin settings and hardcode sample configuration path

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bece9b4164832e9b83977fe219b248