### PR TITLE
Fix preset paths and remove obsolete example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,11 @@ add_subdirectory(libapp)
 add_subdirectory(libplug)
 add_subdirectory(tests)
 
-add_library(analyse STATIC src/presets/Presets_Standard.cpp src/presets/Presets_Vertices.cpp src/presets/Presets_Plots.cpp)
+add_library(analyse STATIC
+    ana/presets/Presets_Standard.cpp
+    ana/presets/Presets_Vertices.cpp
+    ana/presets/Presets_Plots.cpp
+)
 target_link_libraries(analyse
     PUBLIC
         libapp
@@ -55,25 +59,12 @@ target_link_libraries(analyse
         dl
 )
 
-add_executable(neutrino_vertex_stacked_example src/analysis/neutrino_vertex_stacked_plots.cpp src/presets/Presets_Standard.cpp src/presets/Presets_Vertices.cpp src/presets/Presets_Plots.cpp)
-target_link_libraries(neutrino_vertex_stacked_example
-    PRIVATE
-        libapp
-        libplug
-        libdata
-        libhist
-        libplot
-        libsyst
-        libutils
-        Eigen3::Eigen
-        nlohmann_json::nlohmann_json
-        ${ROOT_LIBRARIES}
-        TBB::tbb
-        TMVA
-        dl
+add_executable(pipeline_runner_example
+    ana/pipeline_runner_example.cpp
+    ana/presets/Presets_Standard.cpp
+    ana/presets/Presets_Vertices.cpp
+    ana/presets/Presets_Plots.cpp
 )
-
-add_executable(pipeline_runner_example src/analysis/pipeline_runner_example.cpp src/presets/Presets_Standard.cpp src/presets/Presets_Vertices.cpp src/presets/Presets_Plots.cpp)
 target_link_libraries(pipeline_runner_example
     PRIVATE
         libapp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,13 +20,13 @@ catch_discover_tests(test_quadtree_binning)
 
 add_executable(test_event_display_preset
   test_event_display_preset.cpp
-  ${CMAKE_SOURCE_DIR}/src/presets/Presets_Plots.cpp)
+  ${CMAKE_SOURCE_DIR}/ana/presets/Presets_Plots.cpp)
 target_link_libraries(test_event_display_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
 catch_discover_tests(test_event_display_preset)
 
 add_executable(test_pipeline_builder
   test_pipeline_builder.cpp
-  ${CMAKE_SOURCE_DIR}/src/presets/Presets_Standard.cpp
-  ${CMAKE_SOURCE_DIR}/src/presets/Presets_Vertices.cpp)
+  ${CMAKE_SOURCE_DIR}/ana/presets/Presets_Standard.cpp
+  ${CMAKE_SOURCE_DIR}/ana/presets/Presets_Vertices.cpp)
 target_link_libraries(test_pipeline_builder PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain nlohmann_json::nlohmann_json ${ROOT_LIBRARIES} ${CMAKE_DL_LIBS})
 catch_discover_tests(test_pipeline_builder)


### PR DESCRIPTION
## Summary
- point CMake to presets in `ana/`
- remove build references to missing `neutrino_vertex_stacked_plots`
- update tests to use new preset locations

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bee415a2d0832eba77200a988e4f6c