### PR TITLE
Fix cut flow summary test linking

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ catch_discover_tests(test_cut_flow_preset)
 
 add_executable(test_cut_flow_summary
   test_cut_flow_summary.cpp)
-target_link_libraries(test_cut_flow_summary PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json)
+target_link_libraries(test_cut_flow_summary PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json ${ROOT_LIBRARIES} TBB::tbb)
 catch_discover_tests(test_cut_flow_summary)
 
 add_executable(test_stacked_log_preset


### PR DESCRIPTION
## Summary
- Link ROOT and TBB libraries to `test_cut_flow_summary` to resolve missing symbols during linking

## Testing
- `bash .build.sh` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68bf73187ee0832e9ff075e3d4786632