### PR TITLE
Allow vertex presets to target custom regions

### DIFF
--- a/ana/event_display_runner.cpp
+++ b/ana/event_display_runner.cpp
@@ -12,7 +12,10 @@ int main() {
   // Restrict to a predefined analysis region and include at least one variable
   // definition to satisfy pipeline requirements.
   builder.region("QUALITY");
-  builder.variable("TRUE_NEUTRINO_VERTEX");
+  // Attach vertex variables to the QUALITY region so the preset does not
+  // default to the placeholder region and cause initialisation failures.
+  builder.variable("TRUE_NEUTRINO_VERTEX",
+                   { {"analysis_configs", { {"region", "QUALITY"} }} });
 
   // Generate event displays for background and signal samples.  The presets
   // provide sensible defaults for sample selection and output locations.

--- a/ana/presets/Presets_Vertices.cpp
+++ b/ana/presets/Presets_Vertices.cpp
@@ -5,74 +5,88 @@
 using namespace analysis;
 
 // Preset defining variables for the true neutrino interaction vertex.
+//
+// The region to which the variables are attached can be overridden via the
+// `analysis_configs` field with a key named `region`.  If no override is
+// provided the variables default to the placeholder `EMPTY` region.  This keeps
+// the preset usable in minimal pipelines while allowing callers to target a
+// specific analysis region.
 ANALYSIS_REGISTER_PRESET(TRUE_NEUTRINO_VERTEX, Target::Analysis,
-                         ([](const PluginArgs &) -> PluginSpecList {
-                           nlohmann::json vars = nlohmann::json::array(
-                               {{{"name", "nu_vtx_x"},
-                                 {"branch", "neutrino_vertex_x"},
-                                 {"label", "True #nu Vertex X [cm]"},
-                                 {"stratum", "inclusive_strange_channels"},
-                                 {"regions", {"EMPTY"}},
-                                 {"bins",
-                                  {{"mode", "dynamic"},
-                                   {"strategy", "bayesian_blocks"},
-                                   {"resolution", 0.3}}}},
-                                {{"name", "nu_vtx_y"},
-                                 {"branch", "neutrino_vertex_y"},
-                                 {"label", "True #nu Vertex Y [cm]"},
-                                 {"stratum", "inclusive_strange_channels"},
-                                 {"regions", {"EMPTY"}},
-                                 {"bins",
-                                  {{"mode", "dynamic"},
-                                   {"strategy", "bayesian_blocks"},
-                                   {"resolution", 0.3}}}},
-                                {{"name", "nu_vtx_z"},
-                                 {"branch", "neutrino_vertex_z"},
-                                 {"label", "True #nu Vertex Z [cm]"},
-                                 {"stratum", "inclusive_strange_channels"},
-                                 {"regions", {"EMPTY"}},
-                                 {"bins",
-                                  {{"mode", "dynamic"},
-                                   {"strategy", "bayesian_blocks"},
-                                   {"resolution", 0.3}}}}});
-                           PluginArgs args{
-                               {"analysis_configs", {{"variables", vars}}}};
+                         ([](const PluginArgs &vars) -> PluginSpecList {
+                           std::string region =
+                               vars.analysis_configs.value("region",
+                                                           std::string{"EMPTY"});
+                           auto regions = PluginArgs::array({region});
+
+                           nlohmann::json var_defs = PluginArgs::array({
+                               {{"name", "nu_vtx_x"},
+                                {"branch", "neutrino_vertex_x"},
+                                {"label", "True #nu Vertex X [cm]"},
+                                {"stratum", "inclusive_strange_channels"},
+                                {"regions", regions},
+                                {"bins", {{"mode", "dynamic"},
+                                           {"strategy", "bayesian_blocks"},
+                                           {"resolution", 0.3}}}},
+                               {{"name", "nu_vtx_y"},
+                                {"branch", "neutrino_vertex_y"},
+                                {"label", "True #nu Vertex Y [cm]"},
+                                {"stratum", "inclusive_strange_channels"},
+                                {"regions", regions},
+                                {"bins", {{"mode", "dynamic"},
+                                           {"strategy", "bayesian_blocks"},
+                                           {"resolution", 0.3}}}},
+                               {{"name", "nu_vtx_z"},
+                                {"branch", "neutrino_vertex_z"},
+                                {"label", "True #nu Vertex Z [cm]"},
+                                {"stratum", "inclusive_strange_channels"},
+                                {"regions", regions},
+                                {"bins", {{"mode", "dynamic"},
+                                           {"strategy", "bayesian_blocks"},
+                                           {"resolution", 0.3}}}}});
+
+                           PluginArgs args{{"analysis_configs",
+                                            {{"variables", var_defs}}}};
                            return {{"VariablesPlugin", args}};
                          }))
 
 // Preset defining variables for the reconstructed neutrino interaction vertex.
+// Behaves like TRUE_NEUTRINO_VERTEX with support for an optional `region`
+// override via PluginArgs.
 ANALYSIS_REGISTER_PRESET(RECO_NEUTRINO_VERTEX, Target::Analysis,
-                         ([](const PluginArgs &) -> PluginSpecList {
-                           nlohmann::json vars = nlohmann::json::array(
-                               {{{"name", "reco_nu_vtx_x"},
-                                 {"branch", "reco_neutrino_vertex_x"},
-                                 {"label", "Reco #nu Vertex X [cm]"},
-                                 {"stratum", "inclusive_strange_channels"},
-                                 {"regions", {"EMPTY"}},
-                                 {"bins",
-                                  {{"mode", "dynamic"},
-                                   {"include_oob_bins", true},
-                                   {"strategy", "bayesian_blocks"},
-                                   {"resolution", 0.3}}}},
-                                {{"name", "reco_nu_vtx_y"},
-                                 {"branch", "reco_neutrino_vertex_y"},
-                                 {"label", "Reco #nu Vertex Y [cm]"},
-                                 {"stratum", "inclusive_strange_channels"},
-                                 {"regions", {"EMPTY"}},
-                                 {"bins",
-                                  {{"mode", "dynamic"},
-                                   {"strategy", "bayesian_blocks"},
-                                   {"resolution", 0.3}}}},
-                                {{"name", "reco_nu_vtx_z"},
-                                 {"branch", "reco_neutrino_vertex_z"},
-                                 {"label", "Reco #nu Vertex Z [cm]"},
-                                 {"stratum", "inclusive_strange_channels"},
-                                 {"regions", {"EMPTY"}},
-                                 {"bins",
-                                  {{"mode", "dynamic"},
-                                   {"strategy", "bayesian_blocks"},
-                                   {"resolution", 0.3}}}}});
-                           PluginArgs args{
-                               {"analysis_configs", {{"variables", vars}}}};
+                         ([](const PluginArgs &vars) -> PluginSpecList {
+                           std::string region =
+                               vars.analysis_configs.value("region",
+                                                           std::string{"EMPTY"});
+                           auto regions = PluginArgs::array({region});
+
+                           nlohmann::json var_defs = PluginArgs::array({
+                               {{"name", "reco_nu_vtx_x"},
+                                {"branch", "reco_neutrino_vertex_x"},
+                                {"label", "Reco #nu Vertex X [cm]"},
+                                {"stratum", "inclusive_strange_channels"},
+                                {"regions", regions},
+                                {"bins", {{"mode", "dynamic"},
+                                           {"include_oob_bins", true},
+                                           {"strategy", "bayesian_blocks"},
+                                           {"resolution", 0.3}}}},
+                               {{"name", "reco_nu_vtx_y"},
+                                {"branch", "reco_neutrino_vertex_y"},
+                                {"label", "Reco #nu Vertex Y [cm]"},
+                                {"stratum", "inclusive_strange_channels"},
+                                {"regions", regions},
+                                {"bins", {{"mode", "dynamic"},
+                                           {"strategy", "bayesian_blocks"},
+                                           {"resolution", 0.3}}}},
+                               {{"name", "reco_nu_vtx_z"},
+                                {"branch", "reco_neutrino_vertex_z"},
+                                {"label", "Reco #nu Vertex Z [cm]"},
+                                {"stratum", "inclusive_strange_channels"},
+                                {"regions", regions},
+                                {"bins", {{"mode", "dynamic"},
+                                           {"strategy", "bayesian_blocks"},
+                                           {"resolution", 0.3}}}}});
+
+                           PluginArgs args{{"analysis_configs",
+                                            {{"variables", var_defs}}}};
                            return {{"VariablesPlugin", args}};
                          }))


### PR DESCRIPTION
## Summary
- Make TRUE_NEUTRINO_VERTEX and RECO_NEUTRINO_VERTEX presets accept a region override instead of hard-coding `EMPTY`
- Attach vertex preset to the QUALITY region in `event_display_runner`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT" (missing ROOTConfig.cmake))*

------
https://chatgpt.com/codex/tasks/task_e_68bf2bc9fbc4832eac50f0626f213580