### PR TITLE
Use shared sample configuration for programmable example

### DIFF
--- a/configs/sample.json
+++ b/configs/sample.json
@@ -1,0 +1,20 @@
+{
+  "samples": {
+    "ntupledir": "/path/to/ntuples",
+    "beamlines": {
+      "bnb": {
+        "run1": {
+          "samples": [
+            {
+              "sample_key": "mc_example",
+              "sample_type": "mc",
+              "active": true,
+              "relative_path": "mc_example.root",
+              "pot": 1.0
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/scripts/programmable/run_stacked_plots.py
+++ b/scripts/programmable/run_stacked_plots.py
@@ -3,8 +3,8 @@
 
 This script builds a minimal pipeline composed of region, variable,
 and plot presets and executes the analysis runner. The path to the
-sample configuration is hardcoded to ``sample.json`` within this
-directory.
+sample configuration is set to ``configs/sample.json`` at the
+repository root so the example uses the shared configuration file.
 """
 
 import json
@@ -13,7 +13,8 @@ import subprocess
 from typing import Optional, Dict, Any
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-SAMPLE_CFG = os.path.join(ROOT_DIR, "sample.json")
+REPO_ROOT = os.path.abspath(os.path.join(ROOT_DIR, "..", ".."))
+SAMPLE_CFG = os.path.join(REPO_ROOT, "configs", "sample.json")
 
 
 def build_pipeline(preset: str, preset_vars: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/scripts/programmable/sample.json
+++ b/scripts/programmable/sample.json
@@ -1,8 +1,0 @@
-{
-  "ntupledir": "/path/to/ntuples",
-  "beamlines": {
-    "bnb": {
-      "run1": {}
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- move example sample configuration into `configs/`
- update programmable runner to reference shared sample file

## Testing
- `pytest -q`
- `cmake -S . -B build` *(fails: Could not find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bed4b49828832e8cbd364aa5b57ad7