### PR TITLE
feat: refine truth channel definitions

### DIFF
--- a/libdata/TruthChannelProcessor.h
+++ b/libdata/TruthChannelProcessor.h
@@ -220,30 +220,38 @@ private:
   }
 
   ROOT::RDF::RNode assignChannelDefinitions(ROOT::RDF::RNode df) const {
-    auto chan_df = df.Define("channel_def",
-                             [](bool fv, int nu, int cc, int s, int npi, int np,
-                                int npi0, int ngamma) {
-                               if (!fv)
-                                 return 1; // Cosmic / Dirt
-                               if (cc == 1)
-                                 return 14; // NC
-                               if (s > 0)
-                                 return 15; // Signal (strange)
-                               if (std::abs(nu) == 14 && cc == 0) {
-                                 if (npi == 0 && np > 0)
-                                   return 10; // CC0pi (mu + Np)
-                                 if (npi == 1 && npi0 == 0)
-                                   return 11; // CC1pi±
-                                 if (npi0 > 0 || ngamma >= 2)
-                                   return 12; // CCpi0/gg
-                                 if (npi > 1)
-                                   return 13; // CC multi-pi
-                               }
-                               return 99; // Other
-                             },
-                             {"in_fiducial", "neutrino_pdg", "interaction_ccnc",
-                              "mc_n_strange", "mc_n_pion", "mc_n_proton",
-                              "count_pi_zero", "count_gamma"});
+    auto chan_df =
+        df.Define("channel_def", [](bool fv, int nu, int cc, int s, int npi,
+                                     int np, int npi0, int ngamma) {
+          if (!fv) {
+            if (nu == 0)
+              return 1; // Cosmic / Dirt
+            return 2;   // Outside FV
+          }
+          if (cc == 1)
+            return 14; // NC
+          if (cc == 0 && s > 0) {
+            if (s == 1)
+              return 15; // CC single strange
+            return 16;   // CC associated strange
+          }
+          if (std::abs(nu) == 12 && cc == 0)
+            return 17; // nue CC
+          if (std::abs(nu) == 14 && cc == 0) {
+            if (npi == 0 && np > 0)
+              return 10; // CC0pi (mu + Np)
+            if (npi == 1 && npi0 == 0)
+              return 11; // CC1pi±
+            if (npi0 > 0 || ngamma >= 2)
+              return 12; // CCpi0/gg
+            if (npi > 1)
+              return 13; // CC multi-pi
+          }
+          return 99; // Other
+        },
+                   {"in_fiducial", "neutrino_pdg", "interaction_ccnc",
+                    "mc_n_strange", "mc_n_pion", "mc_n_proton",
+                    "count_pi_zero", "count_gamma"});
 
     auto chan_alias_df = chan_df.Define("channel_definitions", "channel_def");
 

--- a/libhist/StratifierRegistry.h
+++ b/libhist/StratifierRegistry.h
@@ -338,12 +338,15 @@ private:
         "channel_definitions", StratifierType::kScalar,
         {{0, "data", "Data", kBlack, 1001},
          {1, "cosmic_dirt", "Cosmic/Dirt", kGray + 2, 1001},
+         {2, "out_fv", "Outside FV", kGray + 1, 1001},
          {10, "cc0pi", R"(CC0#pi(#mu+Np))", kRed, 1001},
          {11, "cc1pipm", R"(CC1#pi^{#pm})", kOrange - 3, 1001},
          {12, "ccpi0_gg", R"(CC#pi^{0}/#gamma#gamma)", kYellow - 7, 1001},
          {13, "cc_multi_pi", R"(CC multi-#pi)", kGreen + 2, 1001},
          {14, "nc", "NC", kBlue, 1001},
-         {15, "signal", "Signal", kMagenta + 2, 1001},
+         {15, "cc_single_strange", "CC single s", kMagenta + 2, 1001},
+         {16, "cc_assoc_strange", "CC assoc s", kMagenta - 2, 1001},
+         {17, "nue_cc", R"(#nu_{e} CC)", kAzure + 2, 1001},
          {99, "other", "Other", kCyan + 2, 1001}});
   }
 


### PR DESCRIPTION
## Summary
- add explicit outside-FV, CC electron-neutrino, and two strangeness signal channels
- extend stratifier scheme for new channels

## Testing
- `source .container.sh` (missing cvmfs environment)
- `source .setup.sh` (missing cvmfs environment)
- `source .build.sh` (missing ROOT/FindROOT.cmake)
- `ctest --output-on-failure` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68bf367e6578832e8c0e4a6af6f7faaf