### PR TITLE
Avoid concurrent RDataFrame executions

### DIFF
--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -5,8 +5,6 @@
 #include "BinnedHistogram.h"
 #include "ISampleProcessor.h"
 #include <unordered_map>
-#include <mutex>
-#include <tbb/parallel_for_each.h>
 
 namespace analysis {
 
@@ -31,33 +29,26 @@ class MonteCarloProcessor : public ISampleProcessor {
 
     void contributeTo(VariableResult &result) override {
         log::info("MonteCarloProcessor::contributeTo", "Contributing histograms from sample:", sample_key_.str());
-        std::mutex mtx;
-        tbb::parallel_for_each(
-            nominal_futures_.begin(), nominal_futures_.end(),
-            [&, this](auto &entry) {
-                auto &[stratum_key, future] = entry;
-                if (future.GetPtr()) {
-                    auto hist =
-                        BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
-                    ChannelKey channel_key{stratum_key.str()};
-                    std::lock_guard<std::mutex> lock(mtx);
-                    result.strat_hists_[channel_key] =
-                        result.strat_hists_[channel_key] + hist;
-                    result.total_mc_hist_ = result.total_mc_hist_ + hist;
-                }
-            });
+        for (auto &entry : nominal_futures_) {
+            auto &[stratum_key, future] = entry;
+            if (future.GetPtr()) {
+                auto hist =
+                    BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
+                ChannelKey channel_key{stratum_key.str()};
+                result.strat_hists_[channel_key] =
+                    result.strat_hists_[channel_key] + hist;
+                result.total_mc_hist_ = result.total_mc_hist_ + hist;
+            }
+        }
 
-        tbb::parallel_for_each(
-            variation_futures_.begin(), variation_futures_.end(),
-            [&, this](auto &entry) {
-                auto &[var_key, future] = entry;
-                if (future.GetPtr()) {
-                    auto hist =
-                        BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
-                    std::lock_guard<std::mutex> lock(mtx);
-                    result.raw_detvar_hists_[sample_key_][var_key] = hist;
-                }
-            });
+        for (auto &entry : variation_futures_) {
+            auto &[var_key, future] = entry;
+            if (future.GetPtr()) {
+                auto hist =
+                    BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
+                result.raw_detvar_hists_[sample_key_][var_key] = hist;
+            }
+        }
     }
 
   private:

--- a/tests/test_monte_carlo_processor.cpp
+++ b/tests/test_monte_carlo_processor.cpp
@@ -8,7 +8,7 @@
 
 using namespace analysis;
 
-TEST_CASE("MonteCarloProcessor parallel contributeTo") {
+TEST_CASE("MonteCarloProcessor contributeTo") {
     std::vector<double> edges{0.0, 1.0, 2.0};
     BinningDefinition binning(edges, "x", "x", {}, "inclusive_strange_channels");
     auto model = binning.toTH1DModel();


### PR DESCRIPTION
## Summary
- Avoid running multiple RDataFrame event loops in parallel when contributing histograms
- Rename MonteCarloProcessor test to remove reference to parallel execution

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bf67cb31c8832ebe74b2aff1780c29