### PR TITLE
feat: overlay signal histogram on stacked plots

### DIFF
--- a/libhist/StratifierRegistry.h
+++ b/libhist/StratifierRegistry.h
@@ -60,7 +60,8 @@ public:
     signal_channel_groups_ = {
         {"inclusive_strange_channels", {10, 11}},
         {"exclusive_strange_channels",
-         {50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61}}};
+         {50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61}},
+        {"channel_definitions", {15, 16}}};
     log::info("StratifierRegistry::StratifierRegistry",
               "Registry initialised successfully.");
   }

--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -28,416 +28,465 @@
 namespace analysis {
 
 class StackedHistogramPlot : public IHistogramPlot {
-  public:
-    StackedHistogramPlot(
-        std::string plot_name, const VariableResult &var_result,
-        const RegionAnalysis &region_info, std::string category_column,
-        std::string output_directory = "plots", bool overlay_signal = true,
-        std::vector<Cut> cut_list = {}, bool annotate_numbers = true,
-        bool use_log_y = false, std::string y_axis_label = "Events",
-        int uniform_bins = -1, double uniform_min = 0.0,
-        double uniform_max = 0.0)
-        : IHistogramPlot(std::move(plot_name), std::move(output_directory)),
-          variable_result_(var_result), region_analysis_(region_info),
-          category_column_(std::move(category_column)),
-          overlay_signal_(overlay_signal), cuts_(cut_list),
-          annotate_numbers_(annotate_numbers), use_log_y_(use_log_y),
-          y_axis_label_(std::move(y_axis_label)),
-          use_uniform_binning_(uniform_bins > 0), uniform_bins_(uniform_bins),
-          uniform_min_(uniform_min), uniform_max_(uniform_max) {}
+public:
+  StackedHistogramPlot(
+      std::string plot_name, const VariableResult &var_result,
+      const RegionAnalysis &region_info, std::string category_column,
+      std::string output_directory = "plots", bool overlay_signal = true,
+      std::vector<Cut> cut_list = {}, bool annotate_numbers = true,
+      bool use_log_y = false, std::string y_axis_label = "Events",
+      int uniform_bins = -1, double uniform_min = 0.0, double uniform_max = 0.0)
+      : IHistogramPlot(std::move(plot_name), std::move(output_directory)),
+        variable_result_(var_result), region_analysis_(region_info),
+        category_column_(std::move(category_column)),
+        overlay_signal_(overlay_signal), cuts_(cut_list),
+        annotate_numbers_(annotate_numbers), use_log_y_(use_log_y),
+        y_axis_label_(std::move(y_axis_label)),
+        use_uniform_binning_(uniform_bins > 0), uniform_bins_(uniform_bins),
+        uniform_min_(uniform_min), uniform_max_(uniform_max) {}
 
-    ~StackedHistogramPlot() override {
-        delete total_mc_hist_;
-        delete mc_stack_;
-        delete legend_;
-        for (auto vis : cut_visuals_) {
-            delete vis;
-        }
+  ~StackedHistogramPlot() override {
+    delete total_mc_hist_;
+    delete mc_stack_;
+    delete legend_;
+    delete signal_hist_;
+    for (auto vis : cut_visuals_) {
+      delete vis;
+    }
+  }
+
+  void addCut(const Cut &cut) { cuts_.push_back(cut); }
+
+private:
+  static std::string formatWithCommas(double val, int precision = -1) {
+    std::stringstream stream;
+    if (precision >= 0) {
+      stream << std::fixed << std::setprecision(precision);
+    }
+    stream << val;
+    std::string s = stream.str();
+    std::size_t pos = s.find('.');
+    for (int i = (pos == std::string::npos ? s.size() : pos) - 3; i > 0;
+         i -= 3) {
+      s.insert(i, ",");
+    }
+    return s;
+  }
+
+  void setupPads(TCanvas &canvas, TPad *&p_main, TPad *&p_legend) const {
+    const double PLOT_LEGEND_SPLIT = 0.85;
+    canvas.cd();
+    p_main = new TPad("main_pad", "main_pad", 0.0, 0.0, 1.0, PLOT_LEGEND_SPLIT);
+    p_legend =
+        new TPad("legend_pad", "legend_pad", 0.0, PLOT_LEGEND_SPLIT, 1.0, 1.0);
+    p_main->SetTopMargin(0.01);
+    p_main->SetBottomMargin(0.12);
+    p_main->SetLeftMargin(0.12);
+    p_main->SetRightMargin(0.05);
+    if (use_log_y_)
+      p_main->SetLogy();
+    p_legend->SetTopMargin(0.05);
+    p_legend->SetBottomMargin(0.01);
+    p_legend->Draw();
+    p_main->Draw();
+  }
+
+  std::vector<double> prepareHistograms(
+      std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists,
+      double &total_mc_events, double &left_edge, double &right_edge) {
+    mc_stack_ = new THStack("mc_stack", "");
+
+    std::vector<double> orig_edges;
+    if (use_uniform_binning_ && uniform_max_ > uniform_min_) {
+      orig_edges.resize(uniform_bins_ + 1);
+      double width = (uniform_max_ - uniform_min_) / uniform_bins_;
+      for (int i = 0; i <= uniform_bins_; ++i)
+        orig_edges[i] = uniform_min_ + width * i;
+    } else {
+      orig_edges = variable_result_.binning_.getEdges();
     }
 
-    void addCut(const Cut &cut) { cuts_.push_back(cut); }
+    left_edge = orig_edges.empty() ? 0.0 : orig_edges.front();
+    right_edge = orig_edges.empty() ? 0.0 : orig_edges.back();
 
-  private:
-    static std::string formatWithCommas(double val, int precision = -1) {
-        std::stringstream stream;
-        if (precision >= 0) {
-            stream << std::fixed << std::setprecision(precision);
-        }
-        stream << val;
-        std::string s = stream.str();
-        std::size_t pos = s.find('.');
-        for (int i = (pos == std::string::npos ? s.size() : pos) - 3; i > 0;
-             i -= 3) {
-            s.insert(i, ",");
-        }
-        return s;
+    for (auto const &[key, hist] : variable_result_.strat_hists_)
+      if (hist.getSum() > 0)
+        mc_hists.emplace_back(key, hist);
+
+    std::sort(mc_hists.begin(), mc_hists.end(),
+              [](const auto &a, const auto &b) {
+                return a.second.getSum() < b.second.getSum();
+              });
+    std::reverse(mc_hists.begin(), mc_hists.end());
+
+    total_mc_events = 0.0;
+    for (const auto &[key, hist] : mc_hists)
+      total_mc_events += hist.getSum();
+
+    return orig_edges;
+  }
+
+  TH1D *buildSignalHistogram(
+      const std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists,
+      const std::vector<double> &orig_edges) {
+    if (!overlay_signal_)
+      return nullptr;
+
+    StratifierRegistry registry;
+    TH1D *sig_hist = nullptr;
+    std::vector<int> signal_keys = registry.getSignalKeys(category_column_);
+
+    for (const auto &[key, hist] : mc_hists) {
+      int key_int = std::stoi(key.str());
+      if (std::find(signal_keys.begin(), signal_keys.end(), key_int) ==
+          signal_keys.end())
+        continue;
+
+      TH1D *h = (TH1D *)hist.get()->Clone();
+      if (use_uniform_binning_ && uniform_max_ > uniform_min_) {
+        TH1D *h_tmp = (TH1D *)h->Rebin(
+            orig_edges.size() - 1,
+            (std::string(h->GetName()) + "_rebin").c_str(), orig_edges.data());
+        delete h;
+        h = h_tmp;
+      }
+
+      if (!sig_hist) {
+        sig_hist = h;
+        sig_hist->SetDirectory(0);
+      } else {
+        sig_hist->Add(h);
+        delete h;
+      }
     }
 
-    void setupPads(TCanvas &canvas, TPad *&p_main, TPad *&p_legend) const {
-        const double PLOT_LEGEND_SPLIT = 0.85;
-        canvas.cd();
-        p_main =
-            new TPad("main_pad", "main_pad", 0.0, 0.0, 1.0, PLOT_LEGEND_SPLIT);
-        p_legend = new TPad("legend_pad", "legend_pad", 0.0, PLOT_LEGEND_SPLIT,
-                            1.0, 1.0);
-        p_main->SetTopMargin(0.01);
-        p_main->SetBottomMargin(0.12);
-        p_main->SetLeftMargin(0.12);
-        p_main->SetRightMargin(0.05);
-        if (use_log_y_)
-            p_main->SetLogy();
-        p_legend->SetTopMargin(0.05);
-        p_legend->SetBottomMargin(0.01);
-        p_legend->Draw();
-        p_main->Draw();
+    if (sig_hist) {
+      sig_hist->SetFillStyle(0);
+      sig_hist->SetLineColor(kGreen + 2);
+      sig_hist->SetLineStyle(kDashed);
+      sig_hist->SetLineWidth(2);
     }
 
-    std::vector<double> prepareHistograms(
-        std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists,
-        double &total_mc_events, double &left_edge, double &right_edge) {
-        mc_stack_ = new THStack("mc_stack", "");
+    return sig_hist;
+  }
 
-        std::vector<double> orig_edges;
-        if (use_uniform_binning_ && uniform_max_ > uniform_min_) {
-            orig_edges.resize(uniform_bins_ + 1);
-            double width = (uniform_max_ - uniform_min_) / uniform_bins_;
-            for (int i = 0; i <= uniform_bins_; ++i)
-                orig_edges[i] = uniform_min_ + width * i;
-        } else {
-            orig_edges = variable_result_.binning_.getEdges();
-        }
+  void buildLegend(
+      TPad *p_legend,
+      const std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists,
+      TH1D *sig_hist) {
+    StratifierRegistry registry;
 
-        left_edge = orig_edges.empty() ? 0.0 : orig_edges.front();
-        right_edge = orig_edges.empty() ? 0.0 : orig_edges.back();
+    std::map<std::string, std::string> beam_map = {{"numi_fhc", "NuMI FHC"},
+                                                   {"numi_rhc", "NuMI RHC"}};
 
-        for (auto const &[key, hist] : variable_result_.strat_hists_)
-            if (hist.getSum() > 0)
-                mc_hists.emplace_back(key, hist);
+    std::string beam_name = region_analysis_.beamConfig();
+    if (beam_map.count(beam_name))
+      beam_name = beam_map.at(beam_name);
+    if (beam_name.empty())
+      beam_name = "N/A";
 
-        std::sort(mc_hists.begin(), mc_hists.end(),
-                  [](const auto &a, const auto &b) {
-                      return a.second.getSum() < b.second.getSum();
-                  });
-        std::reverse(mc_hists.begin(), mc_hists.end());
-
-        total_mc_events = 0.0;
-        for (const auto &[key, hist] : mc_hists)
-            total_mc_events += hist.getSum();
-
-        return orig_edges;
-    }
-
-    void buildLegend(
-        TPad *p_legend,
-        const std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists) {
-        StratifierRegistry registry;
-
-        std::map<std::string, std::string> beam_map = {
-            {"numi_fhc", "NuMI FHC"}, {"numi_rhc", "NuMI RHC"}};
-
-        std::string beam_name = region_analysis_.beamConfig();
-        if (beam_map.count(beam_name))
-            beam_name = beam_map.at(beam_name);
-        if (beam_name.empty())
-            beam_name = "N/A";
-
-        std::string runs_str;
-        if (!region_analysis_.runNumbers().empty()) {
-            for (size_t i = 0; i < region_analysis_.runNumbers().size(); ++i) {
-                std::string run_label = region_analysis_.runNumbers()[i];
-                if (run_label.rfind("run", 0) == 0)
-                    run_label = run_label.substr(3);
-                runs_str +=
-                    run_label +
+    std::string runs_str;
+    if (!region_analysis_.runNumbers().empty()) {
+      for (size_t i = 0; i < region_analysis_.runNumbers().size(); ++i) {
+        std::string run_label = region_analysis_.runNumbers()[i];
+        if (run_label.rfind("run", 0) == 0)
+          run_label = run_label.substr(3);
+        runs_str += run_label +
                     (i < region_analysis_.runNumbers().size() - 1 ? ", " : "");
-            }
-        } else {
-            runs_str = "N/A";
-        }
-
-        p_legend->cd();
-        legend_ = new TLegend(0.12, 0.0, 0.95, 0.75);
-        legend_->SetBorderSize(0);
-        legend_->SetFillStyle(0);
-        legend_->SetTextFont(42);
-        const int n_entries = mc_hists.size() + 1;
-        int n_cols = (n_entries > 4) ? 3 : 2;
-        legend_->SetNColumns(n_cols);
-
-        for (const auto &[key, hist] : mc_hists) {
-            TH1D *h_leg = new TH1D();
-            const auto &stratum = registry.getStratumProperties(
-                category_column_, std::stoi(key.str()));
-            h_leg->SetFillColor(stratum.fill_colour);
-            h_leg->SetFillStyle(stratum.fill_style);
-            h_leg->SetLineColor(kBlack);
-            h_leg->SetLineWidth(1.5);
-
-            std::string tex_label = stratum.tex_label;
-            if (tex_label == "#emptyset")
-                tex_label = "\xE2\x88\x85";
-
-            std::string legend_label =
-                annotate_numbers_ ? tex_label + " : " +
-                                        this->formatWithCommas(hist.getSum(), 2)
-                                  : tex_label;
-            legend_->AddEntry(h_leg, legend_label.c_str(), "f");
-        }
-
-        if (!mc_hists.empty()) {
-            TH1D *h_unc = new TH1D();
-            h_unc->SetFillColor(kBlack);
-            h_unc->SetFillStyle(3004);
-            h_unc->SetLineColor(kBlack);
-            h_unc->SetLineWidth(1);
-            std::string total_label = "Stat. #oplus Syst. Unc.";
-            legend_->AddEntry(h_unc, total_label.c_str(), "f");
-        }
-
-        legend_->Draw();
-
-        TLatex header;
-        header.SetNDC();
-        header.SetTextFont(42);
-        header.SetTextAlign(13);
-        header.SetTextSize(0.05);
-        header.DrawLatex(0.12, 0.93, ("Beam: " + beam_name).c_str());
-        header.DrawLatex(0.12, 0.80, ("Runs: " + runs_str).c_str());
+      }
+    } else {
+      runs_str = "N/A";
     }
 
-    double drawStack(
-        TPad *p_main,
-        const std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists,
-        const std::vector<double> &orig_edges) {
-        StratifierRegistry registry;
+    p_legend->cd();
+    legend_ = new TLegend(0.12, 0.0, 0.95, 0.75);
+    legend_->SetBorderSize(0);
+    legend_->SetFillStyle(0);
+    legend_->SetTextFont(42);
+    const int n_entries = mc_hists.size() + 1;
+    int n_cols = (n_entries > 4) ? 3 : 2;
+    legend_->SetNColumns(n_cols);
 
-        p_main->cd();
+    for (const auto &[key, hist] : mc_hists) {
+      TH1D *h_leg = new TH1D();
+      const auto &stratum =
+          registry.getStratumProperties(category_column_, std::stoi(key.str()));
+      h_leg->SetFillColor(stratum.fill_colour);
+      h_leg->SetFillStyle(stratum.fill_style);
+      h_leg->SetLineColor(kBlack);
+      h_leg->SetLineWidth(1.5);
 
-        for (const auto &[key, hist] : mc_hists) {
-            TH1D *h = (TH1D *)hist.get()->Clone();
-            if (use_uniform_binning_ && uniform_max_ > uniform_min_) {
-                TH1D *h_tmp = (TH1D *)h->Rebin(
-                    orig_edges.size() - 1,
-                    (std::string(h->GetName()) + "_rebin").c_str(),
-                    orig_edges.data());
-                delete h;
-                h = h_tmp;
-            }
-            const auto &stratum = registry.getStratumProperties(
-                category_column_, std::stoi(key.str()));
-            h->SetFillColor(stratum.fill_colour);
-            h->SetFillStyle(stratum.fill_style);
-            h->SetLineColor(kBlack);
-            h->SetLineWidth(1);
-            mc_stack_->Add(h, "HIST");
-            if (!total_mc_hist_) {
-                total_mc_hist_ = (TH1D *)h->Clone("total_mc_hist");
-                total_mc_hist_->SetDirectory(0);
-            } else {
-                total_mc_hist_->Add(h);
-            }
-        }
+      std::string tex_label = stratum.tex_label;
+      if (tex_label == "#emptyset")
+        tex_label = "\xE2\x88\x85";
 
-        double max_y = total_mc_hist_ ? total_mc_hist_->GetMaximum() +
-                                            total_mc_hist_->GetBinError(
-                                                total_mc_hist_->GetMaximumBin())
-                                      : 1.0;
-        mc_stack_->Draw("HIST");
-        mc_stack_->SetMaximum(max_y * (use_log_y_ ? 10 : 1.3));
-        mc_stack_->SetMinimum(use_log_y_ ? 0.1 : 0.0);
-
-        if (total_mc_hist_) {
-            TMatrixDSym total_syst_cov = variable_result_.total_covariance_;
-
-            for (int i = 1; i <= total_mc_hist_->GetNbinsX(); ++i) {
-                double stat_err = total_mc_hist_->GetBinError(i);
-                double syst_err = (i - 1 < total_syst_cov.GetNrows())
-                                      ? std::sqrt(total_syst_cov(i - 1, i - 1))
-                                      : 0.0;
-                double total_err =
-                    std::sqrt(stat_err * stat_err + syst_err * syst_err);
-                log::info("StackedHistogramPlot::draw", "Bin", i,
-                          "stat_err =", stat_err, "syst_err =", syst_err,
-                          "total_err =", total_err);
-                total_mc_hist_->SetBinError(i, total_err);
-            }
-
-            total_mc_hist_->SetFillColor(kBlack);
-            total_mc_hist_->SetFillStyle(3004);
-            total_mc_hist_->SetMarkerSize(0);
-            total_mc_hist_->SetLineColor(kBlack);
-            total_mc_hist_->SetLineWidth(1);
-            total_mc_hist_->Draw("E2 SAME");
-            total_mc_hist_->Draw("E1 SAME");
-        }
-
-        return max_y;
+      std::string legend_label =
+          annotate_numbers_
+              ? tex_label + " : " + this->formatWithCommas(hist.getSum(), 2)
+              : tex_label;
+      legend_->AddEntry(h_leg, legend_label.c_str(), "f");
     }
 
-    void renderCuts(double max_y) {
-        for (const auto &cut : cuts_) {
-            double y_arrow_pos = max_y * 0.85;
-            double x_range = mc_stack_->GetXaxis()->GetXmax() -
-                             mc_stack_->GetXaxis()->GetXmin();
-            double arrow_length = x_range * 0.04;
-
-            TLine *line =
-                new TLine(cut.threshold, 0, cut.threshold, max_y * 1.3);
-            line->SetLineColor(kRed);
-            line->SetLineWidth(2);
-            line->SetLineStyle(kDashed);
-            line->Draw("same");
-            cut_visuals_.push_back(line);
-
-            double x_start;
-            double x_end;
-            if (cut.direction == CutDirection::GreaterThan) {
-                x_start = cut.threshold;
-                x_end = cut.threshold + arrow_length;
-            } else {
-                x_start = cut.threshold;
-                x_end = cut.threshold - arrow_length;
-            }
-            TArrow *arrow = new TArrow(x_start, y_arrow_pos, x_end, y_arrow_pos,
-                                       0.025, ">");
-            arrow->SetLineColor(kRed);
-            arrow->SetFillColor(kRed);
-            arrow->SetLineWidth(2);
-            arrow->Draw("same");
-            cut_visuals_.push_back(arrow);
-        }
+    if (!mc_hists.empty()) {
+      TH1D *h_unc = new TH1D();
+      h_unc->SetFillColor(kBlack);
+      h_unc->SetFillStyle(3004);
+      h_unc->SetLineColor(kBlack);
+      h_unc->SetLineWidth(1);
+      std::string total_label = "Stat. #oplus Syst. Unc.";
+      legend_->AddEntry(h_unc, total_label.c_str(), "f");
     }
 
-    void configureAxes(double left_edge, double right_edge) {
-        TH1 *frame = mc_stack_->GetHistogram();
-        frame->GetXaxis()->SetTitle(
-            variable_result_.binning_.getTexLabel().c_str());
-        frame->GetYaxis()->SetTitle(y_axis_label_.c_str());
-        frame->GetXaxis()->SetTitleOffset(1.0);
-        frame->GetYaxis()->SetTitleOffset(1.0);
-        frame->GetXaxis()->SetLimits(left_edge, right_edge);
-        frame->GetXaxis()->SetNdivisions(520);
-        frame->GetXaxis()->SetTickLength(0.02);
+    if (sig_hist)
+      legend_->AddEntry(sig_hist, "Signal", "l");
+
+    legend_->Draw();
+
+    TLatex header;
+    header.SetNDC();
+    header.SetTextFont(42);
+    header.SetTextAlign(13);
+    header.SetTextSize(0.05);
+    header.DrawLatex(0.12, 0.93, ("Beam: " + beam_name).c_str());
+    header.DrawLatex(0.12, 0.80, ("Runs: " + runs_str).c_str());
+  }
+
+  double
+  drawStack(TPad *p_main,
+            const std::vector<std::pair<ChannelKey, BinnedHistogram>> &mc_hists,
+            const std::vector<double> &orig_edges) {
+    StratifierRegistry registry;
+
+    p_main->cd();
+
+    for (const auto &[key, hist] : mc_hists) {
+      TH1D *h = (TH1D *)hist.get()->Clone();
+      if (use_uniform_binning_ && uniform_max_ > uniform_min_) {
+        TH1D *h_tmp = (TH1D *)h->Rebin(
+            orig_edges.size() - 1,
+            (std::string(h->GetName()) + "_rebin").c_str(), orig_edges.data());
+        delete h;
+        h = h_tmp;
+      }
+      const auto &stratum =
+          registry.getStratumProperties(category_column_, std::stoi(key.str()));
+      h->SetFillColor(stratum.fill_colour);
+      h->SetFillStyle(stratum.fill_style);
+      h->SetLineColor(kBlack);
+      h->SetLineWidth(1);
+      mc_stack_->Add(h, "HIST");
+      if (!total_mc_hist_) {
+        total_mc_hist_ = (TH1D *)h->Clone("total_mc_hist");
+        total_mc_hist_->SetDirectory(0);
+      } else {
+        total_mc_hist_->Add(h);
+      }
     }
 
-    void drawWatermark(TPad *pad, double total_mc_events) const {
-        pad->cd();
+    double max_y =
+        total_mc_hist_
+            ? total_mc_hist_->GetMaximum() +
+                  total_mc_hist_->GetBinError(total_mc_hist_->GetMaximumBin())
+            : 1.0;
+    mc_stack_->Draw("HIST");
+    mc_stack_->SetMaximum(max_y * (use_log_y_ ? 10 : 1.3));
+    mc_stack_->SetMinimum(use_log_y_ ? 0.1 : 0.0);
 
-        std::string line1 = "#bf{#muBooNE Simulation, Preliminary}";
+    if (total_mc_hist_) {
+      TMatrixDSym total_syst_cov = variable_result_.total_covariance_;
 
-        std::stringstream pot_stream;
-        pot_stream << std::scientific << std::setprecision(2)
-                   << region_analysis_.protonsOnTarget();
-        std::string pot_str = pot_stream.str();
-        size_t e_pos = pot_str.find('e');
-        if (e_pos != std::string::npos) {
-            int exponent = std::stoi(pot_str.substr(e_pos + 1));
-            pot_str = pot_str.substr(0, e_pos);
-            pot_str += " #times 10^{" + std::to_string(exponent) + "}";
+      for (int i = 1; i <= total_mc_hist_->GetNbinsX(); ++i) {
+        double stat_err = total_mc_hist_->GetBinError(i);
+        double syst_err = (i - 1 < total_syst_cov.GetNrows())
+                              ? std::sqrt(total_syst_cov(i - 1, i - 1))
+                              : 0.0;
+        double total_err = std::sqrt(stat_err * stat_err + syst_err * syst_err);
+        log::info("StackedHistogramPlot::draw", "Bin", i,
+                  "stat_err =", stat_err, "syst_err =", syst_err,
+                  "total_err =", total_err);
+        total_mc_hist_->SetBinError(i, total_err);
+      }
+
+      total_mc_hist_->SetFillColor(kBlack);
+      total_mc_hist_->SetFillStyle(3004);
+      total_mc_hist_->SetMarkerSize(0);
+      total_mc_hist_->SetLineColor(kBlack);
+      total_mc_hist_->SetLineWidth(1);
+      total_mc_hist_->Draw("E2 SAME");
+      total_mc_hist_->Draw("E1 SAME");
+    }
+
+    return max_y;
+  }
+
+  void renderCuts(double max_y) {
+    for (const auto &cut : cuts_) {
+      double y_arrow_pos = max_y * 0.85;
+      double x_range =
+          mc_stack_->GetXaxis()->GetXmax() - mc_stack_->GetXaxis()->GetXmin();
+      double arrow_length = x_range * 0.04;
+
+      TLine *line = new TLine(cut.threshold, 0, cut.threshold, max_y * 1.3);
+      line->SetLineColor(kRed);
+      line->SetLineWidth(2);
+      line->SetLineStyle(kDashed);
+      line->Draw("same");
+      cut_visuals_.push_back(line);
+
+      double x_start;
+      double x_end;
+      if (cut.direction == CutDirection::GreaterThan) {
+        x_start = cut.threshold;
+        x_end = cut.threshold + arrow_length;
+      } else {
+        x_start = cut.threshold;
+        x_end = cut.threshold - arrow_length;
+      }
+      TArrow *arrow =
+          new TArrow(x_start, y_arrow_pos, x_end, y_arrow_pos, 0.025, ">");
+      arrow->SetLineColor(kRed);
+      arrow->SetFillColor(kRed);
+      arrow->SetLineWidth(2);
+      arrow->Draw("same");
+      cut_visuals_.push_back(arrow);
+    }
+  }
+
+  void configureAxes(double left_edge, double right_edge) {
+    TH1 *frame = mc_stack_->GetHistogram();
+    frame->GetXaxis()->SetTitle(
+        variable_result_.binning_.getTexLabel().c_str());
+    frame->GetYaxis()->SetTitle(y_axis_label_.c_str());
+    frame->GetXaxis()->SetTitleOffset(1.0);
+    frame->GetYaxis()->SetTitleOffset(1.0);
+    frame->GetXaxis()->SetLimits(left_edge, right_edge);
+    frame->GetXaxis()->SetNdivisions(520);
+    frame->GetXaxis()->SetTickLength(0.02);
+  }
+
+  void drawWatermark(TPad *pad, double total_mc_events) const {
+    pad->cd();
+
+    std::string line1 = "#bf{#muBooNE Simulation, Preliminary}";
+
+    std::stringstream pot_stream;
+    pot_stream << std::scientific << std::setprecision(2)
+               << region_analysis_.protonsOnTarget();
+    std::string pot_str = pot_stream.str();
+    size_t e_pos = pot_str.find('e');
+    if (e_pos != std::string::npos) {
+      int exponent = std::stoi(pot_str.substr(e_pos + 1));
+      pot_str = pot_str.substr(0, e_pos);
+      pot_str += " #times 10^{" + std::to_string(exponent) + "}";
+    }
+
+    std::map<std::string, std::string> beam_map = {{"numi_fhc", "NuMI FHC"},
+                                                   {"numi_rhc", "NuMI RHC"}};
+
+    std::string beam_name = region_analysis_.beamConfig();
+    if (beam_map.count(beam_name)) {
+      beam_name = beam_map.at(beam_name);
+    }
+
+    std::string runs_str;
+    if (!region_analysis_.runNumbers().empty()) {
+      for (size_t i = 0; i < region_analysis_.runNumbers().size(); ++i) {
+        std::string run_label = region_analysis_.runNumbers()[i];
+        if (run_label.rfind("run", 0) == 0) {
+          run_label = run_label.substr(3);
         }
-
-        std::map<std::string, std::string> beam_map = {
-            {"numi_fhc", "NuMI FHC"}, {"numi_rhc", "NuMI RHC"}};
-
-        std::string beam_name = region_analysis_.beamConfig();
-        if (beam_map.count(beam_name)) {
-            beam_name = beam_map.at(beam_name);
+        try {
+          run_label = this->formatWithCommas(std::stod(run_label), 0);
+        } catch (...) {
         }
-
-        std::string runs_str;
-        if (!region_analysis_.runNumbers().empty()) {
-            for (size_t i = 0; i < region_analysis_.runNumbers().size(); ++i) {
-                std::string run_label = region_analysis_.runNumbers()[i];
-                if (run_label.rfind("run", 0) == 0) {
-                    run_label = run_label.substr(3);
-                }
-                try {
-                    run_label = this->formatWithCommas(std::stod(run_label), 0);
-                } catch (...) {
-                }
-                runs_str +=
-                    run_label +
+        runs_str += run_label +
                     (i < region_analysis_.runNumbers().size() - 1 ? ", " : "");
-            }
-        } else {
-            runs_str = "N/A";
-        }
-
-        std::string line2 = "Beam: " + beam_name + ", Runs: " + runs_str;
-        std::string line3 = "POT: " + pot_str;
-        std::string line4 =
-            "#it{Analysis Region}: " + region_analysis_.regionLabel();
-        std::string line5 =
-            "#it{Total Entries}: " + this->formatWithCommas(total_mc_events, 2);
-
-        TLatex watermark;
-        watermark.SetNDC();
-        watermark.SetTextAlign(33);
-        watermark.SetTextFont(62);
-        watermark.SetTextSize(0.05);
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.03, line1.c_str());
-        watermark.SetTextFont(42);
-        watermark.SetTextSize(0.05 * 0.8);
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.09, line2.c_str());
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.15, line3.c_str());
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.21, line4.c_str());
-        watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
-                            1 - pad->GetTopMargin() - 0.27, line5.c_str());
+      }
+    } else {
+      runs_str = "N/A";
     }
 
-  protected:
-    void draw(TCanvas &canvas) override {
-        log::info("StackedHistogramPlot::draw", "X-axis label from result:",
-                  variable_result_.binning_.getTexLabel().c_str());
+    std::string line2 = "Beam: " + beam_name + ", Runs: " + runs_str;
+    std::string line3 = "POT: " + pot_str;
+    std::string line4 =
+        "#it{Analysis Region}: " + region_analysis_.regionLabel();
+    std::string line5 =
+        "#it{Total Entries}: " + this->formatWithCommas(total_mc_events, 2);
 
-        TPad *p_main;
-        TPad *p_legend;
-        this->setupPads(canvas, p_main, p_legend);
+    TLatex watermark;
+    watermark.SetNDC();
+    watermark.SetTextAlign(33);
+    watermark.SetTextFont(62);
+    watermark.SetTextSize(0.05);
+    watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
+                        1 - pad->GetTopMargin() - 0.03, line1.c_str());
+    watermark.SetTextFont(42);
+    watermark.SetTextSize(0.05 * 0.8);
+    watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
+                        1 - pad->GetTopMargin() - 0.09, line2.c_str());
+    watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
+                        1 - pad->GetTopMargin() - 0.15, line3.c_str());
+    watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
+                        1 - pad->GetTopMargin() - 0.21, line4.c_str());
+    watermark.DrawLatex(1 - pad->GetRightMargin() - 0.03,
+                        1 - pad->GetTopMargin() - 0.27, line5.c_str());
+  }
 
-        std::vector<std::pair<ChannelKey, BinnedHistogram>> mc_hists;
-        double total_mc_events;
-        double left_edge;
-        double right_edge;
-        std::vector<double> orig_edges =
-            this->prepareHistograms(mc_hists, total_mc_events, left_edge, right_edge);
+protected:
+  void draw(TCanvas &canvas) override {
+    log::info("StackedHistogramPlot::draw", "X-axis label from result:",
+              variable_result_.binning_.getTexLabel().c_str());
 
-        this->buildLegend(p_legend, mc_hists);
+    TPad *p_main;
+    TPad *p_legend;
+    this->setupPads(canvas, p_main, p_legend);
 
-        double max_y = this->drawStack(p_main, mc_hists, orig_edges);
+    std::vector<std::pair<ChannelKey, BinnedHistogram>> mc_hists;
+    double total_mc_events;
+    double left_edge;
+    double right_edge;
+    std::vector<double> orig_edges = this->prepareHistograms(
+        mc_hists, total_mc_events, left_edge, right_edge);
 
-        this->renderCuts(max_y);
+    signal_hist_ = this->buildSignalHistogram(mc_hists, orig_edges);
 
-        this->configureAxes(left_edge, right_edge);
+    this->buildLegend(p_legend, mc_hists, signal_hist_);
 
-        this->drawWatermark(p_main, total_mc_events);
+    double max_y = this->drawStack(p_main, mc_hists, orig_edges);
 
-        p_main->RedrawAxis();
-        canvas.Update();
-    }
+    if (signal_hist_)
+      signal_hist_->Draw("HIST SAME");
 
-  private:
-    const VariableResult &variable_result_;
-    const RegionAnalysis &region_analysis_;
-    std::string category_column_;
-    bool overlay_signal_;
-    std::vector<Cut> cuts_;
-    bool annotate_numbers_;
-    bool use_log_y_;
-    std::string y_axis_label_;
-    bool use_uniform_binning_;
-    int uniform_bins_;
-    double uniform_min_;
-    double uniform_max_;
-    TH1D *total_mc_hist_ = nullptr;
-    THStack *mc_stack_ = nullptr;
-    TLegend *legend_ = nullptr;
-    std::vector<TObject *> cut_visuals_;
+    this->renderCuts(max_y);
+
+    this->configureAxes(left_edge, right_edge);
+
+    this->drawWatermark(p_main, total_mc_events);
+
+    p_main->RedrawAxis();
+    canvas.Update();
+  }
+
+private:
+  const VariableResult &variable_result_;
+  const RegionAnalysis &region_analysis_;
+  std::string category_column_;
+  bool overlay_signal_;
+  std::vector<Cut> cuts_;
+  bool annotate_numbers_;
+  bool use_log_y_;
+  std::string y_axis_label_;
+  bool use_uniform_binning_;
+  int uniform_bins_;
+  double uniform_min_;
+  double uniform_max_;
+  TH1D *total_mc_hist_ = nullptr;
+  THStack *mc_stack_ = nullptr;
+  TLegend *legend_ = nullptr;
+  TH1D *signal_hist_ = nullptr;
+  std::vector<TObject *> cut_visuals_;
 };
 
-}
+} // namespace analysis
 
 #endif


### PR DESCRIPTION
## Summary
- overlay signal categories as dashed green line on stacked histograms
- declare signal groups for `channel_definitions` stratifier

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bf37e4b9ac832e916180deceddc5b3