### PR TITLE
Add fallback search path for plugins

### DIFF
--- a/libpipe/PluginHost.h
+++ b/libpipe/PluginHost.h
@@ -44,7 +44,11 @@ public:
       }
       CreateFn create = reinterpret_cast<CreateFn>(dlsym(handle, "createPlugin"));
       if (!create) {
-        std::string sym = "create" + name + "Plugin";
+        std::string sym = "create" + name;
+        create = reinterpret_cast<CreateFn>(dlsym(handle, sym.c_str()));
+      }
+      if (!create && endsWith(name, "Plugin")) {
+        std::string sym = "create" + name.substr(0, name.size() - 6) + "Plugin";
         create = reinterpret_cast<CreateFn>(dlsym(handle, sym.c_str()));
       }
       if (create) {
@@ -66,6 +70,10 @@ public:
     std::string base = dir ? dir : "build";
     // soft dlopen (ok if missing) — plugin might be statically linked
     handle = openHandle(base + "/" + nameOrPath + ".so", /*soft=*/true);
+    // If not found and no custom directory provided, try current directory.
+    if (!handle && !dir) {
+      handle = openHandle(nameOrPath + std::string{".so"}, /*soft=*/true);
+    }
     addByName(nameOrPath, args, handle);
   }
 


### PR DESCRIPTION
## Summary
- Try loading plugins from the current working directory if not found in default build directory
- Fix plugin factory lookup to avoid duplicate `Plugin` suffix when searching for factory symbols

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68beed80e00c832ebfa6169ded8933fc