### PR TITLE
Handle float universe weights correctly to avoid inflated covariances

### DIFF
--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -8,126 +8,154 @@
 
 #include <TMatrixDSym.h>
 
-#include "Logger.h"
 #include "BinnedHistogram.h"
+#include "Logger.h"
 #include "SystematicStrategy.h"
 
 namespace analysis {
 
 class UniverseSystematicStrategy : public SystematicStrategy {
-  public:
-    UniverseSystematicStrategy(UniverseDef universe_def, bool store_universe_hists = false)
-        : identifier_(std::move(universe_def.name_)),
-          vector_name_(std::move(universe_def.vector_name_)),
-          n_universes_(universe_def.n_universes_),
-          store_universe_hists_(store_universe_hists) {}
+public:
+  UniverseSystematicStrategy(UniverseDef universe_def,
+                             bool store_universe_hists = false)
+      : identifier_(std::move(universe_def.name_)),
+        vector_name_(std::move(universe_def.vector_name_)),
+        n_universes_(universe_def.n_universes_),
+        store_universe_hists_(store_universe_hists) {}
 
-    const std::string &getName() const override { return identifier_; }
+  const std::string &getName() const override { return identifier_; }
 
-    void bookVariations(const SampleKey &sample_key, ROOT::RDF::RNode &rnode, const BinningDefinition &binning,
-                        const ROOT::RDF::TH1DModel &model, SystematicFutures &futures) override {
-        log::debug("UniverseSystematicStrategy::bookVariations", identifier_, "sample", sample_key.str(),
-                   "universes", n_universes_);
-        for (unsigned u = 0; u < n_universes_; ++u) {
-            const SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
-            const auto weight = [u](const ROOT::RVec<unsigned short> &weights) {
-                if (u < weights.size()) return static_cast<double>(weights[u]);
-                return 1.0;
-            };
-
-            const auto uni_weight_name = "_uni_w_" + std::to_string(u);
-            auto node = rnode.Define(uni_weight_name, weight, {vector_name_});
-            futures.variations[uni_key][sample_key] =
-                node.Histo1D(model, binning.getVariable(), uni_weight_name);
+  void bookVariations(const SampleKey &sample_key, ROOT::RDF::RNode &rnode,
+                      const BinningDefinition &binning,
+                      const ROOT::RDF::TH1DModel &model,
+                      SystematicFutures &futures) override {
+    log::debug("UniverseSystematicStrategy::bookVariations", identifier_,
+               "sample", sample_key.str(), "universes", n_universes_);
+    for (unsigned u = 0; u < n_universes_; ++u) {
+      const SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
+      // Use a generic lambda so that we correctly handle the underlying
+      // type of the weight vector.  The systematic weight branches in
+      // the input ROOT files are stored as floating point numbers, but
+      // the previous implementation hard-coded the type as
+      // `unsigned short`.  This caused the bit patterns of the floats to
+      // be reinterpreted as integers, producing enormously large weights
+      // and, consequently, inflated covariance values.
+      //
+      // By accepting the vector by `auto` we allow `ROOT::RVec<float>`,
+      // `ROOT::RVec<double>` or any other numeric type to be passed in
+      // transparently.  We simply cast the selected universe weight to a
+      // `double`, preserving the true value of the weight.
+      const auto weight = [u](const auto &weights) {
+        if (u < weights.size()) {
+          return static_cast<double>(weights[u]);
         }
+        return 1.0;
+      };
+
+      const auto uni_weight_name = "_uni_w_" + std::to_string(u);
+      auto node = rnode.Define(uni_weight_name, weight, {vector_name_});
+      futures.variations[uni_key][sample_key] =
+          node.Histo1D(model, binning.getVariable(), uni_weight_name);
+    }
+  }
+
+  TMatrixDSym computeCovariance(VariableResult &result,
+                                SystematicFutures &futures) override {
+    const auto &nominal_hist = result.total_mc_hist_;
+    const auto &binning = result.binning_;
+    const int n = nominal_hist.getNumberOfBins();
+    TMatrixDSym cov(n);
+    cov.Zero();
+
+    std::vector<BinnedHistogram> stored_hists;
+    log::debug("UniverseSystematicStrategy::computeCovariance", identifier_,
+               "processing", n_universes_, "universes");
+    unsigned processed_universes = 0;
+    for (unsigned u = 0; u < n_universes_; ++u) {
+      const SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
+      if (!futures.variations.count(uni_key)) {
+        log::warn("UniverseSystematicStrategy::computeCovariance",
+                  "Missing universe", u, "for", identifier_);
+        continue;
+      }
+
+      auto h_universe = buildUniverseHistogram(binning, n, uni_key, futures);
+      updateCovarianceMatrix(cov, nominal_hist, h_universe);
+
+      ++processed_universes;
+      storeUniverseHistogram(stored_hists, std::move(h_universe));
     }
 
-    TMatrixDSym computeCovariance(VariableResult &result, SystematicFutures &futures) override {
-        const auto &nominal_hist = result.total_mc_hist_;
-        const auto &binning = result.binning_;
-        const int n = nominal_hist.getNumberOfBins();
-        TMatrixDSym cov(n);
-        cov.Zero();
-
-        std::vector<BinnedHistogram> stored_hists;
-        log::debug("UniverseSystematicStrategy::computeCovariance", identifier_, "processing", n_universes_,
-                   "universes");
-        unsigned processed_universes = 0;
-        for (unsigned u = 0; u < n_universes_; ++u) {
-            const SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));
-            if (!futures.variations.count(uni_key)) {
-                log::warn("UniverseSystematicStrategy::computeCovariance", "Missing universe", u, "for", identifier_);
-                continue;
-            }
-
-            auto h_universe = buildUniverseHistogram(binning, n, uni_key, futures);
-            updateCovarianceMatrix(cov, nominal_hist, h_universe);
-
-            ++processed_universes;
-            storeUniverseHistogram(stored_hists, std::move(h_universe));
-        }
-
-        const double n_universes = static_cast<double>(processed_universes);
-        for (int i = 0; i < n; ++i) {
-            for (int j = 0; j <= i; ++j) {
-                const double val = n_universes == 0 ? 0 : cov(i, j) / n_universes;
-                cov(i, j) = val;
-                cov(j, i) = val;
-            }
-        }
-
-        if (store_universe_hists_ && !stored_hists.empty()) {
-            result.universe_projected_hists_[SystematicKey{identifier_}] = std::move(stored_hists);
-        }
-
-        log::debug("UniverseSystematicStrategy::computeCovariance", identifier_, "covariance calculated with",
-                   processed_universes, "universes");
-        return cov;
+    const double n_universes = static_cast<double>(processed_universes);
+    for (int i = 0; i < n; ++i) {
+      for (int j = 0; j <= i; ++j) {
+        const double val = n_universes == 0 ? 0 : cov(i, j) / n_universes;
+        cov(i, j) = val;
+        cov(j, i) = val;
+      }
     }
 
-    std::map<SystematicKey, BinnedHistogram> getVariedHistograms(const BinningDefinition &,
-                                                                 SystematicFutures &) override {
-        std::map<SystematicKey, BinnedHistogram> out;
-        return out;
+    if (store_universe_hists_ && !stored_hists.empty()) {
+      result.universe_projected_hists_[SystematicKey{identifier_}] =
+          std::move(stored_hists);
     }
 
-  private:
-    BinnedHistogram buildUniverseHistogram(const BinningDefinition &binning, int n, const SystematicKey &key,
-                                           SystematicFutures &futures) {
-        Eigen::VectorXd shifts = Eigen::VectorXd::Zero(n);
-        Eigen::MatrixXd shifts_mat = shifts;
-        BinnedHistogram h_universe(binning, std::vector<double>(n, 0.0), shifts_mat);
+    log::debug("UniverseSystematicStrategy::computeCovariance", identifier_,
+               "covariance calculated with", processed_universes, "universes");
+    return cov;
+  }
 
-        for (auto &[sample_key, future] : futures.variations.at(key)) {
-            if (future.GetPtr()) {
-                h_universe = h_universe + BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
-            }
-        }
-        return h_universe;
+  std::map<SystematicKey, BinnedHistogram>
+  getVariedHistograms(const BinningDefinition &, SystematicFutures &) override {
+    std::map<SystematicKey, BinnedHistogram> out;
+    return out;
+  }
+
+private:
+  BinnedHistogram buildUniverseHistogram(const BinningDefinition &binning,
+                                         int n, const SystematicKey &key,
+                                         SystematicFutures &futures) {
+    Eigen::VectorXd shifts = Eigen::VectorXd::Zero(n);
+    Eigen::MatrixXd shifts_mat = shifts;
+    BinnedHistogram h_universe(binning, std::vector<double>(n, 0.0),
+                               shifts_mat);
+
+    for (auto &[sample_key, future] : futures.variations.at(key)) {
+      if (future.GetPtr()) {
+        h_universe = h_universe +
+                     BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
+      }
     }
+    return h_universe;
+  }
 
-    void updateCovarianceMatrix(TMatrixDSym &cov, const BinnedHistogram &nominal_hist,
-                                const BinnedHistogram &h_universe) {
-        const int n = nominal_hist.getNumberOfBins();
-        for (int i = 0; i < n; ++i) {
-            const double di = h_universe.getBinContent(i) - nominal_hist.getBinContent(i);
-            for (int j = 0; j <= i; ++j) {
-                const double dj = h_universe.getBinContent(j) - nominal_hist.getBinContent(j);
-                cov(i, j) += di * dj;
-            }
-        }
+  void updateCovarianceMatrix(TMatrixDSym &cov,
+                              const BinnedHistogram &nominal_hist,
+                              const BinnedHistogram &h_universe) {
+    const int n = nominal_hist.getNumberOfBins();
+    for (int i = 0; i < n; ++i) {
+      const double di =
+          h_universe.getBinContent(i) - nominal_hist.getBinContent(i);
+      for (int j = 0; j <= i; ++j) {
+        const double dj =
+            h_universe.getBinContent(j) - nominal_hist.getBinContent(j);
+        cov(i, j) += di * dj;
+      }
     }
+  }
 
-    void storeUniverseHistogram(std::vector<BinnedHistogram> &stored_hists, BinnedHistogram &&h_universe) {
-        if (store_universe_hists_) stored_hists.push_back(std::move(h_universe));
-    }
+  void storeUniverseHistogram(std::vector<BinnedHistogram> &stored_hists,
+                              BinnedHistogram &&h_universe) {
+    if (store_universe_hists_)
+      stored_hists.push_back(std::move(h_universe));
+  }
 
-    std::string identifier_;
-    std::string vector_name_;
-    unsigned n_universes_;
-    bool store_universe_hists_;
+  std::string identifier_;
+  std::string vector_name_;
+  unsigned n_universes_;
+  bool store_universe_hists_;
 };
 
-}
+} // namespace analysis
 
 #endif

--- a/tests/test_systematics.cpp
+++ b/tests/test_systematics.cpp
@@ -1,8 +1,8 @@
-#include "VariableResult.h"
 #include "BinningDefinition.h"
 #include "DetectorSystematicStrategy.h"
 #include "SystematicsProcessor.h"
 #include "UniverseSystematicStrategy.h"
+#include "VariableResult.h"
 #include "WeightSystematicStrategy.h"
 #include <Eigen/Eigenvalues>
 #include <ROOT/RDataFrame.hxx>
@@ -16,133 +16,192 @@ using namespace analysis;
 
 namespace {
 BinningDefinition makeBinning() {
-    std::vector<double> e{0.0, 1.0, 2.0};
-    return BinningDefinition(e, "x", "x", {});
+  std::vector<double> e{0.0, 1.0, 2.0};
+  return BinningDefinition(e, "x", "x", {});
 }
 VariableResult makeResult(const BinningDefinition &b) {
-    VariableResult r;
-    r.binning_ = b;
-    std::vector<double> c{1.0, 1.0};
-    Eigen::MatrixXd m = Eigen::MatrixXd::Identity(2, 2);
-    r.total_mc_hist_ = BinnedHistogram(b, c, m);
-    return r;
+  VariableResult r;
+  r.binning_ = b;
+  std::vector<double> c{1.0, 1.0};
+  Eigen::MatrixXd m = Eigen::MatrixXd::Identity(2, 2);
+  r.total_mc_hist_ = BinnedHistogram(b, c, m);
+  return r;
 }
 // build C = (1/N) sum v v^T from supplied variation vectors
 Eigen::MatrixXd covMatrix(const std::vector<Eigen::VectorXd> &v) {
-    Eigen::MatrixXd c = Eigen::MatrixXd::Zero(v[0].size(), v[0].size());
-    for (const auto &u : v)
-        c += u * u.transpose();
-    return c / v.size();
+  Eigen::MatrixXd c = Eigen::MatrixXd::Zero(v[0].size(), v[0].size());
+  for (const auto &u : v)
+    c += u * u.transpose();
+  return c / v.size();
 }
 // verify positive semidefinite: all lambda_i >= 0 within tolerance
 bool psd(const Eigen::MatrixXd &m) {
-    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(m);
-    return (es.eigenvalues().array() >= -1e-12).all();
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(m);
+  return (es.eigenvalues().array() >= -1e-12).all();
 }
 Eigen::MatrixXd toEigen(const TMatrixDSym &m) {
-    Eigen::MatrixXd out(m.GetNrows(), m.GetNcols());
-    for (int i = 0; i < m.GetNrows(); ++i)
-        for (int j = 0; j < m.GetNcols(); ++j)
-            out(i, j) = m(i, j);
-    return out;
+  Eigen::MatrixXd out(m.GetNrows(), m.GetNcols());
+  for (int i = 0; i < m.GetNrows(); ++i)
+    for (int j = 0; j < m.GetNcols(); ++j)
+      out(i, j) = m(i, j);
+  return out;
 }
 } // namespace
 
-// Processor: check C_total = sum C_s + I and propagated errors sqrt(diag C_total)
+// Processor: check C_total = sum C_s + I and propagated errors sqrt(diag
+// C_total)
 TEST_CASE("systematics processor covariance") {
-    auto b = makeBinning();
-    std::vector<double> x{0.5, 1.5};
-    std::vector<double> up{1.2, 0.8};
-    std::vector<double> dn{0.8, 1.2};
-    std::vector<ROOT::RVec<unsigned short>> u{ROOT::RVec<unsigned short>{2, 0}, ROOT::RVec<unsigned short>{0, 2}};
-    ROOT::RDataFrame df(x.size());
-    ROOT::RDF::RNode rnode = df.Define("x", [&x](ULong64_t i) { return x[i]; }, {"rdfentry_"})
-                                 .Define("knob_up", [&up](ULong64_t i) { return up[i]; }, {"rdfentry_"})
-                                 .Define("knob_dn", [&dn](ULong64_t i) { return dn[i]; }, {"rdfentry_"})
-                                 .Define("uni_weights", [&u](ULong64_t i) { return u[i]; }, {"rdfentry_"});
-    KnobDef k{"knob", "knob_up", "knob_dn"};
-    UniverseDef un{"uni", "uni_weights", 2};
-    SystematicsProcessor p({k}, {un});
-    SampleKey sk(std::string{"sample"});
-    p.bookSystematics(sk, rnode, b, b.toTH1DModel());
-    auto r = makeResult(b);
-    r.raw_detvar_hists_[sk][SampleVariation::kCV] = BinnedHistogram(b, {1.0, 1.0}, Eigen::MatrixXd::Zero(2, 1));
-    r.raw_detvar_hists_[sk][SampleVariation::kSCE] = BinnedHistogram(b, {1.1, 0.9}, Eigen::MatrixXd::Zero(2, 1));
-    p.processSystematics(r);
-    // C_w from delta w = plus or minus 0.2: average of [delta w,-delta w]^T[delta w,-delta w]
-    Eigen::MatrixXd wexp = covMatrix({Eigen::Vector2d(0.2, -0.2), Eigen::Vector2d(-0.2, 0.2)});
-    // C_u from universes giving plus or minus 1 deviations in opposite bins
-    Eigen::MatrixXd uexp = covMatrix({Eigen::Vector2d(1, -1), Eigen::Vector2d(-1, 1)});
-    // C_d from detector shift Delta=[0.1,-0.1]
-    Eigen::MatrixXd dexp = covMatrix({Eigen::Vector2d(0.1, -0.1)});
-    CHECK((toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"knob"}))) - wexp).norm() < 1e-6);
-    CHECK((toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"uni"}))) - uexp).norm() < 1e-6);
-    CHECK((toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"detector_variation"}))) - dexp).norm() < 1e-6);
-    CHECK(psd(toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"knob"})))));
-    CHECK(psd(toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"uni"})))));
-    CHECK(psd(toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"detector_variation"})))));
-    Eigen::MatrixXd totalexp = wexp + uexp + dexp + Eigen::MatrixXd::Identity(2, 2);
-    CHECK((toEigen(r.total_covariance_) - totalexp).norm() < 1e-6);
-    CHECK(psd(toEigen(r.total_covariance_)));
-    Eigen::Vector2d err{std::sqrt(totalexp(0, 0)), std::sqrt(totalexp(1, 1))};
-    CHECK((Eigen::Vector2d(r.nominal_with_band_.getBinError(0), r.nominal_with_band_.getBinError(1)) - err).norm() <
-          1e-6);
-    CHECK(r.universe_projected_hists_.empty());
+  auto b = makeBinning();
+  std::vector<double> x{0.5, 1.5};
+  std::vector<double> up{1.2, 0.8};
+  std::vector<double> dn{0.8, 1.2};
+  std::vector<ROOT::RVec<unsigned short>> u{ROOT::RVec<unsigned short>{2, 0},
+                                            ROOT::RVec<unsigned short>{0, 2}};
+  ROOT::RDataFrame df(x.size());
+  ROOT::RDF::RNode rnode =
+      df.Define("x", [&x](ULong64_t i) { return x[i]; }, {"rdfentry_"})
+          .Define("knob_up", [&up](ULong64_t i) { return up[i]; },
+                  {"rdfentry_"})
+          .Define("knob_dn", [&dn](ULong64_t i) { return dn[i]; },
+                  {"rdfentry_"})
+          .Define("uni_weights", [&u](ULong64_t i) { return u[i]; },
+                  {"rdfentry_"});
+  KnobDef k{"knob", "knob_up", "knob_dn"};
+  UniverseDef un{"uni", "uni_weights", 2};
+  SystematicsProcessor p({k}, {un});
+  SampleKey sk(std::string{"sample"});
+  p.bookSystematics(sk, rnode, b, b.toTH1DModel());
+  auto r = makeResult(b);
+  r.raw_detvar_hists_[sk][SampleVariation::kCV] =
+      BinnedHistogram(b, {1.0, 1.0}, Eigen::MatrixXd::Zero(2, 1));
+  r.raw_detvar_hists_[sk][SampleVariation::kSCE] =
+      BinnedHistogram(b, {1.1, 0.9}, Eigen::MatrixXd::Zero(2, 1));
+  p.processSystematics(r);
+  // C_w from delta w = plus or minus 0.2: average of [delta w,-delta w]^T[delta
+  // w,-delta w]
+  Eigen::MatrixXd wexp =
+      covMatrix({Eigen::Vector2d(0.2, -0.2), Eigen::Vector2d(-0.2, 0.2)});
+  // C_u from universes giving plus or minus 1 deviations in opposite bins
+  Eigen::MatrixXd uexp =
+      covMatrix({Eigen::Vector2d(1, -1), Eigen::Vector2d(-1, 1)});
+  // C_d from detector shift Delta=[0.1,-0.1]
+  Eigen::MatrixXd dexp = covMatrix({Eigen::Vector2d(0.1, -0.1)});
+  CHECK(
+      (toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"knob"}))) -
+       wexp)
+          .norm() < 1e-6);
+  CHECK((toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"uni"}))) -
+         uexp)
+            .norm() < 1e-6);
+  CHECK((toEigen(r.covariance_matrices_.at(
+             SystematicKey(std::string{"detector_variation"}))) -
+         dexp)
+            .norm() < 1e-6);
+  CHECK(psd(
+      toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"knob"})))));
+  CHECK(psd(
+      toEigen(r.covariance_matrices_.at(SystematicKey(std::string{"uni"})))));
+  CHECK(psd(toEigen(r.covariance_matrices_.at(
+      SystematicKey(std::string{"detector_variation"})))));
+  Eigen::MatrixXd totalexp =
+      wexp + uexp + dexp + Eigen::MatrixXd::Identity(2, 2);
+  CHECK((toEigen(r.total_covariance_) - totalexp).norm() < 1e-6);
+  CHECK(psd(toEigen(r.total_covariance_)));
+  Eigen::Vector2d err{std::sqrt(totalexp(0, 0)), std::sqrt(totalexp(1, 1))};
+  CHECK((Eigen::Vector2d(r.nominal_with_band_.getBinError(0),
+                         r.nominal_with_band_.getBinError(1)) -
+         err)
+            .norm() < 1e-6);
+  CHECK(r.universe_projected_hists_.empty());
 }
 
 // Universes: deviations plus or minus 1 yield off-diagonal covariance
 TEST_CASE("universe systematic strategy covariance") {
-    auto b = makeBinning();
-    std::vector<double> x{0.5, 1.5};
-    std::vector<ROOT::RVec<unsigned short>> u{ROOT::RVec<unsigned short>{2, 0}, ROOT::RVec<unsigned short>{0, 2}};
-    ROOT::RDataFrame df(x.size());
-    ROOT::RDF::RNode rnode = df.Define("x", [&x](ULong64_t i) { return x[i]; }, {"rdfentry_"})
-                                 .Define("uni_weights", [&u](ULong64_t i) { return u[i]; }, {"rdfentry_"});
-    UniverseSystematicStrategy s(UniverseDef{"uni", "uni_weights", 2});
-    SystematicFutures f;
-    SampleKey sk(std::string{"s"});
-    s.bookVariations(sk, rnode, b, b.toTH1DModel(), f);
-    auto r = makeResult(b);
-    auto cov = s.computeCovariance(r, f);
-    // C = 1/2([1,-1]^T[1,-1] + [-1,1]^T[-1,1])
-    Eigen::MatrixXd exp = covMatrix({Eigen::Vector2d(1, -1), Eigen::Vector2d(-1, 1)});
-    CHECK((toEigen(cov) - exp).norm() < 1e-6);
-    CHECK(psd(toEigen(cov)));
+  auto b = makeBinning();
+  std::vector<double> x{0.5, 1.5};
+  std::vector<ROOT::RVec<unsigned short>> u{ROOT::RVec<unsigned short>{2, 0},
+                                            ROOT::RVec<unsigned short>{0, 2}};
+  ROOT::RDataFrame df(x.size());
+  ROOT::RDF::RNode rnode =
+      df.Define("x", [&x](ULong64_t i) { return x[i]; }, {"rdfentry_"})
+          .Define("uni_weights", [&u](ULong64_t i) { return u[i]; },
+                  {"rdfentry_"});
+  UniverseSystematicStrategy s(UniverseDef{"uni", "uni_weights", 2});
+  SystematicFutures f;
+  SampleKey sk(std::string{"s"});
+  s.bookVariations(sk, rnode, b, b.toTH1DModel(), f);
+  auto r = makeResult(b);
+  auto cov = s.computeCovariance(r, f);
+  // C = 1/2([1,-1]^T[1,-1] + [-1,1]^T[-1,1])
+  Eigen::MatrixXd exp =
+      covMatrix({Eigen::Vector2d(1, -1), Eigen::Vector2d(-1, 1)});
+  CHECK((toEigen(cov) - exp).norm() < 1e-6);
+  CHECK(psd(toEigen(cov)));
+}
+
+// Ensure that float-based weight vectors are handled correctly.
+TEST_CASE("universe systematic strategy covariance (float weights)") {
+  auto b = makeBinning();
+  std::vector<double> x{0.5, 1.5};
+  std::vector<ROOT::RVec<float>> u{ROOT::RVec<float>{1.1F, 0.9F},
+                                   ROOT::RVec<float>{0.9F, 1.1F}};
+  ROOT::RDataFrame df(x.size());
+  ROOT::RDF::RNode rnode =
+      df.Define("x", [&x](ULong64_t i) { return x[i]; }, {"rdfentry_"})
+          .Define("uni_weights", [&u](ULong64_t i) { return u[i]; },
+                  {"rdfentry_"});
+  UniverseSystematicStrategy s(UniverseDef{"uni", "uni_weights", 2});
+  SystematicFutures f;
+  SampleKey sk(std::string{"s"});
+  s.bookVariations(sk, rnode, b, b.toTH1DModel(), f);
+  auto r = makeResult(b);
+  auto cov = s.computeCovariance(r, f);
+  // Expected covariance from variations of ±0.1 around the nominal weight
+  Eigen::MatrixXd exp =
+      covMatrix({Eigen::Vector2d(0.1, -0.1), Eigen::Vector2d(-0.1, 0.1)});
+  CHECK((toEigen(cov) - exp).norm() < 1e-6);
+  CHECK(psd(toEigen(cov)));
 }
 
 // Weight shifts: symmetric plus or minus 0.2 produce diagonal covariance
 TEST_CASE("weight systematic strategy covariance") {
-    auto b = makeBinning();
-    std::vector<double> x{0.5, 1.5};
-    std::vector<double> up{1.2, 0.8};
-    std::vector<double> dn{0.8, 1.2};
-    ROOT::RDataFrame df(x.size());
-    ROOT::RDF::RNode rnode = df.Define("x", [&x](ULong64_t i) { return x[i]; }, {"rdfentry_"})
-                                 .Define("knob_up", [&up](ULong64_t i) { return up[i]; }, {"rdfentry_"})
-                                 .Define("knob_dn", [&dn](ULong64_t i) { return dn[i]; }, {"rdfentry_"});
-    WeightSystematicStrategy s(KnobDef{"k", "knob_up", "knob_dn"});
-    SystematicFutures f;
-    SampleKey sk(std::string{"s"});
-    s.bookVariations(sk, rnode, b, b.toTH1DModel(), f);
-    auto r = makeResult(b);
-    auto cov = s.computeCovariance(r, f);
-    // Average vv^T for v=[0.2,-0.2] gives 0.04 on the diagonal
-    Eigen::MatrixXd exp = covMatrix({Eigen::Vector2d(0.2, -0.2), Eigen::Vector2d(-0.2, 0.2)});
-    CHECK((toEigen(cov) - exp).norm() < 1e-6);
-    CHECK(psd(toEigen(cov)));
+  auto b = makeBinning();
+  std::vector<double> x{0.5, 1.5};
+  std::vector<double> up{1.2, 0.8};
+  std::vector<double> dn{0.8, 1.2};
+  ROOT::RDataFrame df(x.size());
+  ROOT::RDF::RNode rnode =
+      df.Define("x", [&x](ULong64_t i) { return x[i]; }, {"rdfentry_"})
+          .Define("knob_up", [&up](ULong64_t i) { return up[i]; },
+                  {"rdfentry_"})
+          .Define("knob_dn", [&dn](ULong64_t i) { return dn[i]; },
+                  {"rdfentry_"});
+  WeightSystematicStrategy s(KnobDef{"k", "knob_up", "knob_dn"});
+  SystematicFutures f;
+  SampleKey sk(std::string{"s"});
+  s.bookVariations(sk, rnode, b, b.toTH1DModel(), f);
+  auto r = makeResult(b);
+  auto cov = s.computeCovariance(r, f);
+  // Average vv^T for v=[0.2,-0.2] gives 0.04 on the diagonal
+  Eigen::MatrixXd exp =
+      covMatrix({Eigen::Vector2d(0.2, -0.2), Eigen::Vector2d(-0.2, 0.2)});
+  CHECK((toEigen(cov) - exp).norm() < 1e-6);
+  CHECK(psd(toEigen(cov)));
 }
 
 // Detector variation: single shift Delta=[0.1,-0.1] => C=Delta Delta^T
 TEST_CASE("detector systematic strategy covariance") {
-    auto b = makeBinning();
-    auto r = makeResult(b);
-    SampleKey sk(std::string{"s"});
-    r.raw_detvar_hists_[sk][SampleVariation::kCV] = BinnedHistogram(b, {1.0, 1.0}, Eigen::MatrixXd::Zero(2, 1));
-    r.raw_detvar_hists_[sk][SampleVariation::kSCE] = BinnedHistogram(b, {1.1, 0.9}, Eigen::MatrixXd::Zero(2, 1));
-    DetectorSystematicStrategy s;
-    SystematicFutures f;
-    auto cov = s.computeCovariance(r, f);
-    Eigen::MatrixXd exp = covMatrix({Eigen::Vector2d(0.1, -0.1)});
-    CHECK((toEigen(cov) - exp).norm() < 1e-6);
-    CHECK(psd(toEigen(cov)));
+  auto b = makeBinning();
+  auto r = makeResult(b);
+  SampleKey sk(std::string{"s"});
+  r.raw_detvar_hists_[sk][SampleVariation::kCV] =
+      BinnedHistogram(b, {1.0, 1.0}, Eigen::MatrixXd::Zero(2, 1));
+  r.raw_detvar_hists_[sk][SampleVariation::kSCE] =
+      BinnedHistogram(b, {1.1, 0.9}, Eigen::MatrixXd::Zero(2, 1));
+  DetectorSystematicStrategy s;
+  SystematicFutures f;
+  auto cov = s.computeCovariance(r, f);
+  Eigen::MatrixXd exp = covMatrix({Eigen::Vector2d(0.1, -0.1)});
+  CHECK((toEigen(cov) - exp).norm() < 1e-6);
+  CHECK(psd(toEigen(cov)));
 }


### PR DESCRIPTION
## Summary
- use a generic lambda in `UniverseSystematicStrategy` so universe weight vectors keep their numeric type instead of being forced to `unsigned short`
- add a regression test ensuring float-based universe weights produce the expected covariance

## Testing
- `pytest` *(no tests run, 1 skipped)*
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bf0c8777b4832ea86bc6e827b6e4ab