### PR TITLE
Add explicit factory for StackedHistogram plugin

### DIFF
--- a/libplug/plotting/StackedHistogramPlugin.cc
+++ b/libplug/plotting/StackedHistogramPlugin.cc
@@ -115,7 +115,10 @@ ANALYSIS_REGISTER_PLUGIN(analysis::IPlotPlugin, analysis::AnalysisDataLoader,
                          "StackedHistogramPlugin", analysis::StackedHistogramPlugin)
 
 #ifdef BUILD_PLUGIN
-extern "C" analysis::IPlotPlugin *createPlotPlugin(const analysis::PluginArgs &args) {
+extern "C" analysis::IPlotPlugin *createStackedHistogramPlugin(const analysis::PluginArgs &args) {
     return new analysis::StackedHistogramPlugin(args, nullptr);
+}
+extern "C" analysis::IPlotPlugin *createPlotPlugin(const analysis::PluginArgs &args) {
+    return createStackedHistogramPlugin(args);
 }
 #endif


### PR DESCRIPTION
## Summary
- Export `createStackedHistogramPlugin` factory so plugin host can instantiate the stacked histogram plugin
- Provide backwards-compatible `createPlotPlugin` alias

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bef915dc74832e8bd259d165d213b0