### PR TITLE
Ensure plugin registrars persist under link-time optimization

### DIFF
--- a/include/analysis/PluginRegistry.h
+++ b/include/analysis/PluginRegistry.h
@@ -58,7 +58,11 @@ private:
       );                                                                      \
     }                                                                         \
   };                                                                          \
-  static Registrar registrar_instance;                                        \
+#if defined(__GNUC__) || defined(__clang__)                                   \
+  static Registrar registrar_instance __attribute__((used));                  \
+#else                                                                        \
+  static Registrar registrar_instance;                                       \
+#endif                                                                       \
   }
 
 } // namespace analysis


### PR DESCRIPTION
## Summary
- prevent registrar symbols from being garbage-collected so dynamically loaded plugins register correctly

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bed9d20760832e8317b058597198fc