### PR TITLE
Preallocate histogram counts

### DIFF
--- a/libhist/BinnedHistogram.h
+++ b/libhist/BinnedHistogram.h
@@ -36,11 +36,11 @@ class BinnedHistogram : public TNamed, private TH1DRenderer {
     static BinnedHistogram createFromTH1D(const BinningDefinition &bn, const TH1D &hist,
                                           TString nm = "hist", TString ti = "", Color_t cl = kBlack,
                                           int ht = 0, TString tx = "") {
-        std::vector<double> counts;
         int n = hist.GetNbinsX();
+        std::vector<double> counts(n);
         Eigen::VectorXd sh_vec = Eigen::VectorXd::Zero(n);
         for (int i = 1; i <= n; ++i) {
-            counts.push_back(hist.GetBinContent(i));
+            counts[i - 1] = hist.GetBinContent(i);
             sh_vec(i - 1) = hist.GetBinError(i);
         }
 


### PR DESCRIPTION
## Summary
- preallocate histogram bin counts when converting from `TH1D`

## Testing
- `source .container.sh` *(fails: /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh: No such file or directory)*
- `source .setup.sh` *(fails: /cvmfs/uboone.opensciencegrid.org/products/setup_uboone_mcc9.sh: No such file or directory)*
- `source .build.sh` *(fails: CMake Error at CMakeLists.txt:10 (find_package): By not providing "FindROOT.cmake" ...)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf564e5eb0832e9b2cc75fe371db5d