### PR TITLE
Ensure EventDisplayPlugin receives data loader context

### DIFF
--- a/libapp/RegionAnalysis.h
+++ b/libapp/RegionAnalysis.h
@@ -34,7 +34,13 @@ class RegionAnalysis {
 
     const std::string &beamConfig() const noexcept { return beam_config_; }
 
+    void setBeamConfig(std::string bc) { beam_config_ = std::move(bc); }
+
     const std::vector<std::string> &runNumbers() const noexcept { return run_numbers_; }
+
+    void setRunNumbers(std::vector<std::string> runs) {
+        run_numbers_ = std::move(runs);
+    }
 
     void addFinalVariable(VariableKey v, VariableResult r) {
         final_variables_.insert_or_assign(std::move(v), std::move(r));

--- a/libplug/PipelineRunner.h
+++ b/libplug/PipelineRunner.h
@@ -45,8 +45,16 @@ inline AnalysisResult processBeamline(
 
   AnalysisRunner runner(data_loader, std::move(histogram_factory),
                         systematics_processor, analysis_specs);
+  auto result = runner.run();
 
-  return runner.run();
+  for (auto &kv : result.regions()) {
+    if (kv.second.beamConfig().empty()) {
+      kv.second.setBeamConfig(beam);
+      kv.second.setRunNumbers(periods);
+    }
+  }
+
+  return result;
 }
 
 inline void aggregateResults(AnalysisResult &result,


### PR DESCRIPTION
## Summary
- add setters for beam config and run numbers on `RegionAnalysis`
- populate beam and run info for each region during beamline processing so plot plugins have loader context

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bf324cc8f0832e9869445ac16789ef