### PR TITLE
Ensure histogram plots save in batch mode

### DIFF
--- a/libplot/IHistogramPlot.h
+++ b/libplot/IHistogramPlot.h
@@ -26,11 +26,12 @@ class IHistogramPlot {
     virtual ~IHistogramPlot() = default;
 
     void drawAndSave(const std::string &format = "png") {
+        gROOT->SetBatch(kTRUE);
+        gSystem->mkdir(output_directory_.c_str(), true);
         this->setGlobalStyle();
         TCanvas canvas(plot_name_.c_str(), plot_name_.c_str(), 800, 600);
         this->draw(canvas);
-        canvas.SaveAs(
-            (output_directory_ + "/" + plot_name_ + "." + format).c_str());
+        canvas.SaveAs((output_directory_ + "/" + plot_name_ + "." + format).c_str());
     }
 
     static std::string sanitise(std::string s) {


### PR DESCRIPTION
## Summary
- Force ROOT to operate in batch mode when saving plots
- Re-create the output directory before writing histogram images

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT" [missing dependency])*

------
https://chatgpt.com/codex/tasks/task_e_68befb23cd10832eb7ea1794660c6535