### PR TITLE
Fix macro invocation in preset registration

### DIFF
--- a/ana/presets/Presets_Preselections.cpp
+++ b/ana/presets/Presets_Preselections.cpp
@@ -6,57 +6,57 @@ using namespace analysis;
 
 // Preset defining basic variable preselections for quality checks.
 // Allows an optional `region` override via PluginArgs.
-ANALYSIS_REGISTER_PRESET(
-    PRESELECTION_VARIABLES, Target::Analysis,
-    [](const PluginArgs &vars) -> PluginSpecList {
-      std::string region =
-          vars.analysis_configs.value("region", std::string{"EMPTY"});
-      auto regions = PluginArgs::array({region});
+ANALYSIS_REGISTER_PRESET(PRESELECTION_VARIABLES, Target::Analysis,
+                         ([](const PluginArgs &vars) -> PluginSpecList {
+                           std::string region =
+                               vars.analysis_configs.value("region", std::string{"EMPTY"});
+                           auto regions = PluginArgs::array({region});
 
-      nlohmann::json var_defs = PluginArgs::array(
-          {{{"name", "topological_score"},
-            {"branch", "topological_score"},
-            {"label", "Topological score"},
-            {"stratum", "channel_definitions"},
-            {"regions", regions},
-            {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
-           {{"name", "neutrino_energy"},
-            {"branch", "neutrino_energy"},
-            {"label", "Neutrino energy [GeV]"},
-            {"stratum", "channel_definitions"},
-            {"regions", regions},
-            {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
-           {{"name", "optical_filter_pe_beam"},
-            {"branch", "optical_filter_pe_beam"},
-            {"label", "Optical filter beam PE"},
-            {"stratum", "channel_definitions"},
-            {"regions", regions},
-            {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
-           {{"name", "num_slices"},
-            {"branch", "num_slices"},
-            {"label", "Number of slices"},
-            {"stratum", "channel_definitions"},
-            {"regions", regions},
-            {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
-           {{"name", "software_trigger"},
-            {"branch", "software_trigger"},
-            {"label", "Software trigger"},
-            {"stratum", "channel_definitions"},
-            {"regions", regions},
-            {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
-           {{"name", "slice_cluster_fraction"},
-            {"branch", "slice_cluster_fraction"},
-            {"label", "Fraction of slice clustered"},
-            {"stratum", "channel_definitions"},
-            {"regions", regions},
-            {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
-           {{"name", "slice_contained_fraction"},
-            {"branch", "slice_contained_fraction"},
-            {"label", "Fraction of slice contained"},
-            {"stratum", "channel_definitions"},
-            {"regions", regions},
-            {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}}});
+                           nlohmann::json var_defs = PluginArgs::array(
+                               {{{"name", "topological_score"},
+                                 {"branch", "topological_score"},
+                                 {"label", "Topological score"},
+                                 {"stratum", "channel_definitions"},
+                                 {"regions", regions},
+                                 {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "neutrino_energy"},
+                                 {"branch", "neutrino_energy"},
+                                 {"label", "Neutrino energy [GeV]"},
+                                 {"stratum", "channel_definitions"},
+                                 {"regions", regions},
+                                 {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "optical_filter_pe_beam"},
+                                 {"branch", "optical_filter_pe_beam"},
+                                 {"label", "Optical filter beam PE"},
+                                 {"stratum", "channel_definitions"},
+                                 {"regions", regions},
+                                 {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "num_slices"},
+                                 {"branch", "num_slices"},
+                                 {"label", "Number of slices"},
+                                 {"stratum", "channel_definitions"},
+                                 {"regions", regions},
+                                 {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "software_trigger"},
+                                 {"branch", "software_trigger"},
+                                 {"label", "Software trigger"},
+                                 {"stratum", "channel_definitions"},
+                                 {"regions", regions},
+                                 {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "slice_cluster_fraction"},
+                                 {"branch", "slice_cluster_fraction"},
+                                 {"label", "Fraction of slice clustered"},
+                                 {"stratum", "channel_definitions"},
+                                 {"regions", regions},
+                                 {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
+                                {{"name", "slice_contained_fraction"},
+                                 {"branch", "slice_contained_fraction"},
+                                 {"label", "Fraction of slice contained"},
+                                 {"stratum", "channel_definitions"},
+                                 {"regions", regions},
+                                 {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}}});
 
-      PluginArgs args{{"analysis_configs", {{"variables", var_defs}}}};
-      return {{"VariablesPlugin", args}};
-    });
+                           PluginArgs args{{"analysis_configs",
+                                            {{"variables", var_defs}}}};
+                           return {{"VariablesPlugin", args}};
+                         }))


### PR DESCRIPTION
## Summary
- wrap lambda argument to `ANALYSIS_REGISTER_PRESET` in parentheses
- remove trailing semicolon to match existing preset macros

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4762e250832eb28dafa4fc2f3503