### PR TITLE
Add samples file PipelineRunner overload and update example

### DIFF
--- a/ana/pipeline_runner_example.cpp
+++ b/ana/pipeline_runner_example.cpp
@@ -1,5 +1,3 @@
-#include <nlohmann/json.hpp>
-
 #include "PipelineBuilder.h"
 #include "PipelineRunner.h"
 
@@ -20,13 +18,8 @@ int main() {
   auto analysis_specs = builder.analysisSpecs();
   auto plot_specs = builder.plotSpecs();
 
-  // Minimal sample configuration
-  nlohmann::json samples = {
-      {"ntupledir", "/path/to/ntuples"},
-      {"beamlines", {{"bnb", {{"run1", {}}}}}}};
-
   PipelineRunner runner(analysis_specs, plot_specs);
-  runner.run(samples, "/tmp/output.root");
+  runner.run("config/samples.json", "/tmp/output.root");
 
   return 0;
 }

--- a/libpipe/PipelineRunner.h
+++ b/libpipe/PipelineRunner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -210,6 +211,18 @@ public:
     result.saveToFile(output_path.c_str());
     detail::runPlotting(samples, plot_specs_, result);
     return result;
+  }
+
+  // Convenience overload that reads the samples configuration from a JSON
+  // file located at \p samples_path before executing the pipeline.
+  inline AnalysisResult run(const std::string &samples_path,
+                            const std::string &output_path) const {
+    std::ifstream in(samples_path);
+    nlohmann::json samples;
+    in >> samples;
+    if (samples.contains("samples"))
+      samples = samples.at("samples");
+    return run(samples, output_path);
   }
 
 private:


### PR DESCRIPTION
## Summary
- Allow PipelineRunner to load a samples JSON from a file path
- Use the new file-based overload in the pipeline runner example and mark it executable

## Testing
- `bash .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bee2d2c134832e975ae245d2ceb3c2