### PR TITLE
Add efficiency metrics to cut-flow summary

### DIFF
--- a/libapp/CutFlowCalculator.h
+++ b/libapp/CutFlowCalculator.h
@@ -168,12 +168,28 @@ private:
     std::cout << line << '\n';
 
     std::cout << std::fixed << std::setprecision(2);
-    std::cout << std::left << std::setw(30) << "Stage" << std::right
-              << std::setw(width - 30) << "Total MC Events" << '\n';
+    size_t stage_w = 30;
+    size_t total_w = 20;
+    size_t eff_w = 10;
+    std::cout << std::left << std::setw(stage_w) << "Stage" << std::right
+              << std::setw(total_w) << "Total MC"
+              << std::setw(eff_w) << "Cum Eff"
+              << std::setw(eff_w) << "Inc Eff" << '\n';
+
+    double initial_total = stage_counts.empty() ? 0.0 : stage_counts[0].total;
     for (size_t i = 0; i < stage_counts.size(); ++i) {
       std::string label = i == 0 ? "initial" : clauses[i - 1];
-      std::cout << std::left << std::setw(30) << label << std::right
-                << std::setw(width - 30) << stage_counts[i].total << '\n';
+      double cum_eff =
+          initial_total != 0.0 ? stage_counts[i].total / initial_total : 0.0;
+      double prev_total =
+          i == 0 ? stage_counts[0].total : stage_counts[i - 1].total;
+      double inc_eff =
+          prev_total != 0.0 ? stage_counts[i].total / prev_total : 0.0;
+
+      std::cout << std::left << std::setw(stage_w) << label << std::right
+                << std::setw(total_w) << stage_counts[i].total
+                << std::setw(eff_w) << cum_eff
+                << std::setw(eff_w) << inc_eff << '\n';
     }
 
     std::cout << sub << '\n';
@@ -185,8 +201,8 @@ private:
       for (const auto &[scheme, m] : final_stage.schemes) {
         std::cout << std::left << std::setw(width) << scheme << '\n';
         for (const auto &[key, pr] : m) {
-          std::cout << std::left << std::setw(30) << key << std::right
-                    << std::setw(width - 30) << pr.first << '\n';
+          std::cout << std::left << std::setw(stage_w) << key << std::right
+                    << std::setw(width - stage_w) << pr.first << '\n';
         }
       }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,11 @@ add_executable(test_cut_flow_preset
 target_link_libraries(test_cut_flow_preset PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
 catch_discover_tests(test_cut_flow_preset)
 
+add_executable(test_cut_flow_summary
+  test_cut_flow_summary.cpp)
+target_link_libraries(test_cut_flow_summary PRIVATE Catch2::Catch2WithMain)
+catch_discover_tests(test_cut_flow_summary)
+
 add_executable(test_stacked_log_preset
   test_stacked_log_preset.cpp
   ${CMAKE_SOURCE_DIR}/ana/presets/Presets_Plots.cpp)

--- a/tests/test_cut_flow_summary.cpp
+++ b/tests/test_cut_flow_summary.cpp
@@ -1,0 +1,58 @@
+#define private public
+#include "CutFlowCalculator.h"
+#undef private
+
+#include <catch2/catch_test_macros.hpp>
+#include <sstream>
+
+using namespace analysis;
+
+TEST_CASE("cut flow summary prints efficiencies") {
+    RegionKey rkey{"R"};
+    std::map<RegionKey, std::string> names;
+    std::map<RegionKey, SelectionQuery> sels;
+    std::map<RegionKey, std::unique_ptr<RegionAnalysis>> analyses;
+    std::map<RegionKey, std::vector<VariableKey>> vars;
+
+    RegionHandle rh(rkey, names, sels, analyses, vars);
+
+    std::vector<std::string> clauses{"cut1", "cut2"};
+    std::vector<RegionAnalysis::StageCount> counts(clauses.size() + 1);
+    counts[0].total = 100.0;
+    counts[1].total = 50.0;
+    counts[2].total = 25.0;
+
+    std::stringstream ss;
+    auto *old_buf = std::cout.rdbuf(ss.rdbuf());
+    CutFlowCalculator<int>::printSummary(rh, clauses, counts);
+    std::cout.rdbuf(old_buf);
+
+    std::string output = ss.str();
+    REQUIRE(output.find("Cum Eff") != std::string::npos);
+    REQUIRE(output.find("Inc Eff") != std::string::npos);
+
+    std::istringstream lines(output);
+    std::string line, cut1, cut2;
+    while (std::getline(lines, line)) {
+        if (line.find("cut1") != std::string::npos) { cut1 = line; }
+        if (line.find("cut2") != std::string::npos) { cut2 = line; }
+    }
+
+    auto parse = [](const std::string &l) {
+        std::istringstream iss(l);
+        std::string stage; double total{}, cum{}, inc{};
+        iss >> stage >> total >> cum >> inc;
+        return std::tuple<double,double,double>{total, cum, inc};
+    };
+
+    auto [tot1, cum1, inc1] = parse(cut1);
+    auto [tot2, cum2, inc2] = parse(cut2);
+
+    REQUIRE(tot1 == Approx(50.0));
+    REQUIRE(cum1 == Approx(0.5));
+    REQUIRE(inc1 == Approx(0.5));
+
+    REQUIRE(tot2 == Approx(25.0));
+    REQUIRE(cum2 == Approx(0.25));
+    REQUIRE(inc2 == Approx(0.5));
+}


### PR DESCRIPTION
## Summary
- Compute cumulative and incremental efficiencies for each cut-flow stage
- Display efficiencies alongside totals in cut-flow summary
- Add unit test for cut-flow summary output

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOTConfig.cmake)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6ae12f80832ea58e62e8d6588558