### PR TITLE
Skip dynamic binning when MC samples absent

### DIFF
--- a/libapp/AnalysisDefinition.h
+++ b/libapp/AnalysisDefinition.h
@@ -178,10 +178,11 @@ public:
             }
 
             if (mc_nodes.empty()) {
-                log::fatal("AnalysisDefinition::resolveDynamicBinning",
-                           "Cannot perform dynamic binning: No Monte Carlo "
-                           "samples "
-                           "were found!");
+                log::warn("AnalysisDefinition::resolveDynamicBinning",
+                          "Skipping dynamic binning for variable",
+                          var_handle.key_.str(),
+                          ": no Monte Carlo samples were found.");
+                continue;
             }
 
             bool include_oob = this->includeOobBins(var_handle.key_);


### PR DESCRIPTION
## Summary
- Avoid fatal error when no Monte Carlo samples are present by skipping dynamic binning for that variable

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bf11612bc8832e8bef809c4fa94425