### PR TITLE
Resolve ambiguous PipelineRunner::run overload

### DIFF
--- a/ana/pipeline_runner_example.cpp
+++ b/ana/pipeline_runner_example.cpp
@@ -1,5 +1,6 @@
 #include "PipelineBuilder.h"
 #include "PipelineRunner.h"
+#include <string>
 
 int main() {
   using namespace analysis;
@@ -19,7 +20,7 @@ int main() {
   auto plot_specs = builder.plotSpecs();
 
   PipelineRunner runner(analysis_specs, plot_specs);
-  runner.run("config/samples.json", "/tmp/output.root");
+  runner.run(std::string{"config/samples.json"}, std::string{"/tmp/output.root"});
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- Include `<string>` in `pipeline_runner_example.cpp`
- Use `std::string` to select the correct `PipelineRunner::run` overload

## Testing
- `bash .build.sh` *(fails: Could not find a package configuration file provided by "ROOT" – missing ROOT)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bee4b6d03c832eb377227cbf01c052