### PR TITLE
Pass bin resolution to dynamic binning handlers

### DIFF
--- a/libhist/DynamicBinning.h
+++ b/libhist/DynamicBinning.h
@@ -136,7 +136,8 @@ private:
 
     if (auto it = kTypeDispatch.find(type_name); it != kTypeDispatch.end()) {
       return it->second(std::move(nodes), original_bdef, weight_col,
-                        min_neff_per_bin, include_oob_bins, strategy);
+                        min_neff_per_bin, include_oob_bins, strategy,
+                        bin_resolution);
     }
 
     for (const auto &entry : kTypeDispatch) {


### PR DESCRIPTION
## Summary
- Ensure bin resolution is forwarded when dispatching to dynamic binning handlers

## Testing
- `source .build.sh` *(fails: By not providing "FindROOT.cmake"...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1fba86e0832e95e6a761f8cf2934