### PR TITLE
Add test preset for topological score variable

### DIFF
--- a/ana/presets/Presets_Preselections.cpp
+++ b/ana/presets/Presets_Preselections.cpp
@@ -14,13 +14,7 @@ ANALYSIS_REGISTER_PRESET(
       auto regions = PluginArgs::array({region});
 
       nlohmann::json var_defs = PluginArgs::array(
-          {{{"name", "topological_score"},
-            {"branch", "topological_score"},
-            {"label", "Topological score"},
-            {"stratum", "channel_definitions"},
-            {"regions", regions},
-            {"bins", {{"mode", "dynamic"}, {"strategy", "bayesian_blocks"}}}},
-           {{"name", "neutrino_energy"},
+          {{{"name", "neutrino_energy"},
             {"branch", "neutrino_energy"},
             {"label", "Neutrino energy [GeV]"},
             {"stratum", "channel_definitions"},

--- a/ana/presets/Presets_TopologicalScore.cpp
+++ b/ana/presets/Presets_TopologicalScore.cpp
@@ -1,0 +1,26 @@
+#include "PluginSpec.h"
+#include "PresetRegistry.h"
+#include <nlohmann/json.hpp>
+
+using namespace analysis;
+
+// Preset defining only the topological score variable with fixed bins for
+// testing.
+ANALYSIS_REGISTER_PRESET(
+    TEST_TOPOLOGICAL_SCORE, Target::Analysis,
+    ([](const PluginArgs &vars) -> PluginSpecList {
+      std::string region =
+          vars.analysis_configs.value("region", std::string{"EMPTY"});
+      auto regions = PluginArgs::array({region});
+
+      nlohmann::json var_defs = PluginArgs::array(
+          {{{"name", "topological_score"},
+            {"branch", "topological_score"},
+            {"label", "Topological score"},
+            {"stratum", "channel_definitions"},
+            {"regions", regions},
+            {"bins", {{"n", 10}, {"min", 0.0}, {"max", 1.0}}}}});
+
+      PluginArgs args{{"analysis_configs", {{"variables", var_defs}}}};
+      return {{"VariablesPlugin", args}};
+    }));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,3 +36,9 @@ add_executable(test_pipeline_builder
   ${CMAKE_SOURCE_DIR}/ana/presets/Presets_Vertices.cpp)
 target_link_libraries(test_pipeline_builder PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain nlohmann_json::nlohmann_json ${ROOT_LIBRARIES} TBB::tbb ${CMAKE_DL_LIBS})
 catch_discover_tests(test_pipeline_builder)
+
+add_executable(test_topological_score_preset
+  test_topological_score_preset.cpp
+  ${CMAKE_SOURCE_DIR}/ana/presets/Presets_TopologicalScore.cpp)
+target_link_libraries(test_topological_score_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
+catch_discover_tests(test_topological_score_preset)

--- a/tests/test_topological_score_preset.cpp
+++ b/tests/test_topological_score_preset.cpp
@@ -1,0 +1,23 @@
+#include "PresetRegistry.h"
+#include <catch2/catch_test_macros.hpp>
+
+using namespace analysis;
+
+TEST_CASE("topological_score_preset_generates_variable_spec") {
+  auto pr = PresetRegistry::instance().find("TEST_TOPOLOGICAL_SCORE");
+  REQUIRE(pr != nullptr);
+  auto list = pr->make({});
+  REQUIRE(list.size() == 1);
+  auto spec = list.front();
+  REQUIRE(spec.id == "VariablesPlugin");
+  REQUIRE(spec.args.analysis_configs.contains("variables"));
+  auto vars = spec.args.analysis_configs.at("variables");
+  REQUIRE(vars.is_array());
+  REQUIRE(vars.size() == 1);
+  auto var = vars.at(0);
+  REQUIRE(var.at("name") == "topological_score");
+  auto bins = var.at("bins");
+  REQUIRE(bins.at("n") == 10);
+  REQUIRE(bins.at("min") == 0.0);
+  REQUIRE(bins.at("max") == 1.0);
+}


### PR DESCRIPTION
## Summary
- Remove `topological_score` from general preselection variables
- Introduce `TEST_TOPOLOGICAL_SCORE` preset with fixed 0-1 bins for the score
- Add unit test verifying the preset and register it in CMake

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bf5a082f0c832ea08c85b70187533c