### PR TITLE
Remove legend header from stacked histograms

### DIFF
--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -195,27 +195,6 @@ class StackedHistogramPlot : public IHistogramPlot {
         }
 
         legend_->Draw();
-
-        TLatex header;
-        header.SetNDC();
-        header.SetTextFont(42);
-        header.SetTextAlign(13);
-        header.SetTextSize(0.05);
-
-        std::stringstream pot_stream;
-        pot_stream << std::scientific << std::setprecision(2)
-                   << region_analysis_.protonsOnTarget();
-        std::string pot_str = pot_stream.str();
-        size_t e_pos = pot_str.find('e');
-        if (e_pos != std::string::npos) {
-            int exponent = std::stoi(pot_str.substr(e_pos + 1));
-            pot_str = pot_str.substr(0, e_pos);
-            pot_str += " #times 10^{" + std::to_string(exponent) + "}";
-        }
-
-        std::string header_text = "Beam: " + beam_name + ", Runs: " + runs_str +
-                                  " [POT: " + pot_str + "]";
-        header.DrawLatex(0.12, 0.85, header_text.c_str());
     }
 
     double drawStack(


### PR DESCRIPTION
## Summary
- stop drawing beam/run POT header text on stacked histogram plots

## Testing
- `source .container.sh` *(fails: /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh: No such file or directory)*
- `source .setup.sh` *(fails: /cvmfs/uboone.opensciencegrid.org/products/setup_uboone_mcc9.sh: No such file or directory)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bf6e64b99c832eae15aff290d396b3