### PR TITLE
Wrap lambda with parentheses in preset registration

### DIFF
--- a/ana/presets/Presets_Preselections.cpp
+++ b/ana/presets/Presets_Preselections.cpp
@@ -8,7 +8,7 @@ using namespace analysis;
 // Allows an optional `region` override via PluginArgs.
 ANALYSIS_REGISTER_PRESET(
     PRESELECTION_VARIABLES, Target::Analysis,
-    [](const PluginArgs &vars) -> PluginSpecList {
+    ([](const PluginArgs &vars) -> PluginSpecList {
       std::string region =
           vars.analysis_configs.value("region", std::string{"EMPTY"});
       auto regions = PluginArgs::array({region});
@@ -59,4 +59,4 @@ ANALYSIS_REGISTER_PRESET(
 
       PluginArgs args{{"analysis_configs", {{"variables", var_defs}}}};
       return {{"VariablesPlugin", args}};
-    });
+    }));


### PR DESCRIPTION
## Summary
- fix Presets_Preselections registration by wrapping lambda in parentheses so commas inside body don't break macro arguments

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4774a008832eacdb7e9c9154b482