### PR TITLE
feat: expand topological score bins

### DIFF
--- a/ana/presets/Presets_TopologicalScore.cpp
+++ b/ana/presets/Presets_TopologicalScore.cpp
@@ -5,7 +5,7 @@
 using namespace analysis;
 
 // Preset defining only the topological score variable with fixed bins for
-// testing.
+// testing. Updated to use 100 bins across the 0 to 1 range.
 ANALYSIS_REGISTER_PRESET(
     TEST_TOPOLOGICAL_SCORE, Target::Analysis,
     ([](const PluginArgs &vars) -> PluginSpecList {
@@ -19,7 +19,8 @@ ANALYSIS_REGISTER_PRESET(
             {"label", "Topological score"},
             {"stratum", "channel_definitions"},
             {"regions", regions},
-            {"bins", {{"n", 10}, {"min", 0.0}, {"max", 1.0}}}}});
+            // Use 100 bins between 0 and 1.
+            {"bins", {{"n", 100}, {"min", 0.0}, {"max", 1.0}}}}});
 
       PluginArgs args{{"analysis_configs", {{"variables", var_defs}}}};
       return {{"VariablesPlugin", args}};

--- a/tests/test_topological_score_preset.cpp
+++ b/tests/test_topological_score_preset.cpp
@@ -17,7 +17,7 @@ TEST_CASE("topological_score_preset_generates_variable_spec") {
   auto var = vars.at(0);
   REQUIRE(var.at("name") == "topological_score");
   auto bins = var.at("bins");
-  REQUIRE(bins.at("n") == 10);
+  REQUIRE(bins.at("n") == 100);
   REQUIRE(bins.at("min") == 0.0);
   REQUIRE(bins.at("max") == 1.0);
 }


### PR DESCRIPTION
## Summary
- expand topological score preset to use 100 bins over 0-1 range
- adjust test to expect 100 bins

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bf640d5128832e912d3704e00ae90d