### PR TITLE
Reserve processor storage before populating

### DIFF
--- a/libdata/AnalysisDataLoader.h
+++ b/libdata/AnalysisDataLoader.h
@@ -123,6 +123,8 @@ class AnalysisDataLoader {
     }
 
     void processRunConfig(const RunConfig &rc) {
+        processors_.reserve(processors_.size() + rc.samples.size());
+        // SampleFrameMap is a std::map, which does not support reserve.
         for (auto &sample_json : rc.samples) {
             if (sample_json.contains("active") && !sample_json.at("active").get<bool>()) {
                 log::info("AnalysisDataLoader::processRunConfig",


### PR DESCRIPTION
## Summary
- Reserve space in `processors_` before iterating over run configuration samples to avoid repeated reallocations
- Document that `SampleFrameMap` (std::map) cannot be reserved

## Testing
- `cmake -S . -B build` *(fails: could not find ROOT)*
- `cd build && ctest --output-on-failure` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf565a3a60832ea47245accda4a1e1