### PR TITLE
Skip processing of explicit numi_ext beamline

### DIFF
--- a/libplug/PipelineRunner.h
+++ b/libplug/PipelineRunner.h
@@ -70,6 +70,8 @@ inline AnalysisResult runAnalysis(const nlohmann::json &samples,
 
   AnalysisResult result;
   for (auto const &[beam, runs] : samples.at("beamlines").items()) {
+    if (beam == "numi_ext")
+      continue;
     auto beamline_result =
         processBeamline(run_config_registry, ntuple_dir, beam, runs,
                         analysis_specs);
@@ -113,6 +115,8 @@ inline void runPlotting(const nlohmann::json &samples,
   auto result_map = result.resultsByBeam();
   bool plotted = false;
   for (auto const &[beam, runs] : samples.at("beamlines").items()) {
+    if (beam == "numi_ext")
+      continue;
     auto it = result_map.find(beam);
     if (it != result_map.end()) {
       plotBeamline(run_config_registry, ntuple_dir, beam, runs, plot_specs,


### PR DESCRIPTION
## Summary
- Avoid running the pipeline separately for the `numi_ext` beamline since external data is already loaded alongside each physics beam.
- Skip `numi_ext` during plotting for consistency.

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bf15862894832ebc1791c43e791bd2