### PR TITLE
Include external run triggers in total

### DIFF
--- a/libdata/AnalysisDataLoader.h
+++ b/libdata/AnalysisDataLoader.h
@@ -113,6 +113,10 @@ class AnalysisDataLoader {
             auto key = ext_beam + ":" + period;
             if (run_registry_.all().count(key)) {
                 const auto &ext_rc = run_registry_.get(ext_beam, period);
+                // Include external run totals before building pipelines so
+                // external samples are scaled by the full trigger count.
+                total_pot_ += ext_rc.nominal_pot;
+                total_triggers_ += ext_rc.nominal_triggers;
                 this->processRunConfig(ext_rc);
             }
         }


### PR DESCRIPTION
## Summary
- ensure external run POT and triggers are added before processing, allowing external samples to scale by total triggers

## Testing
- `bash .build.sh` *(fails: Could not find a package configuration file provided by "ROOT"...)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf315e05d0832e97fa61f4d48e2aee