### PR TITLE
Use RResultPtr directly when collecting handles

### DIFF
--- a/libapp/DataProcessor.h
+++ b/libapp/DataProcessor.h
@@ -14,7 +14,7 @@ class DataProcessor : public ISampleProcessor {
     }
 
     void collectHandles(std::vector<ROOT::RDF::RResultHandle> &handles) override {
-        handles.emplace_back(data_future_.GetHandle());
+        handles.emplace_back(data_future_);
     }
 
     void contributeTo(VariableResult &result) override {

--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -33,10 +33,10 @@ class MonteCarloProcessor : public ISampleProcessor {
     void collectHandles(std::vector<ROOT::RDF::RResultHandle> &handles) override {
         handles.reserve(handles.size() + nominal_futures_.size() + variation_futures_.size());
         for (auto &pair : nominal_futures_) {
-            handles.emplace_back(pair.second.GetHandle());
+            handles.emplace_back(pair.second);
         }
         for (auto &pair : variation_futures_) {
-            handles.emplace_back(pair.second.GetHandle());
+            handles.emplace_back(pair.second);
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace removed `GetHandle` calls with direct `RResultPtr` usage in data and Monte Carlo processors
- Maintain collection of `RResultHandle` objects for `RunGraphs`

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: Could not find ROOT package)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7027ab7c832e9ff204fd278fc9c5