### PR TITLE
Fix x-axis ticks in StackedHistogramPlot

### DIFF
--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -328,7 +328,7 @@ class StackedHistogramPlot : public IHistogramPlot {
         frame->GetYaxis()->SetTitle(y_axis_label_.c_str());
         frame->GetXaxis()->SetTitleOffset(1.0);
         frame->GetYaxis()->SetTitleOffset(1.0);
-        frame->GetXaxis()->SetLimits(left_edge, right_edge);
+        frame->GetXaxis()->SetRangeUser(left_edge, right_edge);
         frame->GetXaxis()->SetNdivisions(520);
         frame->GetXaxis()->SetTickLength(0.02);
     }


### PR DESCRIPTION
## Summary
- use `SetRangeUser` for x-axis to avoid distorted tick marks when plotting histograms

## Testing
- `ctest --output-on-failure` *(no tests found)*
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bf648864d0832e894c8b7eea18d486