### PR TITLE
Reduce x-axis tick density in StackedHistogramPlot

### DIFF
--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -329,7 +329,7 @@ class StackedHistogramPlot : public IHistogramPlot {
         frame->GetXaxis()->SetTitleOffset(1.0);
         frame->GetYaxis()->SetTitleOffset(1.0);
         frame->GetXaxis()->SetRangeUser(left_edge, right_edge);
-        frame->GetXaxis()->SetNdivisions(520);
+        frame->GetXaxis()->SetNdivisions(510);
         frame->GetXaxis()->SetTickLength(0.02);
     }
 


### PR DESCRIPTION
## Summary
- Adjust x-axis tick divisions on stacked histograms to prevent overcrowding

## Testing
- `ctest` *(fails: No test configuration file found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf6f35e114832ea7fce62874367a2c