### PR TITLE
Parallelize MonteCarlo contribution loops

### DIFF
--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -5,6 +5,8 @@
 #include "BinnedHistogram.h"
 #include "ISampleProcessor.h"
 #include <unordered_map>
+#include <mutex>
+#include <tbb/parallel_for_each.h>
 
 namespace analysis {
 
@@ -29,21 +31,33 @@ class MonteCarloProcessor : public ISampleProcessor {
 
     void contributeTo(VariableResult &result) override {
         log::info("MonteCarloProcessor::contributeTo", "Contributing histograms from sample:", sample_key_.str());
-        for (auto &[stratum_key, future] : nominal_futures_) {
-            if (future.GetPtr()) {
-                auto hist = BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
-                ChannelKey channel_key{stratum_key.str()};
-                result.strat_hists_[channel_key] = result.strat_hists_[channel_key] + hist;
-                result.total_mc_hist_ = result.total_mc_hist_ + hist;
-            }
-        }
+        std::mutex mtx;
+        tbb::parallel_for_each(
+            nominal_futures_.begin(), nominal_futures_.end(),
+            [&, this](auto &entry) {
+                auto &[stratum_key, future] = entry;
+                if (future.GetPtr()) {
+                    auto hist =
+                        BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
+                    ChannelKey channel_key{stratum_key.str()};
+                    std::lock_guard<std::mutex> lock(mtx);
+                    result.strat_hists_[channel_key] =
+                        result.strat_hists_[channel_key] + hist;
+                    result.total_mc_hist_ = result.total_mc_hist_ + hist;
+                }
+            });
 
-        for (auto &[var_key, future] : variation_futures_) {
-            if (future.GetPtr()) {
-                result.raw_detvar_hists_[sample_key_][var_key] =
-                    BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
-            }
-        }
+        tbb::parallel_for_each(
+            variation_futures_.begin(), variation_futures_.end(),
+            [&, this](auto &entry) {
+                auto &[var_key, future] = entry;
+                if (future.GetPtr()) {
+                    auto hist =
+                        BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
+                    std::lock_guard<std::mutex> lock(mtx);
+                    result.raw_detvar_hists_[sample_key_][var_key] = hist;
+                }
+            });
     }
 
   private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,3 +42,7 @@ add_executable(test_topological_score_preset
   ${CMAKE_SOURCE_DIR}/ana/presets/Presets_TopologicalScore.cpp)
 target_link_libraries(test_topological_score_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
 catch_discover_tests(test_topological_score_preset)
+
+add_executable(test_monte_carlo_processor test_monte_carlo_processor.cpp)
+target_link_libraries(test_monte_carlo_processor PRIVATE libapp libhist libutils libsyst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES} TBB::tbb)
+catch_discover_tests(test_monte_carlo_processor)

--- a/tests/test_monte_carlo_processor.cpp
+++ b/tests/test_monte_carlo_processor.cpp
@@ -1,0 +1,51 @@
+#include "MonteCarloProcessor.h"
+#include "HistogramFactory.h"
+#include "VariableResult.h"
+#include "BinningDefinition.h"
+#include "SampleDataset.h"
+#include <catch2/catch_test_macros.hpp>
+#include <ROOT/RDataFrame.hxx>
+
+using namespace analysis;
+
+TEST_CASE("MonteCarloProcessor parallel contributeTo") {
+    std::vector<double> edges{0.0, 1.0, 2.0};
+    BinningDefinition binning(edges, "x", "x", {}, "inclusive_strange_channels");
+    auto model = binning.toTH1DModel();
+
+    std::vector<double> x{0.5, 1.5, 0.5, 1.5};
+    std::vector<int> channels{10, 10, 11, 11};
+
+    ROOT::RDataFrame df(x.size());
+    auto rnode = df.Define("x", [&x](ULong64_t i) { return x[i]; }, {"rdfentry_"})
+                    .Define("nominal_event_weight", [](ULong64_t) { return 1.0; }, {"rdfentry_"})
+                    .Define("inclusive_strange_channels", [&channels](ULong64_t i) { return channels[i]; }, {"rdfentry_"});
+
+    SampleDataset nominal{SampleOrigin::kMonteCarlo, AnalysisRole::kNominal, rnode};
+    SampleDataset var1{SampleOrigin::kMonteCarlo, AnalysisRole::kVariation, rnode};
+    SampleDataset var2{SampleOrigin::kMonteCarlo, AnalysisRole::kVariation, rnode};
+    std::unordered_map<SampleVariation, SampleDataset> variations{{SampleVariation::kSCE, var1}, {SampleVariation::kLYDown, var2}};
+    SampleDatasetGroup group{nominal, variations};
+
+    SampleKey sample_key{"s"};
+    MonteCarloProcessor proc(sample_key, group);
+
+    HistogramFactory factory;
+    proc.book(factory, binning, model);
+
+    VariableResult result;
+    result.binning_ = binning;
+    proc.contributeTo(result);
+
+    ChannelKey c10{StratumKey{"10"}.str()};
+    ChannelKey c11{StratumKey{"11"}.str()};
+    REQUIRE(result.strat_hists_[c10].getBinContent(0) == 1.0);
+    REQUIRE(result.strat_hists_[c10].getBinContent(1) == 1.0);
+    REQUIRE(result.strat_hists_[c11].getBinContent(0) == 1.0);
+    REQUIRE(result.strat_hists_[c11].getBinContent(1) == 1.0);
+    REQUIRE(result.total_mc_hist_.getBinContent(0) == 2.0);
+    REQUIRE(result.total_mc_hist_.getBinContent(1) == 2.0);
+    auto &var_hists = result.raw_detvar_hists_[sample_key];
+    REQUIRE(var_hists.at(SampleVariation::kSCE).getBinContent(0) == 2.0);
+    REQUIRE(var_hists.at(SampleVariation::kLYDown).getBinContent(0) == 2.0);
+}


### PR DESCRIPTION
## Summary
- Replace sequential histogram collection with `tbb::parallel_for_each` and mutex-protected updates
- Add unit test verifying MonteCarloProcessor parallel histogram contribution

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bf6385046c832ea6e40ce0828ac8d4