### PR TITLE
Ensure histogram plots save in batch mode

### DIFF
--- a/libplot/IHistogramPlot.h
+++ b/libplot/IHistogramPlot.h
@@ -26,11 +26,12 @@ class IHistogramPlot {
     virtual ~IHistogramPlot() = default;
 
     void drawAndSave(const std::string &format = "png") {
+        gROOT->SetBatch(kTRUE);
+        gSystem->mkdir(output_directory_.c_str(), true);
         this->setGlobalStyle();
         TCanvas canvas(plot_name_.c_str(), plot_name_.c_str(), 800, 600);
         this->draw(canvas);
-        canvas.SaveAs(
-            (output_directory_ + "/" + plot_name_ + "." + format).c_str());
+        canvas.SaveAs((output_directory_ + "/" + plot_name_ + "." + format).c_str());
     }
 
     static std::string sanitise(std::string s) {

--- a/libplug/plotting/StackedHistogramPlugin.cc
+++ b/libplug/plotting/StackedHistogramPlugin.cc
@@ -64,8 +64,8 @@ class StackedHistogramPlugin : public IPlotPlugin {
     }
 
     void onPlot(const AnalysisResult &result) override {
-        gSystem->mkdir("plots", true);
         for (auto const &pc : plots_) {
+            gSystem->mkdir(pc.output_directory.c_str(), true);
             std::vector<RegionKey> regions;
             if (pc.region.empty()) {
                 for (const auto &kv : result.regions())
@@ -95,10 +95,15 @@ class StackedHistogramPlugin : public IPlotPlugin {
                         continue;
                     }
                     const auto &variable_result = result.result(rkey, vkey);
-                    StackedHistogramPlot plot("stack_" + vkey.str() + "_" + rkey.str(), variable_result,
-                                              region_analysis, pc.category_column, pc.output_directory,
-                                              pc.overlay_signal, pc.cut_list, pc.annotate_numbers, pc.use_log_y,
-                                              pc.y_axis_label, pc.n_bins, pc.min, pc.max);
+                    std::string plot_name =
+                        "stack_" + IHistogramPlot::sanitise(vkey.str()) + "_" +
+                        IHistogramPlot::sanitise(rkey.str());
+                    StackedHistogramPlot plot(plot_name, variable_result,
+                                              region_analysis, pc.category_column,
+                                              pc.output_directory, pc.overlay_signal,
+                                              pc.cut_list, pc.annotate_numbers,
+                                              pc.use_log_y, pc.y_axis_label, pc.n_bins,
+                                              pc.min, pc.max);
                     plot.drawAndSave("pdf");
                 }
             }


### PR DESCRIPTION
## Summary
- Force ROOT to operate in batch mode when saving plots
- Re-create the output directory before writing histogram images
- Sanitise stacked histogram plot names and ensure per-config output directories are created

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68befb23cd10832eb7ea1794660c6535