### PR TITLE
Add event display pipeline and presets for background and signal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,3 +81,26 @@ target_link_libraries(pipeline_runner_example
         dl
 )
 
+add_executable(event_display_runner
+    ana/event_display_runner.cpp
+    ana/presets/Presets_Standard.cpp
+    ana/presets/Presets_Vertices.cpp
+    ana/presets/Presets_Plots.cpp
+)
+target_link_libraries(event_display_runner
+    PRIVATE
+        libapp
+        libplug
+        libdata
+        libhist
+        libplot
+        libsyst
+        libutils
+        Eigen3::Eigen
+        nlohmann_json::nlohmann_json
+        ${ROOT_LIBRARIES}
+        TBB::tbb
+        TMVA
+        dl
+)
+

--- a/ana/event_display_runner.cpp
+++ b/ana/event_display_runner.cpp
@@ -1,0 +1,33 @@
+#include "PipelineBuilder.h"
+#include "PipelineRunner.h"
+#include <string>
+
+int main() {
+  using namespace analysis;
+
+  AnalysisPluginHost analysis_host;
+  PlotPluginHost plot_host;
+  PipelineBuilder builder(analysis_host, plot_host);
+
+  // Restrict to a predefined analysis region and include at least one variable
+  // definition to satisfy pipeline requirements.
+  builder.region("QUALITY");
+  builder.variable("TRUE_NEUTRINO_VERTEX");
+
+  // Generate event displays for background and signal samples.  The presets
+  // provide sensible defaults for sample selection and output locations.
+  builder.preset("BACKGROUND_EVENT_DISPLAY",
+                 { {"plot_configs", {{"region", "QUALITY"}, {"n_events", 2}}} });
+  builder.preset("SIGNAL_EVENT_DISPLAY",
+                 { {"plot_configs", {{"region", "QUALITY"}, {"n_events", 2}}} });
+  builder.uniqueById();
+
+  auto analysis_specs = builder.analysisSpecs();
+  auto plot_specs = builder.plotSpecs();
+
+  PipelineRunner runner(analysis_specs, plot_specs);
+  runner.run(std::string{"config/samples.json"},
+             std::string{"/tmp/event_displays.root"});
+
+  return 0;
+}

--- a/ana/presets/Presets_Plots.cpp
+++ b/ana/presets/Presets_Plots.cpp
@@ -34,3 +34,41 @@ ANALYSIS_REGISTER_PRESET(EVENT_DISPLAY, Target::Plot,
   })
 )
 
+// Preset to configure detector event displays for background events.  Uses the
+// inclusive MC sample by default and writes images to a dedicated directory.
+ANALYSIS_REGISTER_PRESET(BACKGROUND_EVENT_DISPLAY, Target::Plot,
+  ([](const PluginArgs& vars) -> PluginSpecList {
+    auto cfg = vars.plot_configs;
+    nlohmann::json ed = {
+      {"sample", cfg.value("sample", std::string{"mc_inclusive_run1_fhc"})},
+      {"region", cfg.value("region", std::string{})},
+      {"n_events", cfg.value("n_events", 1)},
+      {"image_size", cfg.value("image_size", 800)},
+      {"output_directory",
+       cfg.value("output_directory", std::string{"./plots/background_event_displays"})}
+    };
+    PluginArgs args{{"plot_configs",
+                     {{"event_displays", nlohmann::json::array({ed})}}}};
+    return {{"EventDisplayPlugin", args}};
+  })
+)
+
+// Preset to configure detector event displays for signal events.  Defaults to
+// the strangeness-enriched MC sample and saves images separately.
+ANALYSIS_REGISTER_PRESET(SIGNAL_EVENT_DISPLAY, Target::Plot,
+  ([](const PluginArgs& vars) -> PluginSpecList {
+    auto cfg = vars.plot_configs;
+    nlohmann::json ed = {
+      {"sample", cfg.value("sample", std::string{"mc_strangeness_run1_fhc"})},
+      {"region", cfg.value("region", std::string{})},
+      {"n_events", cfg.value("n_events", 1)},
+      {"image_size", cfg.value("image_size", 800)},
+      {"output_directory",
+       cfg.value("output_directory", std::string{"./plots/signal_event_displays"})}
+    };
+    PluginArgs args{{"plot_configs",
+                     {{"event_displays", nlohmann::json::array({ed})}}}};
+    return {{"EventDisplayPlugin", args}};
+  })
+)
+

--- a/tests/test_event_display_preset.cpp
+++ b/tests/test_event_display_preset.cpp
@@ -22,3 +22,31 @@ TEST_CASE("event_display_preset_generates_plugin_spec") {
     REQUIRE(ed.at("image_size") == 800);
     REQUIRE(ed.at("output_directory") == "./plots/event_displays");
 }
+
+TEST_CASE("background_event_display_preset_defaults") {
+    auto pr = PresetRegistry::instance().find("BACKGROUND_EVENT_DISPLAY");
+    REQUIRE(pr != nullptr);
+    auto list = pr->make({});
+    REQUIRE(list.size() == 1);
+    auto spec = list.front();
+    REQUIRE(spec.id == "EventDisplayPlugin");
+    auto eds = spec.args.plot_configs.at("event_displays");
+    auto ed = eds.at(0);
+    REQUIRE(ed.at("sample") == "mc_inclusive_run1_fhc");
+    REQUIRE(ed.at("n_events") == 1);
+    REQUIRE(ed.at("output_directory") == "./plots/background_event_displays");
+}
+
+TEST_CASE("signal_event_display_preset_defaults") {
+    auto pr = PresetRegistry::instance().find("SIGNAL_EVENT_DISPLAY");
+    REQUIRE(pr != nullptr);
+    auto list = pr->make({});
+    REQUIRE(list.size() == 1);
+    auto spec = list.front();
+    REQUIRE(spec.id == "EventDisplayPlugin");
+    auto eds = spec.args.plot_configs.at("event_displays");
+    auto ed = eds.at(0);
+    REQUIRE(ed.at("sample") == "mc_strangeness_run1_fhc");
+    REQUIRE(ed.at("n_events") == 1);
+    REQUIRE(ed.at("output_directory") == "./plots/signal_event_displays");
+}


### PR DESCRIPTION
## Summary
- add `BACKGROUND_EVENT_DISPLAY` and `SIGNAL_EVENT_DISPLAY` presets to configure detector event displays for background and signal samples
- provide `event_display_runner` example using the new presets
- test default configuration for new event display presets
- wire up new runner in CMake build

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*
- `apt-get update` *(fails: repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2a610fd8832e8405380bc7003dd7