### PR TITLE
Fix missing nlohmann JSON dependency for cut flow summary test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ catch_discover_tests(test_cut_flow_preset)
 
 add_executable(test_cut_flow_summary
   test_cut_flow_summary.cpp)
-target_link_libraries(test_cut_flow_summary PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(test_cut_flow_summary PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
 catch_discover_tests(test_cut_flow_summary)
 
 add_executable(test_stacked_log_preset


### PR DESCRIPTION
## Summary
- link `test_cut_flow_summary` against nlohmann JSON to satisfy ROOT RDF metadata include

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bf717b40fc832e9397fef9522b8bbe