### PR TITLE
Add debug logs to cutflow processing

### DIFF
--- a/libapp/CutFlowCalculator.h
+++ b/libapp/CutFlowCalculator.h
@@ -45,8 +45,13 @@ public:
       }
     }
 
+    log::debug("CutFlowCalculator::compute", "Processing", sample_frames.size(),
+               "sample frames");
     for (auto &[skey, sample_def] : sample_frames) {
+      log::debug("CutFlowCalculator::compute", "Examining sample", skey.str());
       if (!sample_def.isMc()) {
+        log::debug("CutFlowCalculator::compute", skey.str(),
+                   "is not MC - skipping");
         continue;
       }
 
@@ -55,6 +60,7 @@ public:
 
       calculateWeightsPerStage(base_df, cumulative_filters, stage_counts,
                                schemes, scheme_keys, scheme_filters);
+      log::debug("CutFlowCalculator::compute", "Completed sample", skey.str());
     }
 
     region_analysis.setCutFlow(std::move(stage_counts));
@@ -89,7 +95,9 @@ private:
           &scheme_filters,
       RegionAnalysis::StageCount &stage_count) {
     for (const auto &scheme : schemes) {
+      log::debug("CutFlowCalculator::updateSchemeTallies", "Scheme", scheme);
       for (int key : scheme_keys.at(scheme)) {
+        log::debug("CutFlowCalculator::updateSchemeTallies", "  Key", key);
         auto ch_df = df.Filter(scheme_filters.at(scheme).at(key));
 
         auto ch_w = ch_df.Sum<double>("nominal_event_weight");
@@ -112,6 +120,8 @@ private:
           &scheme_filters) {
     for (size_t i = 0; i < cumulative_filters.size(); ++i) {
       auto df = base_df;
+      log::debug("CutFlowCalculator::calculateWeightsPerStage", "Stage", i,
+                 "Filter", cumulative_filters[i]);
 
       if (!cumulative_filters[i].empty()) {
         df = df.Filter(cumulative_filters[i]);
@@ -122,6 +132,8 @@ private:
 
       stage_counts[i].total += tot_w.GetValue();
       stage_counts[i].total_w2 += tot_w2.GetValue();
+      log::debug("CutFlowCalculator::calculateWeightsPerStage", "Stage", i,
+                 "Totals", stage_counts[i].total, stage_counts[i].total_w2);
 
       updateSchemeTallies(df, schemes, scheme_keys, scheme_filters,
                           stage_counts[i]);


### PR DESCRIPTION
## Summary
- add debug messages in CutFlowCalculator::compute to trace sample frame handling
- log stage filters and totals in calculateWeightsPerStage
- log scheme/key processing in updateSchemeTallies

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "ROOT")*
- `python -m pytest tests/test_sample_processing.py` *(skipped: 1 test skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5da7cf54832e8f2977888aee096c