### PR TITLE
Reserve capacity for cumulative cut filters

### DIFF
--- a/libapp/CutFlowCalculator.h
+++ b/libapp/CutFlowCalculator.h
@@ -57,7 +57,10 @@ public:
 
   static std::vector<std::string>
   buildCumulativeFilters(const std::vector<std::string> &clauses) {
-    std::vector<std::string> filters{""};
+    const auto expected_size = clauses.size() + 1;
+    std::vector<std::string> filters;
+    filters.reserve(expected_size);
+    filters.emplace_back("");
     std::string current;
 
     for (const auto &clause : clauses) {


### PR DESCRIPTION
## Summary
- Pre-reserve space in `buildCumulativeFilters` to avoid reallocations when generating cumulative filters

## Testing
- `pytest tests/test_sample_processing.py` *(skipped: numpy or uproot not installed)*
- `cmake -S . -B build` *(failed: could not find ROOT package)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf56505ff8832e976bf49f9165959f