### PR TITLE
Use integer stratum keys

### DIFF
--- a/libapp/CutFlowCalculator.h
+++ b/libapp/CutFlowCalculator.h
@@ -37,8 +37,7 @@ public:
         scheme_filters;
 
     for (const auto &scheme : schemes) {
-      for (const auto &key : strat_reg.getAllStratumKeysForScheme(scheme)) {
-        int int_key = std::stoi(key.str());
+      for (int int_key : strat_reg.getAllStratumIntKeysForScheme(scheme)) {
         scheme_keys[scheme].push_back(int_key);
         scheme_filters[scheme][int_key] =
             scheme + " == " + std::to_string(int_key);

--- a/libhist/StratifierRegistry.h
+++ b/libhist/StratifierRegistry.h
@@ -110,16 +110,27 @@ public:
     return it->second;
   }
 
-  std::vector<StratumKey>
-  getAllStratumKeysForScheme(const std::string &scheme_name) const {
+  std::vector<int>
+  getAllStratumIntKeysForScheme(const std::string &scheme_name) const {
     auto scheme_it = scheme_definitions_.find(scheme_name);
     if (scheme_it == scheme_definitions_.end())
-      log::fatal("StratifierRegistry::getAllStratumKeysForScheme",
+      log::fatal("StratifierRegistry::getAllStratumIntKeysForScheme",
                  "Scheme not found: " + scheme_name);
 
-    std::vector<StratumKey> keys;
+    std::vector<int> keys;
     keys.reserve(scheme_it->second.strata.size());
     for (const auto &[key_int, _] : scheme_it->second.strata) {
+      keys.push_back(key_int);
+    }
+    return keys;
+  }
+
+  std::vector<StratumKey>
+  getAllStratumKeysForScheme(const std::string &scheme_name) const {
+    auto int_keys = getAllStratumIntKeysForScheme(scheme_name);
+    std::vector<StratumKey> keys;
+    keys.reserve(int_keys.size());
+    for (int key_int : int_keys) {
       keys.emplace_back(std::to_string(key_int));
     }
     return keys;


### PR DESCRIPTION
## Summary
- Add `getAllStratumIntKeysForScheme` to retrieve integer stratum keys directly
- Update cut flow computation to use integer keys without string conversions

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5eeb3c24832ea938e03142bed873