### PR TITLE
Add expected handle counts for sample processors

### DIFF
--- a/libapp/DataProcessor.h
+++ b/libapp/DataProcessor.h
@@ -13,6 +13,8 @@ class DataProcessor : public ISampleProcessor {
         data_future_ = factory.bookNominalHist(binning, dataset_, model);
     }
 
+    std::size_t expectedHandleCount() const override { return 1; }
+
     void collectHandles(std::vector<ROOT::RDF::RResultHandle> &handles) override {
         handles.emplace_back(data_future_);
     }

--- a/libapp/ISampleProcessor.h
+++ b/libapp/ISampleProcessor.h
@@ -5,6 +5,7 @@
 #include "HistogramFactory.h"
 #include <ROOT/RDataFrame.hxx>
 #include <vector>
+#include <cstddef>
 
 namespace analysis {
 
@@ -18,6 +19,8 @@ class ISampleProcessor {
     virtual void collectHandles(std::vector<ROOT::RDF::RResultHandle> &handles) = 0;
 
     virtual void contributeTo(VariableResult &result) = 0;
+
+    virtual std::size_t expectedHandleCount() const = 0;
 };
 
 }

--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -30,8 +30,11 @@ class MonteCarloProcessor : public ISampleProcessor {
         }
     }
 
+    std::size_t expectedHandleCount() const override {
+        return nominal_futures_.size() + variation_futures_.size();
+    }
+
     void collectHandles(std::vector<ROOT::RDF::RResultHandle> &handles) override {
-        handles.reserve(handles.size() + nominal_futures_.size() + variation_futures_.size());
         for (auto &pair : nominal_futures_) {
             handles.emplace_back(pair.second);
         }

--- a/libapp/VariableProcessor.h
+++ b/libapp/VariableProcessor.h
@@ -62,7 +62,12 @@ template <typename SysProc> class VariableProcessor {
             }
 
             log::info("VariableProcessor::process", "Persisting results...");
+            std::size_t total_handles = 0;
+            for (auto &entry : sample_processors) {
+                total_handles += entry.second->expectedHandleCount();
+            }
             std::vector<ROOT::RDF::RResultHandle> handles;
+            handles.reserve(total_handles);
             for (auto &entry : sample_processors) {
                 entry.second->collectHandles(handles);
             }


### PR DESCRIPTION
## Summary
- define `expectedHandleCount()` in `ISampleProcessor`
- implement handle count for data and MC sample processors
- reserve result handles in `VariableProcessor` before collecting

## Testing
- `bash ./.build.sh` *(fails: Could not find package configuration file provided by "ROOT")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf8caed490832e902abfbeba1e5ada