### PR TITLE
Fix RunConfig constructor parentheses

### DIFF
--- a/libdata/RunConfig.h
+++ b/libdata/RunConfig.h
@@ -26,9 +26,9 @@ struct RunConfig {
     RunConfig(const json &j, std::string bm, std::string pr)
         : beam_mode(std::move(bm)),
           run_period(std::move(pr)),
-          nominal_pot(j.value("nominal_pot",
-                              j.value("pot_target_wcut_total",
-                                      j.value("torb_target_pot_wcut", 0.0))),
+            nominal_pot(j.value("nominal_pot",
+                                j.value("pot_target_wcut_total",
+                                        j.value("torb_target_pot_wcut", 0.0)))),
           nominal_triggers(j.value("nominal_triggers",
                                    j.value("ext_triggers_total",
                                            j.value("ext_triggers", 0L)))),


### PR DESCRIPTION
## Summary
- Close nested `j.value` calls in `RunConfig` constructor to properly initialize `nominal_pot`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*
- `g++ -std=c++17 -I. -Ilibdata /tmp/test_runconfig.cpp -c` *(fails: fatal error: nlohmann/json.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0e65fe54832ea2cec34b8f16c65c