### PR TITLE
Exclude external sample POT from region totals

### DIFF
--- a/libapp/SampleProcessorFactory.h
+++ b/libapp/SampleProcessorFactory.h
@@ -68,7 +68,9 @@ template <typename Loader> class SampleProcessorFactory {
             ++sample_index;
 
             if (accounted_runs.insert(run_config->label()).second) {
-                region_analysis.addProtonsOnTarget(run_config->nominal_pot);
+                if (run_config->beam_mode != "numi_ext") {
+                    region_analysis.addProtonsOnTarget(run_config->nominal_pot);
+                }
             }
             log::info("SampleProcessorFactory::create",
                       "--> Conditioning sample (", sample_index, "/",


### PR DESCRIPTION
## Summary
- avoid counting nominal POT from `numi_ext` runs when accumulating region POT

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf28b38ca8832eaf59ce1b97ff4a8e