### PR TITLE
Expose CutFlowCalculator summary for testing

### DIFF
--- a/tests/test_cut_flow_summary.cpp
+++ b/tests/test_cut_flow_summary.cpp
@@ -1,11 +1,11 @@
-#define private public
 #include "CutFlowCalculator.h"
-#undef private
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
 #include <sstream>
 
 using namespace analysis;
+using Catch::Approx;
 
 TEST_CASE("cut flow summary prints efficiencies") {
     RegionKey rkey{"R"};


### PR DESCRIPTION
## Summary
- Make `CutFlowCalculator::printSummary` public to allow direct invocation
- Simplify cut flow summary unit test and use Catch2's Approx for comparisons

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bf71fd6db8832eb19f61a9a1d01ef0