### PR TITLE
Add rule lookup helper to SelectionRegistry

### DIFF
--- a/libapp/SelectionRegistry.h
+++ b/libapp/SelectionRegistry.h
@@ -23,22 +23,30 @@ class SelectionRegistry {
 
     void addRule(std::string key, SelectionRule rule) { rules_.emplace(std::move(key), std::move(rule)); }
 
+    /// Return a SelectionQuery representing the rule identified by `key`.
+    /// Throws std::out_of_range if the rule is not registered.
     SelectionQuery get(const std::string &key) const {
-        auto it = rules_.find(key);
-        if (it == rules_.end())
+        const SelectionRule *rule = this->findRule(key);
+        if (!rule)
             throw std::out_of_range("Unknown selection key: " + key);
-        return this->makeSelection(it->second);
+        return this->makeSelection(*rule);
     }
 
+    /// Retrieve the SelectionRule identified by `key` without constructing a
+    /// SelectionQuery. Throws std::out_of_range if the rule is not registered.
     const SelectionRule &getRule(const std::string &key) const {
-        auto it = rules_.find(key);
-        if (it == rules_.end()) {
+        const SelectionRule *rule = this->findRule(key);
+        if (!rule)
             throw std::out_of_range("unknown selection rule: " + key);
-        }
-        return it->second;
+        return *rule;
     }
 
   private:
+    const SelectionRule *findRule(const std::string &key) const {
+        auto it = rules_.find(key);
+        return it == rules_.end() ? nullptr : &it->second;
+    }
+
     SelectionQuery makeSelection(const SelectionRule &r) const {
         if (r.clauses.empty())
             return SelectionQuery{};


### PR DESCRIPTION
## Summary
- factor out rule lookup into private `findRule` utility
- use `findRule` in `get` and `getRule`
- clarify `get` vs `getRule` behavior in comments

## Testing
- `source .setup.sh` (fails: No such file or directory)
- `source .build.sh` (fails: Could not find ROOT package)


------
https://chatgpt.com/codex/tasks/task_e_68bed9912cc4832ea7182866cc5db6c1