### PR TITLE
Enable dynamic binning in vertex presets

### DIFF
--- a/ana/presets/Presets_Vertices.cpp
+++ b/ana/presets/Presets_Vertices.cpp
@@ -1,76 +1,89 @@
-#include "PresetRegistry.h"
 #include "PluginSpec.h"
+#include "PresetRegistry.h"
 #include <nlohmann/json.hpp>
 
 using namespace analysis;
 
 // Preset defining variables for the true neutrino interaction vertex.
 ANALYSIS_REGISTER_PRESET(TRUE_NEUTRINO_VERTEX, Target::Analysis,
-  ([](const PluginArgs&) -> PluginSpecList {
-    nlohmann::json vars = nlohmann::json::array({
-      {
-        {"name", "nu_vtx_x"},
-        {"branch", "neutrino_vertex_x"},
-        {"label", "True #nu Vertex X [cm]"},
-        {"stratum", "inclusive_strange_channels"},
-        {"regions", {"EMPTY"}},
-        {"bins", {{"n", 26}, {"min", 0.0}, {"max", 260.0}}}
-      },
-      {
-        {"name", "nu_vtx_y"},
-        {"branch", "neutrino_vertex_y"},
-        {"label", "True #nu Vertex Y [cm]"},
-        {"stratum", "inclusive_strange_channels"},
-        {"regions", {"EMPTY"}},
-        {"bins", {{"n", 24}, {"min", -120.0}, {"max", 120.0}}}
-      },
-      {
-        {"name", "nu_vtx_z"},
-        {"branch", "neutrino_vertex_z"},
-        {"label", "True #nu Vertex Z [cm]"},
-        {"stratum", "inclusive_strange_channels"},
-        {"regions", {"EMPTY"}},
-        {"bins", {{"n", 52}, {"min", 0.0}, {"max", 1040.0}}}
-      }
-    });
-    PluginArgs args{{"analysis_configs", {{"variables", vars}}}};
-    return {{"VariablesPlugin", args}};
-  })
-)
+                         ([](const PluginArgs &) -> PluginSpecList {
+                           nlohmann::json vars = nlohmann::json::array(
+                               {{{"name", "nu_vtx_x"},
+                                 {"branch", "neutrino_vertex_x"},
+                                 {"label", "True #nu Vertex X [cm]"},
+                                 {"stratum", "inclusive_strange_channels"},
+                                 {"regions", {"EMPTY"}},
+                                 {"bins",
+                                  {{"mode", "dynamic"},
+                                   {"min", 0.0},
+                                   {"max", 260.0},
+                                   {"include_oob_bins", true},
+                                   {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "nu_vtx_y"},
+                                 {"branch", "neutrino_vertex_y"},
+                                 {"label", "True #nu Vertex Y [cm]"},
+                                 {"stratum", "inclusive_strange_channels"},
+                                 {"regions", {"EMPTY"}},
+                                 {"bins",
+                                  {{"mode", "dynamic"},
+                                   {"min", -120.0},
+                                   {"max", 120.0},
+                                   {"include_oob_bins", true},
+                                   {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "nu_vtx_z"},
+                                 {"branch", "neutrino_vertex_z"},
+                                 {"label", "True #nu Vertex Z [cm]"},
+                                 {"stratum", "inclusive_strange_channels"},
+                                 {"regions", {"EMPTY"}},
+                                 {"bins",
+                                  {{"mode", "dynamic"},
+                                   {"min", 0.0},
+                                   {"max", 1040.0},
+                                   {"include_oob_bins", true},
+                                   {"strategy", "bayesian_blocks"}}}}});
+                           PluginArgs args{
+                               {"analysis_configs", {{"variables", vars}}}};
+                           return {{"VariablesPlugin", args}};
+                         }))
 
 // Preset defining variables for the reconstructed neutrino interaction vertex.
 ANALYSIS_REGISTER_PRESET(RECO_NEUTRINO_VERTEX, Target::Analysis,
-  ([](const PluginArgs&) -> PluginSpecList {
-    nlohmann::json vars = nlohmann::json::array({
-      {
-        {"name", "reco_nu_vtx_x"},
-        {"branch", "reco_neutrino_vertex_x"},
-        {"label", "Reco #nu Vertex X [cm]"},
-        {"stratum", "inclusive_strange_channels"},
-        {"regions", {"EMPTY"}},
-        {"bins", {{"n", 26}, {"min", 0.0}, {"max", 260.0}}}
-      },
-      {
-        {"name", "reco_nu_vtx_y"},
-        {"branch", "reco_neutrino_vertex_y"},
-        {"label", "Reco #nu Vertex Y [cm]"},
-        {"stratum", "inclusive_strange_channels"},
-        {"regions", {"EMPTY"}},
-        {"bins", {{"n", 24}, {"min", -120.0}, {"max", 120.0}}}
-      },
-      {
-        {"name", "reco_nu_vtx_z"},
-        {"branch", "reco_neutrino_vertex_z"},
-        {"label", "Reco #nu Vertex Z [cm]"},
-        {"stratum", "inclusive_strange_channels"},
-        {"regions", {"EMPTY"}},
-        {"bins", {{"n", 52}, {"min", 0.0}, {"max", 1040.0}}}
-      }
-    });
-    PluginArgs args{{"analysis_configs", {{"variables", vars}}}};
-    return {{"VariablesPlugin", args}};
-  })
-)
-
-
-
+                         ([](const PluginArgs &) -> PluginSpecList {
+                           nlohmann::json vars = nlohmann::json::array(
+                               {{{"name", "reco_nu_vtx_x"},
+                                 {"branch", "reco_neutrino_vertex_x"},
+                                 {"label", "Reco #nu Vertex X [cm]"},
+                                 {"stratum", "inclusive_strange_channels"},
+                                 {"regions", {"EMPTY"}},
+                                 {"bins",
+                                  {{"mode", "dynamic"},
+                                   {"min", 0.0},
+                                   {"max", 260.0},
+                                   {"include_oob_bins", true},
+                                   {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "reco_nu_vtx_y"},
+                                 {"branch", "reco_neutrino_vertex_y"},
+                                 {"label", "Reco #nu Vertex Y [cm]"},
+                                 {"stratum", "inclusive_strange_channels"},
+                                 {"regions", {"EMPTY"}},
+                                 {"bins",
+                                  {{"mode", "dynamic"},
+                                   {"min", -120.0},
+                                   {"max", 120.0},
+                                   {"include_oob_bins", true},
+                                   {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "reco_nu_vtx_z"},
+                                 {"branch", "reco_neutrino_vertex_z"},
+                                 {"label", "Reco #nu Vertex Z [cm]"},
+                                 {"stratum", "inclusive_strange_channels"},
+                                 {"regions", {"EMPTY"}},
+                                 {"bins",
+                                  {{"mode", "dynamic"},
+                                   {"min", 0.0},
+                                   {"max", 1040.0},
+                                   {"include_oob_bins", true},
+                                   {"strategy", "bayesian_blocks"}}}}});
+                           PluginArgs args{
+                               {"analysis_configs", {{"variables", vars}}}};
+                           return {{"VariablesPlugin", args}};
+                         }))


### PR DESCRIPTION
## Summary
- Switch TRUE_NEUTRINO_VERTEX preset variables to dynamic binning with Bayesian blocks strategy
- Switch RECO_NEUTRINO_VERTEX preset variables to dynamic binning with Bayesian blocks strategy

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOT package)*
- `apt-get update` *(fails: repository ... is not signed / 403 Forbidden)*
- `pytest tests/test_sample_processing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf0c91e24c832eb595b6d69e76c9e4