### PR TITLE
Use variable presets for neutrino vertices

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ structure explicit:
 
 ```cpp
 PipelineBuilder builder(analysis_host, plot_host);
-builder.region("TRUE_NEUTRINO_VERTEX");
-builder.region("RECO_NEUTRINO_VERTEX");
-builder.variable("EMPTY");
-builder.preset("NEUTRINO_VERTEX_STACKED_PLOTS");
+builder.region("EMPTY");
+builder.variable("TRUE_NEUTRINO_VERTEX");
+builder.variable("RECO_NEUTRINO_VERTEX");
+builder.preset("STACKED_PLOTS");
 ```
 
 The resulting specification lists can be supplied directly to `AnalysisRunner`

--- a/ana/pipeline_runner_example.cpp
+++ b/ana/pipeline_runner_example.cpp
@@ -11,9 +11,9 @@ int main() {
   PipelineBuilder builder(analysis_host, plot_host);
 
   // Build a simple pipeline programmatically
-  builder.region("TRUE_NEUTRINO_VERTEX");
-  builder.region("RECO_NEUTRINO_VERTEX");
-  builder.variable("EMPTY");
+  builder.region("EMPTY");
+  builder.variable("TRUE_NEUTRINO_VERTEX");
+  builder.variable("RECO_NEUTRINO_VERTEX");
   builder.preset("STACKED_PLOTS");
   builder.uniqueById();
 

--- a/tests/test_pipeline_builder.cpp
+++ b/tests/test_pipeline_builder.cpp
@@ -9,9 +9,9 @@ TEST_CASE("pipeline_builder_requires_region_and_variable") {
     PlotPluginHost p_host;
     PipelineBuilder builder(a_host, p_host);
 
-    builder.region("TRUE_NEUTRINO_VERTEX");
+    builder.region("EMPTY");
     REQUIRE_THROWS(builder.analysisSpecs());
 
-    builder.variable("EMPTY");
+    builder.variable("TRUE_NEUTRINO_VERTEX");
     REQUIRE_NOTHROW(builder.analysisSpecs());
 }


### PR DESCRIPTION
## Summary
- treat TRUE_NEUTRINO_VERTEX and RECO_NEUTRINO_VERTEX as variable presets, not regions
- supply an EMPTY region when building example pipelines
- update pipeline builder test to use proper region/variable presets

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bee1521a3c832e97f97cd297befde7