### PR TITLE
Add log-scale stacked histogram preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ builder.variable("RECO_NEUTRINO_VERTEX");
 builder.preset("STACKED_PLOTS");
 ```
 
+The `STACKED_PLOTS_LOG` preset offers the same configuration but uses a logarithmic y-axis.
+
 The resulting specification lists can be supplied directly to `AnalysisRunner`
 without writing intermediate JSON:
 

--- a/ana/presets/Presets_Plots.cpp
+++ b/ana/presets/Presets_Plots.cpp
@@ -14,6 +14,18 @@ ANALYSIS_REGISTER_PRESET(STACKED_PLOTS, Target::Plot,
   })
 )
 
+// Preset for stacked histogram plots with a logarithmic y-axis.
+ANALYSIS_REGISTER_PRESET(STACKED_PLOTS_LOG, Target::Plot,
+  ([](const PluginArgs&) -> PluginSpecList {
+    nlohmann::json plot = {
+      {"category_column", "channel_definitions"},
+      {"log_y", true}
+    };
+    PluginArgs args{{"plot_configs", {{"plots", nlohmann::json::array({plot})}}}};
+    return {{"StackedHistogramPlugin", args}};
+  })
+)
+
 // Preset to configure the EventDisplay plugin with a single display request.
 // Values are taken from the provided variables or fall back to sensible
 // defaults matching the plugin's own choices.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,12 @@ add_executable(test_cut_flow_preset
 target_link_libraries(test_cut_flow_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
 catch_discover_tests(test_cut_flow_preset)
 
+add_executable(test_stacked_log_preset
+  test_stacked_log_preset.cpp
+  ${CMAKE_SOURCE_DIR}/ana/presets/Presets_Plots.cpp)
+target_link_libraries(test_stacked_log_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
+catch_discover_tests(test_stacked_log_preset)
+
 add_executable(test_pipeline_builder
   test_pipeline_builder.cpp
   ${CMAKE_SOURCE_DIR}/ana/presets/Presets_Standard.cpp

--- a/tests/test_stacked_log_preset.cpp
+++ b/tests/test_stacked_log_preset.cpp
@@ -1,0 +1,20 @@
+#include "PresetRegistry.h"
+#include <catch2/catch_test_macros.hpp>
+
+using namespace analysis;
+
+TEST_CASE("stacked_log_preset_generates_plugin_spec") {
+    auto pr = PresetRegistry::instance().find("STACKED_PLOTS_LOG");
+    REQUIRE(pr != nullptr);
+    auto list = pr->make({});
+    REQUIRE(list.size() == 1);
+    auto spec = list.front();
+    REQUIRE(spec.id == "StackedHistogramPlugin");
+    REQUIRE(spec.args.plot_configs.contains("plots"));
+    auto plots = spec.args.plot_configs.at("plots");
+    REQUIRE(plots.is_array());
+    REQUIRE(plots.size() == 1);
+    auto plot = plots.at(0);
+    REQUIRE(plot.at("category_column") == "channel_definitions");
+    REQUIRE(plot.at("log_y") == true);
+}


### PR DESCRIPTION
## Summary
- Add `STACKED_PLOTS_LOG` preset for `StackedHistogramPlot` with a logarithmic y-axis
- Document new preset and include regression test
- Integrate test into CMake build

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*
- `apt-get update` *(fails: repository not signed)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf63ed8354832ea7a685b3f215a5fb