### PR TITLE
Fix weight systematic covariance calculation

### DIFF
--- a/libsyst/WeightSystematicStrategy.h
+++ b/libsyst/WeightSystematicStrategy.h
@@ -44,13 +44,15 @@ class WeightSystematicStrategy : public SystematicStrategy {
         result.variation_hists_[up_key] = hu;
         result.variation_hists_[dn_key] = hd;
 
-        std::vector<double> diff(n);
+        std::vector<double> diff_up(n), diff_dn(n);
         for (int i = 0; i < n; ++i) {
-            diff[i] = 0.5 * (hu.getBinContent(i) - hd.getBinContent(i));
+            diff_up[i] = hu.getBinContent(i) - nominal_hist.getBinContent(i);
+            diff_dn[i] = hd.getBinContent(i) - nominal_hist.getBinContent(i);
             log::debug("WeightSystematicStrategy::computeCovariance", identifier_,
-                       "bin", i, "diff", diff[i]);
+                       "bin", i, "diff_up", diff_up[i], "diff_down", diff_dn[i]);
             for (int j = 0; j <= i; ++j) {
-                const double val = diff[i] * diff[j];
+                const double val = 0.5 *
+                                   (diff_up[i] * diff_up[j] + diff_dn[i] * diff_dn[j]);
                 cov(i, j) = val;
                 cov(j, i) = val;
             }


### PR DESCRIPTION
## Summary
- compute weight systematic covariance from deviations of up and down variations
- average contributions of up and down shifts when building covariance matrix

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68bf74d99cb4832e85f15050f5d4763f