### PR TITLE
Add snapshot runner for quality and numu selections

### DIFF
--- a/ana/quality_numu_snapshot.cpp
+++ b/ana/quality_numu_snapshot.cpp
@@ -1,0 +1,27 @@
+#include "PipelineBuilder.h"
+#include "PipelineRunner.h"
+#include <string>
+
+int main() {
+  using namespace analysis;
+
+  AnalysisPluginHost analysis_host;
+  PlotPluginHost plot_host;
+  PipelineBuilder builder(analysis_host, plot_host);
+
+  // Apply quality and νμ CC selection presets then snapshot the resulting data frame.
+  builder.variable("TRUE_NEUTRINO_VERTEX");
+  builder.preset("QUALITY");
+  builder.preset("NUMU_CC");
+  builder.preset("NUMU_CC_SNAPSHOT");
+  //builder.uniqueById();
+
+  auto analysis_specs = builder.analysisSpecs();
+  auto plot_specs = builder.plotSpecs();
+
+  PipelineRunner runner(analysis_specs, plot_specs);
+  runner.run(std::string{"config/samples.json"},
+             std::string{"/tmp/numu_cc_snapshot.root"});
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add quality_numu_snapshot.cpp example that cascades quality and NUMU_CC presets and snapshots the resulting data frame

## Testing
- `source .container.sh` (fails: No such file or directory)
- `source .setup.sh` (fails: No such file or directory)
- `source .build.sh` (fails: Could not find a package configuration file provided by "ROOT")

------
https://chatgpt.com/codex/tasks/task_e_68bf328651b4832eb37995fa13f23fe8