### PR TITLE
Ignore sentinel extremes in dynamic binning

### DIFF
--- a/libhist/DynamicBinning.h
+++ b/libhist/DynamicBinning.h
@@ -252,12 +252,24 @@ private:
     log::debug("DynamicBinning::filterEntries", "Starting with", before,
                "entries");
 
+    const double float_low =
+        static_cast<double>(std::numeric_limits<float>::lowest());
+    const double float_high =
+        static_cast<double>(std::numeric_limits<float>::max());
+    const double double_low = std::numeric_limits<double>::lowest();
+    const double double_high = std::numeric_limits<double>::max();
+
     xw.erase(std::remove_if(xw.begin(), xw.end(),
                             [&](const auto &p) {
                               double x = p.first;
                               double w = p.second;
-                              return !std::isfinite(x) || !std::isfinite(w) ||
-                                     w <= 0.0;
+                              bool invalid_x =
+                                  !std::isfinite(x) || x == float_low ||
+                                  x == float_high || x == double_low ||
+                                  x == double_high;
+                              bool invalid_w =
+                                  !std::isfinite(w) || w <= 0.0;
+                              return invalid_x || invalid_w;
                             }),
              xw.end());
 

--- a/libhist/QuadTreeBinning.h
+++ b/libhist/QuadTreeBinning.h
@@ -52,6 +52,17 @@ class QuadTreeBinning {
         std::vector<Point> pts;
         pts.reserve(262144);
 
+        const double float_low =
+            static_cast<double>(std::numeric_limits<float>::lowest());
+        const double float_high =
+            static_cast<double>(std::numeric_limits<float>::max());
+        const double double_low = std::numeric_limits<double>::lowest();
+        const double double_high = std::numeric_limits<double>::max();
+        auto is_extreme = [&](double v) {
+            return v == float_low || v == float_high || v == double_low ||
+                   v == double_high;
+        };
+
         for (auto &n : nodes) {
             bool has_w = n.HasColumn(weight_col);
             auto xv = n.Take<double>(xb.getVariable());
@@ -62,15 +73,17 @@ class QuadTreeBinning {
                     double x = (*xv)[i];
                     double y = (*yv)[i];
                     double w = (*wv)[i];
-                    if (std::isfinite(x) && std::isfinite(y) && std::isfinite(w) && w > 0.0 && x >= xmin && x <= xmax &&
-                        y >= ymin && y <= ymax)
+                    if (std::isfinite(x) && std::isfinite(y) && std::isfinite(w) && w > 0.0 &&
+                        x >= xmin && x <= xmax && y >= ymin && y <= ymax &&
+                        !is_extreme(x) && !is_extreme(y))
                         pts.push_back({x, y, w});
                 }
             } else {
                 for (size_t i = 0; i < xv->size(); ++i) {
                     double x = (*xv)[i];
                     double y = (*yv)[i];
-                    if (std::isfinite(x) && std::isfinite(y) && x >= xmin && x <= xmax && y >= ymin && y <= ymax)
+                    if (std::isfinite(x) && std::isfinite(y) && x >= xmin && x <= xmax &&
+                        y >= ymin && y <= ymax && !is_extreme(x) && !is_extreme(y))
                         pts.push_back({x, y, 1.0});
                 }
             }


### PR DESCRIPTION
## Summary
- Exclude NaN and numeric-limits sentinels when filtering values for dynamic binning.
- Guard quad-tree binning against extreme sentinel coordinates.

## Testing
- `pytest -q`
- `ctest` *(fails: No test configuration file found)*
- `cmake -S . -B build` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2dee6bbc832e9bebf3fc5a66d5fa