### PR TITLE
Fail fast when required plugin configuration is missing

### DIFF
--- a/libplug/analytics/RegionsPlugin.cc
+++ b/libplug/analytics/RegionsPlugin.cc
@@ -13,7 +13,7 @@ class RegionsPlugin : public IAnalysisPlugin {
     void onInitialisation(AnalysisDefinition &def, const SelectionRegistry &) override {
         log::info("RegionsPlugin::onInitialisation", "Defining regions...");
         if (!config_.contains("regions"))
-            return;
+            log::fatal("RegionsPlugin::onInitialisation", "no regions configured");
 
         for (auto const &region_cfg : config_.at("regions")) {
 

--- a/libplug/analytics/VariablesPlugin.cc
+++ b/libplug/analytics/VariablesPlugin.cc
@@ -20,7 +20,7 @@ class VariablesPlugin : public IAnalysisPlugin {
     void onInitialisation(AnalysisDefinition &def, const SelectionRegistry &) override {
         log::info("VariablesPlugin::onInitialisation", "Defining variables...");
         if (!config_.contains("variables"))
-            return;
+            log::fatal("VariablesPlugin::onInitialisation", "no variables configured");
 
         for (auto const &var_cfg : config_.at("variables")) {
 


### PR DESCRIPTION
## Summary
- exit with an error when RegionsPlugin is added without region definitions
- exit with an error when VariablesPlugin is added without variable definitions

## Testing
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68bf00d184c8832e8ce5cb9770d01437