### PR TITLE
Skip empty systematics calculations

### DIFF
--- a/libapp/VariableProcessor.h
+++ b/libapp/VariableProcessor.h
@@ -71,9 +71,14 @@ template <typename SysProc> class VariableProcessor {
                 entry.second->contributeTo(result);
             }
 
-            log::info("VariableProcessor::process",
-                        "Computing systematic covariances");
-            systematics_processor_.processSystematics(result);
+            if (systematics_processor_.hasSystematics() || !result.raw_detvar_hists_.empty()) {
+                log::info("VariableProcessor::process",
+                          "Computing systematic covariances");
+                systematics_processor_.processSystematics(result);
+            } else {
+                log::info("VariableProcessor::process",
+                          "No systematics found. Skipping covariance calculation.");
+            }
             systematics_processor_.clearFutures();
 
             AnalysisResult::printSummary(result);

--- a/libsyst/DetectorSystematicStrategy.h
+++ b/libsyst/DetectorSystematicStrategy.h
@@ -37,6 +37,11 @@ class DetectorSystematicStrategy : public SystematicStrategy {
         }
 
         auto total_detvar_hists = aggregateVariations(result);
+        if (total_detvar_hists.size() <= 1) {
+            log::warn("DetectorSystematicStrategy::computeCovariance",
+                      "No detector variations beyond CV found. Skipping detector systematics.");
+            return total_detvar_cov;
+        }
         auto h_det_cv_opt = sanitiseCvHistogram(total_detvar_hists);
         if (!h_det_cv_opt) return total_detvar_cov;
 

--- a/libsyst/SystematicsProcessor.h
+++ b/libsyst/SystematicsProcessor.h
@@ -59,6 +59,12 @@ class SystematicsProcessor {
     }
 
     void processSystematics(VariableResult &result) {
+        if (!hasSystematics() && result.raw_detvar_hists_.empty()) {
+            log::info("SystematicsProcessor::processSystematics",
+                      "No systematics found. Skipping covariance calculation.");
+            return;
+        }
+
         log::debug("SystematicsProcessor::processSystematics", "Commencing covariance calculations");
         for (const auto &strategy : systematic_strategies_) {
             VariableResult local_result = result;
@@ -75,6 +81,8 @@ class SystematicsProcessor {
     }
 
     void clearFutures() { systematic_futures_.variations.clear(); }
+
+    bool hasSystematics() const { return !systematic_futures_.variations.empty(); }
 
   private:
     static void sanitiseMatrix(TMatrixDSym &m) {

--- a/libsyst/UniverseSystematicStrategy.h
+++ b/libsyst/UniverseSystematicStrategy.h
@@ -35,6 +35,15 @@ public:
                       SystematicFutures &futures) override {
     log::debug("UniverseSystematicStrategy::bookVariations", identifier_,
                "sample", sample_key.str(), "universes", n_universes_);
+
+    if (!rnode.HasColumn(vector_name_)) {
+      log::warn("UniverseSystematicStrategy::bookVariations",
+                "Missing weight vector column", vector_name_, "for",
+                identifier_, "in sample", sample_key.str(),
+                ". Skipping systematic.");
+      return;
+    }
+
     auto col_type = rnode.GetColumnType(vector_name_);
     for (unsigned u = 0; u < n_universes_; ++u) {
       const SystematicKey uni_key(identifier_ + "_u" + std::to_string(u));

--- a/libsyst/WeightSystematicStrategy.h
+++ b/libsyst/WeightSystematicStrategy.h
@@ -3,6 +3,7 @@
 
 #include "BinnedHistogram.h"
 #include "SystematicStrategy.h"
+#include "Logger.h"
 #include <TMatrixDSym.h>
 #include <map>
 #include <string>
@@ -22,6 +23,12 @@ class WeightSystematicStrategy : public SystematicStrategy {
     void bookVariations(const SampleKey &sample_key, ROOT::RDF::RNode &rnode, const BinningDefinition &binning,
                         const ROOT::RDF::TH1DModel &model, SystematicFutures &futures) override {
         log::debug("WeightSystematicStrategy::bookVariations", identifier_, "sample", sample_key.str());
+        if (!rnode.HasColumn(up_column_) || !rnode.HasColumn(dn_column_)) {
+            log::warn("WeightSystematicStrategy::bookVariations", "Missing weight columns",
+                      up_column_, "or", dn_column_, "for", identifier_, "in sample",
+                      sample_key.str(), ". Skipping systematic.");
+            return;
+        }
         const SystematicKey up_key{identifier_ + "_up"};
         const SystematicKey dn_key{identifier_ + "_dn"};
         futures.variations[up_key][sample_key] = rnode.Histo1D(model, binning.getVariable(), up_column_);


### PR DESCRIPTION
## Summary
- Avoid covariance calculations when no systematic variations are present
- Provide `hasSystematics()` helper to detect booked variations
- Only compute systematics in `VariableProcessor` when necessary
- Skip weight systematics when required weight columns are missing
- Guard detector and universe systematic strategies against absent inputs

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `sudo apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf81571994832e8b0f841a8d9aa348