### PR TITLE
Warn when variables lack region assignments

### DIFF
--- a/libplug/analytics/VariablesPlugin.cc
+++ b/libplug/analytics/VariablesPlugin.cc
@@ -70,6 +70,12 @@ class VariablesPlugin : public IAnalysisPlugin {
                 for (auto const &region_name : var_cfg.at("regions")) {
                     def.addVariableToRegion(region_name.get<std::string>(), name);
                 }
+            } else {
+                // No default region assignment: skip this variable and warn so the
+                // configuration can be fixed explicitly.
+                log::warn("VariablesPlugin::onInitialisation",
+                          "Variable '{}' has no 'regions' field and will not be attached to any regions",
+                          name);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Avoid default assignment of variables to all regions
- Warn when variable definitions omit `regions`

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68befe60e434832e9d860b0907e70ee6