### PR TITLE
Handle dirt samples separately

### DIFF
--- a/config/data.json
+++ b/config/data.json
@@ -44,7 +44,7 @@
                     {
                         "sample_key": "mc_dirt_run1_fhc",
                         "stage_name": "selection_dirt",
-                        "sample_type": "mc",
+                        "sample_type": "dirt",
                         "active": true,
                         "do_hadd": true
                     }

--- a/config/samples.json
+++ b/config/samples.json
@@ -45,7 +45,7 @@
                         },
                         {
                             "sample_key": "mc_dirt_run1_fhc",
-                            "sample_type": "mc",
+                            "sample_type": "dirt",
                             "active": true,
                             "relative_path": "mc_dirt_run1_fhc.root",
                             "pot": 1.3691716923392262e+19

--- a/libdata/SampleDefinition.h
+++ b/libdata/SampleDefinition.h
@@ -71,6 +71,7 @@ class SampleDefinition {
               return (ts == "mc"     ? SampleOrigin::kMonteCarlo
                       : ts == "data" ? SampleOrigin::kData
                       : ts == "ext"  ? SampleOrigin::kExternal
+                      : ts == "dirt" ? SampleOrigin::kDirt
                                       : SampleOrigin::kUnknown);
           }()},
           rel_path_{j.value("relative_path", "")},
@@ -102,8 +103,10 @@ class SampleDefinition {
             log::fatal("SampleDefinition::validateFiles", "empty sample_key_");
         if (sample_origin_ == SampleOrigin::kUnknown)
             log::fatal("SampleDefinition::validateFiles", "unknown sample_origin_ for", sample_key_.str());
-        if (sample_origin_ == SampleOrigin::kMonteCarlo && pot_ <= 0)
-            log::fatal("SampleDefinition::validateFiles", "invalid pot_ for MC", sample_key_.str());
+        if ((sample_origin_ == SampleOrigin::kMonteCarlo ||
+             sample_origin_ == SampleOrigin::kDirt) &&
+            pot_ <= 0)
+            log::fatal("SampleDefinition::validateFiles", "invalid pot_ for MC/Dirt", sample_key_.str());
         if (sample_origin_ == SampleOrigin::kData && triggers_ <= 0)
             log::fatal("SampleDefinition::validateFiles", "invalid triggers_ for Data", sample_key_.str());
         if (sample_origin_ != SampleOrigin::kData && rel_path_.empty())

--- a/libdata/WeightProcessor.h
+++ b/libdata/WeightProcessor.h
@@ -27,7 +27,7 @@ class WeightProcessor : public IEventProcessor {
     }
 
     ROOT::RDF::RNode process(ROOT::RDF::RNode df, SampleOrigin st) const override {
-        if (st == SampleOrigin::kMonteCarlo) {
+        if (st == SampleOrigin::kMonteCarlo || st == SampleOrigin::kDirt) {
             double scale = 1.0;
             if (sample_pot_ > 0.0 && total_run_pot_ > 0.0) {
                 scale = total_run_pot_ / sample_pot_;


### PR DESCRIPTION
## Summary
- Recognize `dirt` sample type and map it to `SampleOrigin::kDirt`
- Weight dirt events using POT like other MC samples
- Mark dirt datasets in configs so they show up as their own category

## Testing
- `pytest -q` *(skipped: numpy/uproot not installed)*
- `cmake -S . -B build` *(fails: could not find ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2c2a4564832eaf983f17115d10e1