### PR TITLE
Make analysis script executable and allow file-based pipeline samples

### DIFF
--- a/PipelineRunner.cpp
+++ b/PipelineRunner.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -207,6 +208,13 @@ AnalysisResult PipelineRunner::run(const nlohmann::json &samples,
   result.saveToFile(output_path.c_str());
   runPlotting(samples, plot_specs_, result);
   return result;
+}
+
+AnalysisResult PipelineRunner::run(const std::string &samples_path,
+                                   const std::string &output_path) const {
+  std::ifstream in(samples_path);
+  nlohmann::json samples = nlohmann::json::parse(in, nullptr, true, true);
+  return run(samples, output_path);
 }
 
 } // namespace analysis

--- a/ana/pipeline_runner_example.cpp
+++ b/ana/pipeline_runner_example.cpp
@@ -1,5 +1,3 @@
-#include <nlohmann/json.hpp>
-
 #include "PipelineBuilder.h"
 #include "PipelineRunner.h"
 
@@ -20,13 +18,8 @@ int main() {
   auto analysis_specs = builder.analysisSpecs();
   auto plot_specs = builder.plotSpecs();
 
-  // Minimal sample configuration
-  nlohmann::json samples = {
-      {"ntupledir", "/path/to/ntuples"},
-      {"beamlines", {{"bnb", {{"run1", {}}}}}}};
-
   PipelineRunner runner(analysis_specs, plot_specs);
-  runner.run(samples, "/tmp/output.root");
+  runner.run("config/samples.json", "/tmp/output.root");
 
   return 0;
 }

--- a/libpipe/PipelineRunner.h
+++ b/libpipe/PipelineRunner.h
@@ -28,6 +28,11 @@ public:
   AnalysisResult run(const nlohmann::json &samples,
                      const std::string &output_path) const;
 
+  // Convenience overload: load the samples configuration from a JSON file
+  // located at \p samples_path before executing the analysis pipeline.
+  AnalysisResult run(const std::string &samples_path,
+                     const std::string &output_path) const;
+
 private:
   PluginSpecList analysis_specs_;
   PluginSpecList plot_specs_;


### PR DESCRIPTION
## Summary
- Add overload to PipelineRunner to accept a path to a JSON sample configuration file
- Update example analysis script to use `config/samples.json` and mark it executable

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bee1115f24832eb812b49d7cca6b10