### PR TITLE
Include topological score preset in pipeline runner build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(analyse STATIC
     ana/presets/Presets_Vertices.cpp
     ana/presets/Presets_Plots.cpp
     ana/presets/Presets_Preselections.cpp
+    ana/presets/Presets_TopologicalScore.cpp
 )
 target_link_libraries(analyse
     PUBLIC
@@ -72,6 +73,7 @@ add_executable(pipeline_runner_example
     ana/presets/Presets_Vertices.cpp
     ana/presets/Presets_Plots.cpp
     ana/presets/Presets_Preselections.cpp
+    ana/presets/Presets_TopologicalScore.cpp
 )
 target_link_libraries(pipeline_runner_example
     PRIVATE


### PR DESCRIPTION
## Summary
- Include `Presets_TopologicalScore.cpp` in the default analysis library
- Add the topological score preset to the pipeline runner example build

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOT package)*
- `apt-get update` *(fails: 403 Forbidden when accessing repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5caf9cb4832e98ab23e4aadd40bb