### PR TITLE
Fix AnalysisKey constructor overload ambiguity

### DIFF
--- a/libapp/AnalysisKey.h
+++ b/libapp/AnalysisKey.h
@@ -9,7 +9,9 @@ namespace analysis {
 template <class Tag> class AnalysisKey {
   public:
     AnalysisKey() = default;
-    explicit AnalysisKey(std::string v) : v_(std::move(v)) {}
+    explicit AnalysisKey(const char *v) : v_(v) {}
+    explicit AnalysisKey(const std::string &v) : v_(v) {}
+    explicit AnalysisKey(std::string &&v) : v_(std::move(v)) {}
     explicit AnalysisKey(std::string_view v) : v_(v) {}
     const std::string &str() const noexcept { return v_; }
     const char *c_str() const noexcept { return v_.c_str(); }


### PR DESCRIPTION
## Summary
- Add overloads for `AnalysisKey` to accept `const char*`, `const std::string&`, rvalue `std::string`, and `std::string_view`
- Prevent ambiguity when constructing keys from different string types

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bf66621340832ebd9bbf4da124594f