### PR TITLE
Add additional stratifier debugging

### DIFF
--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -16,6 +16,7 @@ class MonteCarloProcessor : public ISampleProcessor {
 
     void book(HistogramFactory &factory, const BinningDefinition &binning, const ROOT::RDF::TH1DModel &model) override {
         analysis::log::info("MonteCarloProcessor::book", "Beginning stratification...");
+        analysis::log::debug("MonteCarloProcessor::book", "Requested stratifier key:", binning.getStratifierKey().str());
         nominal_futures_ = factory.bookStratifiedHists(binning, nominal_dataset_, model);
 
         analysis::log::info("MonteCarloProcessor::book", "Booking nominals...");

--- a/libhist/HistogramFactory.h
+++ b/libhist/HistogramFactory.h
@@ -24,6 +24,8 @@ class HistogramFactory {
     bookStratifiedHists(const BinningDefinition &binning, const SampleDataset &dataset,
                         const ROOT::RDF::TH1DModel &model) {
         analysis::log::info("HistogramFactory::bookStratifiedHists", "Calling stratifier manager...");
+        analysis::log::debug("HistogramFactory::bookStratifiedHists", "Binning requests stratifier key:",
+                             binning.getStratifierKey().str());
         auto &stratifier = stratifier_manager_.get(binning.getStratifierKey());
 
         analysis::log::info("HistogramFactory::bookStratifiedHists", "Creating stratified hists.");

--- a/libhist/StratifierManager.h
+++ b/libhist/StratifierManager.h
@@ -36,6 +36,15 @@ class StratifierManager {
             } else if (type == StratifierType::kVector) {
                 stratifier = makeVectorStratifier(key, registry_);
             } else {
+                auto available = registry_.getRegisteredSchemeNames();
+                std::string joined;
+                for (const auto &name : available) {
+                    joined += name + ",";
+                }
+                if (!joined.empty()) {
+                    joined.pop_back();
+                }
+                log::warn("StratifierManager::get", "Available stratifier schemes:", joined);
                 log::fatal("StratifierManager::get", "Unknown or unregistered stratifier configuration:", key.str());
             }
 

--- a/libhist/StratifierRegistry.h
+++ b/libhist/StratifierRegistry.h
@@ -104,6 +104,15 @@ class StratifierRegistry {
         return keys;
     }
 
+    std::vector<std::string> getRegisteredSchemeNames() const {
+        std::vector<std::string> names;
+        names.reserve(scheme_definitions_.size());
+        for (const auto &pair : scheme_definitions_) {
+            names.push_back(pair.first);
+        }
+        return names;
+    }
+
     StratifierType findSchemeType(const StratifierKey &key) const {
         auto it = scheme_definitions_.find(key.str());
         if (it != scheme_definitions_.end()) {


### PR DESCRIPTION
## Summary
- Add method to list registered stratifier schemes
- Warn with available schemes when unknown stratifier requested
- Log requested stratifier key during MC processing and histogram booking

## Testing
- `cmake ..` *(fails: Could not find ROOTConfig.cmake)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf02d3961c832e90f156ef1c427c6a