### PR TITLE
Add cut flow plot preset and runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,3 +107,27 @@ target_link_libraries(event_display_runner
         dl
 )
 
+add_executable(cut_flow_plot_runner
+    ana/cut_flow_plot_runner.cpp
+    ana/presets/Presets_Standard.cpp
+    ana/presets/Presets_Vertices.cpp
+    ana/presets/Presets_Plots.cpp
+    ana/presets/Presets_Preselections.cpp
+)
+target_link_libraries(cut_flow_plot_runner
+    PRIVATE
+        libapp
+        libplug
+        libdata
+        libhist
+        libplot
+        libsyst
+        libutils
+        Eigen3::Eigen
+        nlohmann_json::nlohmann_json
+        ${ROOT_LIBRARIES}
+        TBB::tbb
+        TMVA
+        dl
+)
+

--- a/ana/cut_flow_plot_runner.cpp
+++ b/ana/cut_flow_plot_runner.cpp
@@ -1,0 +1,36 @@
+#include "PipelineBuilder.h"
+#include "PipelineRunner.h"
+#include <string>
+
+int main() {
+  using namespace analysis;
+
+  AnalysisPluginHost analysis_host;
+  PlotPluginHost plot_host;
+  PipelineBuilder builder(analysis_host, plot_host);
+
+  // Configure analysis region and at least one variable to satisfy pipeline requirements.
+  builder.preset("QUALITY_NUMU_CC");
+  builder.variable("TRUE_NEUTRINO_VERTEX",
+                   {{"analysis_configs", {{"region", "QUALITY_NUMU_CC"}}}});
+
+  // Generate a cut flow plot for the combined selection.
+  builder.preset("CUT_FLOW_PLOT",
+                 {{"plot_configs",
+                   {{"selection_rule", "QUALITY_NUMU_CC"},
+                    {"region", "QUALITY_NUMU_CC"},
+                    {"signal_group", "inclusive_strange_channels"},
+                    {"channel_column", "channel_definitions"},
+                    {"initial_label", "All events"},
+                    {"plot_name", "quality_numu_cc_cut_flow"}}}});
+
+  auto analysis_specs = builder.analysisSpecs();
+  auto plot_specs = builder.plotSpecs();
+
+  PipelineRunner runner(analysis_specs, plot_specs);
+  runner.run(std::string{"config/samples.json"},
+             std::string{"/tmp/cut_flow.root"});
+
+  return 0;
+}
+

--- a/ana/presets/Presets_Plots.cpp
+++ b/ana/presets/Presets_Plots.cpp
@@ -72,3 +72,29 @@ ANALYSIS_REGISTER_PRESET(SIGNAL_EVENT_DISPLAY, Target::Plot,
   })
 )
 
+// Preset to configure the CutFlow plot plugin with a single cut flow request.
+// Defaults target the inclusive strange channel scheme and write output to a
+// dedicated directory.
+ANALYSIS_REGISTER_PRESET(CUT_FLOW_PLOT, Target::Plot,
+  ([](const PluginArgs& vars) -> PluginSpecList {
+    auto cfg = vars.plot_configs;
+    nlohmann::json plot = {
+      {"selection_rule", cfg.value("selection_rule", std::string{})},
+      {"region", cfg.value("region", std::string{})},
+      {"signal_group",
+       cfg.value("signal_group", std::string{"inclusive_strange_channels"})},
+      {"channel_column",
+       cfg.value("channel_column", std::string{"channel_definitions"})},
+      {"initial_label", cfg.value("initial_label", std::string{"All events"})},
+      {"plot_name", cfg.value("plot_name", std::string{"cut_flow"})},
+      {"output_directory",
+       cfg.value("output_directory", std::string{"./plots/cut_flow"})},
+      {"log_y", cfg.value("log_y", false)},
+      {"clauses", cfg.value("clauses", nlohmann::json::array())}
+    };
+    PluginArgs args{{"plot_configs",
+                     {{"plots", nlohmann::json::array({plot})}}}};
+    return {{"CutFlowPlotPlugin", args}};
+  })
+)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,12 @@ add_executable(test_event_display_preset
 target_link_libraries(test_event_display_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
 catch_discover_tests(test_event_display_preset)
 
+add_executable(test_cut_flow_preset
+  test_cut_flow_preset.cpp
+  ${CMAKE_SOURCE_DIR}/ana/presets/Presets_Plots.cpp)
+target_link_libraries(test_cut_flow_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
+catch_discover_tests(test_cut_flow_preset)
+
 add_executable(test_pipeline_builder
   test_pipeline_builder.cpp
   ${CMAKE_SOURCE_DIR}/ana/presets/Presets_Standard.cpp

--- a/tests/test_cut_flow_preset.cpp
+++ b/tests/test_cut_flow_preset.cpp
@@ -1,0 +1,36 @@
+#include "PresetRegistry.h"
+#include <catch2/catch_test_macros.hpp>
+
+using namespace analysis;
+
+TEST_CASE("cut_flow_preset_generates_plugin_spec") {
+    PluginArgs vars{{"plot_configs",
+                     {{"selection_rule", "SEL"},
+                      {"region", "R"},
+                      {"signal_group", "inclusive_strange_channels"},
+                      {"channel_column", "channel_definitions"},
+                      {"initial_label", "Start"},
+                      {"plot_name", "my_plot"}}}};
+    auto pr = PresetRegistry::instance().find("CUT_FLOW_PLOT");
+    REQUIRE(pr != nullptr);
+    auto list = pr->make(vars);
+    REQUIRE(list.size() == 1);
+    auto spec = list.front();
+    REQUIRE(spec.id == "CutFlowPlotPlugin");
+    REQUIRE(spec.args.plot_configs.contains("plots"));
+    auto plots = spec.args.plot_configs.at("plots");
+    REQUIRE(plots.is_array());
+    REQUIRE(plots.size() == 1);
+    auto cf = plots.at(0);
+    REQUIRE(cf.at("selection_rule") == "SEL");
+    REQUIRE(cf.at("region") == "R");
+    REQUIRE(cf.at("signal_group") == "inclusive_strange_channels");
+    REQUIRE(cf.at("channel_column") == "channel_definitions");
+    REQUIRE(cf.at("initial_label") == "Start");
+    REQUIRE(cf.at("plot_name") == "my_plot");
+    REQUIRE(cf.at("output_directory") == "./plots/cut_flow");
+    REQUIRE(cf.at("log_y") == false);
+    REQUIRE(cf.at("clauses").is_array());
+    REQUIRE(cf.at("clauses").empty());
+}
+


### PR DESCRIPTION
## Summary
- add `CUT_FLOW_PLOT` preset to wire up `CutFlowPlotPlugin`
- provide example `cut_flow_plot_runner` program for generating the plot
- include unit test ensuring preset produces correct plugin spec

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf40620d6c832e93aa923471574759