### PR TITLE
Fix TH1D usage in DynamicBinning

### DIFF
--- a/libhist/DynamicBinning.h
+++ b/libhist/DynamicBinning.h
@@ -121,7 +121,7 @@ private:
       nbins = std::max(1, static_cast<int>(std::ceil((xmax - xmin) / bin_resolution)));
     }
 
-    ROOT::TH1D hist("dynamic_binning_tmp", "", nbins, xmin, xmax);
+    TH1D hist("dynamic_binning_tmp", "", nbins, xmin, xmax);
     hist.Sumw2();
 
     for (auto &n : nodes) {


### PR DESCRIPTION
## Summary
- fix DynamicBinning histogram construction by using global TH1D class instead of ROOT namespace

## Testing
- `cmake ..` *(fails: Could not find package ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4e531788832e846a502db1df68f0