### PR TITLE
Add debug checks for extreme universe weights

### DIFF
--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -1,6 +1,8 @@
 #ifndef UNIVERSE_SYSTEMATIC_STRATEGY_H
 #define UNIVERSE_SYSTEMATIC_STRATEGY_H
 
+#include <algorithm>
+#include <cmath>
 #include <map>
 #include <stdexcept>
 #include <string>
@@ -43,57 +45,123 @@ public:
       // arguments) in Define, so provide explicit overloads for the
       // numeric vector types we expect.
       if (col_type == "ROOT::VecOps::RVec<float>") {
-        auto weight = [u](const ROOT::RVec<float> &weights) {
-          if (weights.empty())
+        auto weight = [u, this](const ROOT::RVec<float> &weights) {
+          if (weights.empty()) {
+            log::warn("UniverseSystematicStrategy::bookVariations", identifier_,
+                      "empty weight vector");
             return 1.0;
+          }
 
           double central = 0.0;
           for (const auto &w : weights)
             central += w;
           central /= static_cast<double>(weights.size());
-          if (central == 0.0)
+          if (central == 0.0) {
+            log::warn("UniverseSystematicStrategy::bookVariations", identifier_,
+                      "central weight is zero");
             return 1.0;
+          }
 
-          if (u < weights.size())
-            return static_cast<double>(weights[u]) / central;
+          const double central_first = static_cast<double>(weights.front());
+          if (std::abs(central_first - central) >
+              1e-6 * std::max(1.0, std::abs(central_first))) {
+            log::debug("UniverseSystematicStrategy::bookVariations", identifier_,
+                       "central weight differs from first element", "first",
+                       central_first, "mean", central);
+          }
+
+          if (u < weights.size()) {
+            const double w = static_cast<double>(weights[u]);
+            const double ratio = w / central;
+            if (std::abs(ratio) > 1e3) {
+              log::warn("UniverseSystematicStrategy::bookVariations", identifier_,
+                        "extreme universe weight", "universe", u, "weight", w,
+                        "central", central, "ratio", ratio);
+            }
+            return ratio;
+          }
           return 1.0;
         };
         auto node = rnode.Define(uni_weight_name, weight, {vector_name_});
         futures.variations[uni_key][sample_key] =
             node.Histo1D(model, binning.getVariable(), uni_weight_name);
       } else if (col_type == "ROOT::VecOps::RVec<double>") {
-        auto weight = [u](const ROOT::RVec<double> &weights) {
-          if (weights.empty())
+        auto weight = [u, this](const ROOT::RVec<double> &weights) {
+          if (weights.empty()) {
+            log::warn("UniverseSystematicStrategy::bookVariations", identifier_,
+                      "empty weight vector");
             return 1.0;
+          }
 
           double central = 0.0;
           for (const auto &w : weights)
             central += w;
           central /= static_cast<double>(weights.size());
-          if (central == 0.0)
+          if (central == 0.0) {
+            log::warn("UniverseSystematicStrategy::bookVariations", identifier_,
+                      "central weight is zero");
             return 1.0;
+          }
 
-          if (u < weights.size())
-            return static_cast<double>(weights[u]) / central;
+          const double central_first = static_cast<double>(weights.front());
+          if (std::abs(central_first - central) >
+              1e-6 * std::max(1.0, std::abs(central_first))) {
+            log::debug("UniverseSystematicStrategy::bookVariations", identifier_,
+                       "central weight differs from first element", "first",
+                       central_first, "mean", central);
+          }
+
+          if (u < weights.size()) {
+            const double w = static_cast<double>(weights[u]);
+            const double ratio = w / central;
+            if (std::abs(ratio) > 1e3) {
+              log::warn("UniverseSystematicStrategy::bookVariations", identifier_,
+                        "extreme universe weight", "universe", u, "weight", w,
+                        "central", central, "ratio", ratio);
+            }
+            return ratio;
+          }
           return 1.0;
         };
         auto node = rnode.Define(uni_weight_name, weight, {vector_name_});
         futures.variations[uni_key][sample_key] =
             node.Histo1D(model, binning.getVariable(), uni_weight_name);
       } else if (col_type == "ROOT::VecOps::RVec<unsigned short>") {
-        auto weight = [u](const ROOT::RVec<unsigned short> &weights) {
-          if (weights.empty())
+        auto weight = [u, this](const ROOT::RVec<unsigned short> &weights) {
+          if (weights.empty()) {
+            log::warn("UniverseSystematicStrategy::bookVariations", identifier_,
+                      "empty weight vector");
             return 1.0;
+          }
 
           double central = 0.0;
           for (const auto &w : weights)
             central += w;
           central /= static_cast<double>(weights.size());
-          if (central == 0.0)
+          if (central == 0.0) {
+            log::warn("UniverseSystematicStrategy::bookVariations", identifier_,
+                      "central weight is zero");
             return 1.0;
+          }
 
-          if (u < weights.size())
-            return static_cast<double>(weights[u]) / central;
+          const double central_first = static_cast<double>(weights.front());
+          if (std::abs(central_first - central) >
+              1e-6 * std::max(1.0, std::abs(central_first))) {
+            log::debug("UniverseSystematicStrategy::bookVariations", identifier_,
+                       "central weight differs from first element", "first",
+                       central_first, "mean", central);
+          }
+
+          if (u < weights.size()) {
+            const double w = static_cast<double>(weights[u]);
+            const double ratio = w / central;
+            if (std::abs(ratio) > 1e3) {
+              log::warn("UniverseSystematicStrategy::bookVariations", identifier_,
+                        "extreme universe weight", "universe", u, "weight", w,
+                        "central", central, "ratio", ratio);
+            }
+            return ratio;
+          }
           return 1.0;
         };
         auto node = rnode.Define(uni_weight_name, weight, {vector_name_});
@@ -185,6 +253,11 @@ private:
           h_universe.getBinContent(i) - nominal_hist.getBinContent(i);
       log::debug("UniverseSystematicStrategy::updateCovarianceMatrix",
                  identifier_, "bin", i, "delta", di);
+      if (std::abs(di) > 1e5) {
+        log::warn("UniverseSystematicStrategy::updateCovarianceMatrix", identifier_,
+                  "large bin delta", "bin", i, "delta", di,
+                  "nominal", nominal_hist.getBinContent(i));
+      }
       for (int j = 0; j <= i; ++j) {
         const double dj =
             h_universe.getBinContent(j) - nominal_hist.getBinContent(j);


### PR DESCRIPTION
## Summary
- log empty or zero central weights and extreme ratios during `bookVariations`
- warn when a universe weight deviates significantly from the first element
- flag large bin deltas in `updateCovarianceMatrix`

## Testing
- `cmake -S . -B build` *(fails: could not find ROOTConfig.cmake)*
- `apt-get update` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bf705c097c832ea6cca1e2e42cbc3f