### PR TITLE
Add muon-neutrino CC other channel

### DIFF
--- a/libdata/TruthChannelProcessor.h
+++ b/libdata/TruthChannelProcessor.h
@@ -220,38 +220,39 @@ private:
   }
 
   ROOT::RDF::RNode assignChannelDefinitions(ROOT::RDF::RNode df) const {
-    auto chan_df =
-        df.Define("channel_def", [](bool fv, int nu, int cc, int s, int npi,
-                                     int np, int npi0, int ngamma) {
-          if (!fv) {
-            if (nu == 0)
-              return 1; // External
-            return 2;   // Out FV
-          }
-          if (cc == 1)
-            return 14; // nc
-          if (cc == 0 && s > 0) {
-            if (s == 1)
-              return 15; // numu_cc_1s
-            return 16;   // numu_cc_ms
-          }
-          if (std::abs(nu) == 12 && cc == 0)
-            return 17; // nue_cc
-          if (std::abs(nu) == 14 && cc == 0) {
-            if (npi == 0 && np > 0)
-              return 10; // numu_cc_np0pi
-            if (npi == 1 && npi0 == 0)
-              return 11; // numu_cc_0pnpi
-            if (npi0 > 0 || ngamma >= 2)
-              return 12; // numu_cc_pi0gg
-            if (npi > 1)
-              return 13; // numu_cc_npnpi
-          }
-          return 99; // other
-        },
-                   {"in_fiducial", "neutrino_pdg", "interaction_ccnc",
-                    "mc_n_strange", "mc_n_pion", "mc_n_proton",
-                    "count_pi_zero", "count_gamma"});
+    auto chan_df = df.Define("channel_def",
+                             [](bool fv, int nu, int cc, int s, int npi, int np,
+                                int npi0, int ngamma) {
+                               if (!fv) {
+                                 if (nu == 0)
+                                   return 1; // External
+                                 return 2;   // Out FV
+                               }
+                               if (cc == 1)
+                                 return 14; // nc
+                               if (cc == 0 && s > 0) {
+                                 if (s == 1)
+                                   return 15; // numu_cc_1s
+                                 return 16;   // numu_cc_ms
+                               }
+                               if (std::abs(nu) == 12 && cc == 0)
+                                 return 17; // nue_cc
+                               if (std::abs(nu) == 14 && cc == 0) {
+                                 if (npi == 0 && np > 0)
+                                   return 10; // numu_cc_np0pi
+                                 if (npi == 1 && npi0 == 0)
+                                   return 11; // numu_cc_0pnpi
+                                 if (npi0 > 0 || ngamma >= 2)
+                                   return 12; // numu_cc_pi0gg
+                                 if (npi > 1)
+                                   return 13; // numu_cc_npnpi
+                                 return 18;   // numu_cc_other
+                               }
+                               return 99; // other
+                             },
+                             {"in_fiducial", "neutrino_pdg", "interaction_ccnc",
+                              "mc_n_strange", "mc_n_pion", "mc_n_proton",
+                              "count_pi_zero", "count_gamma"});
 
     auto chan_alias_df = chan_df.Define("channel_definitions", "channel_def");
 

--- a/libhist/StratifierRegistry.h
+++ b/libhist/StratifierRegistry.h
@@ -352,13 +352,14 @@ private:
          {2, "out_fv", "Out FV", kYellow - 7, 1001},
          {10, "numu_cc_np0pi", R"(#nu_{#mu}CC Np0#pi)", kRed, 1001},
          {11, "numu_cc_0pnpi", R"(#nu_{#mu}CC 0p1#pi)", kRed - 7, 1001},
-         {12, "numu_cc_pi0gg",
-          R"(#nu_{#mu}CC #pi^{0}/#gamma#gamma)", kOrange, 1001},
+         {12, "numu_cc_pi0gg", R"(#nu_{#mu}CC #pi^{0}/#gamma#gamma)", kOrange,
+          1001},
          {13, "numu_cc_npnpi", R"(#nu_{#mu}CC multi-#pi)", kViolet, 1001},
          {14, "nc", R"(#nu_{x}NC)", kBlue, 1001},
          {15, "numu_cc_1s", R"(#nu_{#mu}CC 1s)", kSpring + 5, 1001},
          {16, "numu_cc_ms", R"(#nu_{#mu}CC Ms)", kGreen + 2, 1001},
          {17, "nue_cc", R"(#nu_{e}CC)", kMagenta, 1001},
+         {18, "numu_cc_other", R"(#nu_{#mu}CC Other)", kCyan + 2, 1001},
          {99, "other", "Other", kCyan, 1001}});
   }
 


### PR DESCRIPTION
## Summary
- extend channel definition stratifier with muon-neutrino CC other category
- classify muon-neutrino CC events into new channel when no specific topology matched

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf83e92e1c832e9fce4a73839bc05e