### PR TITLE
Link pipeline builder test against dl library

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,5 +25,5 @@ target_link_libraries(test_event_display_preset PRIVATE Catch2::Catch2WithMain n
 catch_discover_tests(test_event_display_preset)
 
 add_executable(test_pipeline_builder test_pipeline_builder.cpp)
-target_link_libraries(test_pipeline_builder PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES})
+target_link_libraries(test_pipeline_builder PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES} ${CMAKE_DL_LIBS})
 catch_discover_tests(test_pipeline_builder)


### PR DESCRIPTION
## Summary
- Link `test_pipeline_builder` against the system dl library to resolve missing symbol errors

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT"...)*

------
https://chatgpt.com/codex/tasks/task_e_68bed3ff4d60832e8bdf5e9169c5ce6c