### PR TITLE
Add file-based PipelineRunner run overload and update example

### DIFF
--- a/ana/pipeline_runner_example.cpp
+++ b/ana/pipeline_runner_example.cpp
@@ -1,5 +1,3 @@
-#include <nlohmann/json.hpp>
-
 #include "PipelineBuilder.h"
 #include "PipelineRunner.h"
 
@@ -20,13 +18,8 @@ int main() {
   auto analysis_specs = builder.analysisSpecs();
   auto plot_specs = builder.plotSpecs();
 
-  // Minimal sample configuration
-  nlohmann::json samples = {
-      {"ntupledir", "/path/to/ntuples"},
-      {"beamlines", {{"bnb", {{"run1", {}}}}}}};
-
   PipelineRunner runner(analysis_specs, plot_specs);
-  runner.run(samples, "/tmp/output.root");
+  runner.run("config/samples.json", "/tmp/output.root");
 
   return 0;
 }

--- a/libpipeline/PipelineRunner.h
+++ b/libpipeline/PipelineRunner.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <fstream>
 
 #include <ROOT/RDataFrame.hxx>
 #include <nlohmann/json.hpp>
@@ -210,6 +211,18 @@ public:
     result.saveToFile(output_path.c_str());
     detail::runPlotting(samples, plot_specs_, result);
     return result;
+  }
+
+  // Convenience overload that loads the samples configuration from a
+  // JSON file located at \p samples_path before executing the analysis and
+  // plotting stages. The analysis result is written to \p output_path and
+  // returned to the caller.
+  inline AnalysisResult run(const std::string &samples_path,
+                            const std::string &output_path) const {
+    std::ifstream in(samples_path);
+    nlohmann::json samples;
+    in >> samples;
+    return run(samples, output_path);
   }
 
 private:


### PR DESCRIPTION
## Summary
- add PipelineRunner::run overload taking path to JSON samples file
- read config/samples.json in pipeline_runner_example and make script executable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bee1f88070832e94f97f07aad08da3