### PR TITLE
Fix autodomain binning edge truncation

### DIFF
--- a/libhist/DynamicBinning.h
+++ b/libhist/DynamicBinning.h
@@ -595,15 +595,7 @@ private:
     log::info("DynamicBinning::finaliseEdges",
               "In-range entries:", in_range.size());
 
-    if (!in_range.empty()) {
-      auto mm = std::minmax_element(
-          in_range.begin(), in_range.end(),
-          [](const auto &a, const auto &b) { return a.first < b.first; });
-      if (!std::isfinite(domain_edges.front()))
-        domain_min = mm.first->first;
-      if (!std::isfinite(domain_edges.back()))
-        domain_max = mm.second->first;
-    } else {
+    if (in_range.empty()) {
       if (!std::isfinite(domain_edges.front()))
         domain_min = 0.0;
       if (!std::isfinite(domain_edges.back()))


### PR DESCRIPTION
## Summary
- ensure autodomain binning uses true data range rather than histogram bin centers

## Testing
- `cmake -S . -B build` *(fails: ROOTConfig.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf598228e0832ea3a1cac1612112f0