### PR TITLE
Fix EventDisplay plugin factory symbol

### DIFF
--- a/libplug/plotting/EventDisplayPlugin.cc
+++ b/libplug/plotting/EventDisplayPlugin.cc
@@ -129,8 +129,13 @@ ANALYSIS_REGISTER_PLUGIN(analysis::IPlotPlugin, analysis::AnalysisDataLoader,
                          "EventDisplayPlugin", analysis::EventDisplayPlugin)
 
 #ifdef BUILD_PLUGIN
+extern "C" analysis::IPlotPlugin *createEventDisplayPlugin(
+    const analysis::PluginArgs &args) {
+    return new analysis::EventDisplayPlugin(args,
+                                           analysis::EventDisplayPlugin::legacyLoader());
+}
 extern "C" analysis::IPlotPlugin *createPlotPlugin(const analysis::PluginArgs &args) {
-    return new analysis::EventDisplayPlugin(args, analysis::EventDisplayPlugin::legacyLoader());
+    return createEventDisplayPlugin(args);
 }
 extern "C" void setPluginContext(analysis::AnalysisDataLoader *loader) {
     analysis::EventDisplayPlugin::setLegacyLoader(loader);


### PR DESCRIPTION
## Summary
- Export `createEventDisplayPlugin` factory function and alias `createPlotPlugin`

## Testing
- `bash .build.sh` *(fails: Could not find package configuration file provided by "ROOT" - missing ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bf301f08c4832e8a10171f538fc8c2