### PR TITLE
Parallelise sample processor contributions

### DIFF
--- a/libapp/DataProcessor.h
+++ b/libapp/DataProcessor.h
@@ -17,11 +17,13 @@ class DataProcessor : public ISampleProcessor {
         handles.emplace_back(data_future_);
     }
 
-    void contributeTo(VariableResult &result) override {
+    VariableResult contribute(const BinningDefinition &binning) override {
+        VariableResult local;
+        local.binning_ = binning;
         if (data_future_.GetPtr()) {
-            result.data_hist_ =
-                result.data_hist_ + BinnedHistogram::createFromTH1D(result.binning_, *data_future_.GetPtr());
+            local.data_hist_ = BinnedHistogram::createFromTH1D(binning, *data_future_.GetPtr());
         }
+        return local;
     }
 
   private:

--- a/libapp/ISampleProcessor.h
+++ b/libapp/ISampleProcessor.h
@@ -17,7 +17,7 @@ class ISampleProcessor {
 
     virtual void collectHandles(std::vector<ROOT::RDF::RResultHandle> &handles) = 0;
 
-    virtual void contributeTo(VariableResult &result) = 0;
+    virtual VariableResult contribute(const BinningDefinition &binning) = 0;
 };
 
 }

--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -40,24 +40,29 @@ class MonteCarloProcessor : public ISampleProcessor {
         }
     }
 
-    void contributeTo(VariableResult &result) override {
-        log::info("MonteCarloProcessor::contributeTo", "Contributing histograms from sample:", sample_key_.str());
+    VariableResult contribute(const BinningDefinition &binning) override {
+        log::info("MonteCarloProcessor::contribute", "Contributing histograms from sample:", sample_key_.str());
+
+        VariableResult local;
+        local.binning_ = binning;
 
         for (auto &[stratum_key, future] : nominal_futures_) {
             if (future.GetPtr()) {
-                auto hist = BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
+                auto hist = BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
                 ChannelKey channel_key{stratum_key.str()};
-                result.strat_hists_[channel_key] = result.strat_hists_[channel_key] + hist;
-                result.total_mc_hist_ = result.total_mc_hist_ + hist;
+                local.strat_hists_[channel_key] = local.strat_hists_[channel_key] + hist;
+                local.total_mc_hist_ = local.total_mc_hist_ + hist;
             }
         }
 
         for (auto &[var_key, future] : variation_futures_) {
             if (future.GetPtr()) {
-                auto hist = BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
-                result.raw_detvar_hists_[sample_key_][var_key] = hist;
+                auto hist = BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
+                local.raw_detvar_hists_[sample_key_][var_key] = hist;
             }
         }
+
+        return local;
     }
 
   private:

--- a/tests/test_monte_carlo_processor.cpp
+++ b/tests/test_monte_carlo_processor.cpp
@@ -10,7 +10,7 @@
 
 using namespace analysis;
 
-TEST_CASE("MonteCarloProcessor parallel contributeTo") {
+TEST_CASE("MonteCarloProcessor parallel contribute") {
     std::vector<double> edges{0.0, 1.0, 2.0};
     BinningDefinition binning(edges, "x", "x", {}, "inclusive_strange_channels");
     auto model = binning.toTH1DModel();
@@ -35,8 +35,6 @@ TEST_CASE("MonteCarloProcessor parallel contributeTo") {
     HistogramFactory factory;
     proc.book(factory, binning, model);
 
-    VariableResult result;
-    result.binning_ = binning;
     std::vector<ROOT::RDF::RResultHandle> handles;
     proc.collectHandles(handles);
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 26, 0)
@@ -46,7 +44,7 @@ TEST_CASE("MonteCarloProcessor parallel contributeTo") {
         h.GetResultPtr();
     }
 #endif
-    proc.contributeTo(result);
+    auto result = proc.contribute(binning);
 
     ChannelKey c10{StratumKey{"10"}.str()};
     ChannelKey c11{StratumKey{"11"}.str()};


### PR DESCRIPTION
## Summary
- Refactor sample processor interface to return local `VariableResult`s
- Parallelise sample contribution in `VariableProcessor` and merge results safely
- Update MonteCarlo and Data processors plus related unit test

## Testing
- `cmake -S . -B build` *(fails: ROOTConfig.cmake not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8caf3a0c832eac61e8ccdba185be