### PR TITLE
Initialize PluginArgs json fields

### DIFF
--- a/libplug/PluginArgs.h
+++ b/libplug/PluginArgs.h
@@ -10,8 +10,8 @@ namespace analysis {
 // stores a JSON object, but the separation of categories provides a clear,
 // compile-time view of what settings are available.
 struct PluginArgs {
-    nlohmann::json plot_configs{};     // configuration for plotting plugins
-    nlohmann::json analysis_configs{}; // configuration for analysis plugins
+    nlohmann::json plot_configs = nlohmann::json::object();     // configuration for plotting plugins
+    nlohmann::json analysis_configs = nlohmann::json::object(); // configuration for analysis plugins
 
     PluginArgs() = default;
 


### PR DESCRIPTION
## Summary
- Ensure PluginArgs default json members are empty objects instead of null

## Testing
- `cmake -S . -B build` *(fails: ROOT package configuration not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2ba8cb54832eb627d03b90cc369d