### PR TITLE
Include AnalysisDataLoader header in UnstackedHistogramPlugin

### DIFF
--- a/libplug/plotting/UnstackedHistogramPlugin.cc
+++ b/libplug/plotting/UnstackedHistogramPlugin.cc
@@ -7,6 +7,7 @@
 #include "PluginRegistry.h"
 #include <TSystem.h>
 
+#include "AnalysisDataLoader.h"
 #include "Logger.h"
 #include "IPlotPlugin.h"
 #include "UnstackedHistogramPlot.h"


### PR DESCRIPTION
## Summary
- Fix compilation by including `AnalysisDataLoader` in `UnstackedHistogramPlugin`.

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bed363e764832e8b125b829a33ee53