### PR TITLE
Use ccache for faster rebuilds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.10)
 project(RareXSec LANGUAGES CXX)
 
+# Use ccache for faster rebuilds when available
+find_program(CCACHE_PROGRAM ccache)
+if (CCACHE_PROGRAM)
+    message(STATUS "Found ccache: ${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+endif()
+
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ source .container.sh
 source .setup.sh
 source .build.sh
 ```
+If [ccache](https://ccache.dev/) is available on your system it will be used
+automatically to cache compilation results, speeding up subsequent builds.
 
 ## Configuration
 ```bash


### PR DESCRIPTION
## Summary
- Detect and use ccache via CMake to speed up subsequent builds
- Document ccache usage in the build instructions

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bf590d34d4832e86d5f1b945ba683e