### PR TITLE
Overlay signal on stacked histograms

### DIFF
--- a/ana/pipeline_runner_example.cpp
+++ b/ana/pipeline_runner_example.cpp
@@ -13,7 +13,11 @@ int main() {
   builder.region("EMPTY");
   builder.variable("TEST_TOPOLOGICAL_SCORE");
   //builder.variable("RECO_NEUTRINO_VERTEX");
-  builder.preset("STACKED_PLOTS_LOG");
+  builder.preset("STACKED_PLOTS_LOG",
+                 {{"plot_configs",
+                   {{"plots",
+                     PluginArgs::array({{{"signal_group",
+                                           "inclusive_strange_channels"}}})}}}});
   //builder.uniqueById();
 
   auto analysis_specs = builder.analysisSpecs();

--- a/libplot/PlotCatalog.h
+++ b/libplot/PlotCatalog.h
@@ -33,6 +33,8 @@ class PlotCatalog {
                              const std::string &region,
                              const std::string &category_column,
                              bool overlay_signal = true,
+                             const std::string &signal_group =
+                                 "inclusive_strange_channels",
                              const std::vector<Cut> &cut_list = {},
                              bool annotate_numbers = true) const {
         const auto &result = this->fetchResult(res, variable, region);
@@ -44,8 +46,9 @@ class PlotCatalog {
         const RegionAnalysis &region_info = res.region(RegionKey{region});
 
         StackedHistogramPlot plot(std::move(name), result, region_info,
-                                    category_column, output_directory_.string(),
-                                    overlay_signal, cut_list, annotate_numbers);
+                                  category_column, output_directory_.string(),
+                                  overlay_signal, signal_group, cut_list,
+                                  annotate_numbers);
         plot.drawAndSave();
     }
 

--- a/libplug/plotting/StackedHistogramPlugin.cc
+++ b/libplug/plotting/StackedHistogramPlugin.cc
@@ -20,6 +20,7 @@ class StackedHistogramPlugin : public IPlotPlugin {
         std::string category_column{"inclusive"};
         std::string output_directory = "plots";
         bool overlay_signal = true;
+        std::string signal_group{"inclusive_strange_channels"};
         std::vector<Cut> cut_list;
         bool annotate_numbers = true;
         bool use_log_y = false;
@@ -40,6 +41,9 @@ class StackedHistogramPlugin : public IPlotPlugin {
                 pc.category_column = p.value("category_column", std::string("inclusive"));
                 pc.output_directory = p.value("output_directory", std::string("plots"));
                 pc.overlay_signal = p.value("overlay_signal", true);
+                pc.signal_group =
+                    p.value("signal_group",
+                             std::string{"inclusive_strange_channels"});
                 pc.annotate_numbers = p.value("annotate_numbers", true);
                 pc.use_log_y = p.value("log_y", false);
                 pc.y_axis_label = p.value("y_axis_label", "Events");
@@ -109,8 +113,9 @@ class StackedHistogramPlugin : public IPlotPlugin {
                     StackedHistogramPlot plot(plot_name, variable_result,
                                               region_analysis, pc.category_column,
                                               pc.output_directory, pc.overlay_signal,
-                                              pc.cut_list, pc.annotate_numbers,
-                                              pc.use_log_y, pc.y_axis_label, pc.n_bins,
+                                              pc.signal_group, pc.cut_list,
+                                              pc.annotate_numbers, pc.use_log_y,
+                                              pc.y_axis_label, pc.n_bins,
                                               pc.min, pc.max);
                     plot.drawAndSave("pdf");
                 }


### PR DESCRIPTION
## Summary
- Allow StackedHistogram plots to overlay a summed signal distribution
- Let StackedHistogramPlugin accept a `signal_group` option and pass it through
- Enable signal overlay in the pipeline runner example

## Testing
- `source .build.sh` *(fails: Could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bf8727d5b0832ea20d3d292c8bb220