### PR TITLE
Include preset sources in pipeline builder test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,9 @@ add_executable(test_event_display_preset
 target_link_libraries(test_event_display_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
 catch_discover_tests(test_event_display_preset)
 
-add_executable(test_pipeline_builder test_pipeline_builder.cpp)
-target_link_libraries(test_pipeline_builder PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES} ${CMAKE_DL_LIBS})
+add_executable(test_pipeline_builder
+  test_pipeline_builder.cpp
+  ${CMAKE_SOURCE_DIR}/src/presets/Presets_Standard.cpp
+  ${CMAKE_SOURCE_DIR}/src/presets/Presets_Vertices.cpp)
+target_link_libraries(test_pipeline_builder PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain nlohmann_json::nlohmann_json ${ROOT_LIBRARIES} ${CMAKE_DL_LIBS})
 catch_discover_tests(test_pipeline_builder)


### PR DESCRIPTION
## Summary
- Ensure pipeline builder test registers standard and vertex presets

## Testing
- `cmake ..` *(fails: Could not find package ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bed49a191c832e8555bb8495fded00