### PR TITLE
Infer dynamic bin domains from data

### DIFF
--- a/libhist/DynamicBinning.h
+++ b/libhist/DynamicBinning.h
@@ -503,6 +503,21 @@ private:
     log::info("DynamicBinning::finaliseEdges",
               "In-range entries:", in_range.size());
 
+    if (!in_range.empty()) {
+      auto mm = std::minmax_element(
+          in_range.begin(), in_range.end(),
+          [](const auto &a, const auto &b) { return a.first < b.first; });
+      if (!std::isfinite(domain_min))
+        domain_min = mm.first->first;
+      if (!std::isfinite(domain_max))
+        domain_max = mm.second->first;
+    } else {
+      if (!std::isfinite(domain_min))
+        domain_min = 0.0;
+      if (!std::isfinite(domain_max))
+        domain_max = 1.0;
+    }
+
     if (in_range.size() < 2) {
       return BinningDefinition({domain_min, domain_max},
                                original_bdef.getVariable(),

--- a/tests/test_dynamic_binning.cpp
+++ b/tests/test_dynamic_binning.cpp
@@ -5,6 +5,7 @@
 #include "TTree.h"
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <limits>
 #include <vector>
 
 using namespace analysis;
@@ -63,4 +64,31 @@ TEST_CASE("bayesian_blocks_weighted") {
     REQUIRE(e.size() == 4);
     REQUIRE(e[1] == Approx(4.85).margin(0.01));
     REQUIRE(e[2] == Approx(10.05).margin(0.01));
+}
+
+TEST_CASE("bayesian_blocks_autodomain") {
+    TFile f("auto.root", "RECREATE");
+    TTree t("t", "");
+    double x;
+    t.Branch("x", &x);
+    for (int i = 0; i < 50; ++i) {
+        x = i / 10.0;
+        t.Fill();
+    }
+    for (int i = 0; i < 50; ++i) {
+        x = 10 + i / 10.0;
+        t.Fill();
+    }
+    t.Write();
+    ROOT::RDataFrame df("t", "auto.root");
+    std::vector<ROOT::RDF::RNode> nodes{df};
+    BinningDefinition b({-std::numeric_limits<double>::infinity(),
+                         std::numeric_limits<double>::infinity()},
+                        "x", "x", std::vector<SelectionKey>{});
+    auto res = DynamicBinning::calculate(nodes, b, "nominal_event_weight", 0.0,
+                                         false, DynamicBinningStrategy::BayesianBlocks);
+    auto e = res.getEdges();
+    REQUIRE(e.size() == 4);
+    REQUIRE(e.front() == Approx(0.0));
+    REQUIRE(e.back() == Approx(14.9).margin(0.01));
 }


### PR DESCRIPTION
## Summary
- drop hard-coded vertex bounds so dynamic binning finds range automatically
- teach dynamic binning to deduce min/max from data when unspecified
- add regression test covering automatic domain discovery

## Testing
- `bash .build.sh` *(fails: Could not find ROOT package)*
- `apt-get update` *(fails: 403 Forbidden for Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2348c518832ebce4ceb14856a9e7