### PR TITLE
Restore sample processor contribute API and include TBB task

### DIFF
--- a/libapp/ISampleProcessor.h
+++ b/libapp/ISampleProcessor.h
@@ -3,6 +3,7 @@
 
 #include "VariableResult.h"
 #include "HistogramFactory.h"
+#include "BinningDefinition.h"
 #include <ROOT/RDataFrame.hxx>
 #include <vector>
 #include <cstddef>
@@ -18,7 +19,7 @@ class ISampleProcessor {
 
     virtual void collectHandles(std::vector<ROOT::RDF::RResultHandle> &handles) = 0;
 
-    virtual void contributeTo(VariableResult &result) = 0;
+    virtual VariableResult contribute(const BinningDefinition &binning) = 0;
 
     virtual std::size_t expectedHandleCount() const = 0;
 };

--- a/libapp/VariableProcessor.h
+++ b/libapp/VariableProcessor.h
@@ -2,6 +2,7 @@
 #define VARIABLE_PROCESSOR_H
 
 #include <algorithm>
+#include <tbb/task.h>
 #include <execution>
 #include <memory>
 #include <unordered_map>


### PR DESCRIPTION
## Summary
- Restore `ISampleProcessor::contribute` returning `VariableResult`
- Include `<tbb/task.h>` before `<execution>` to provide `tbb::task` for parallel algorithms

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68bf8f358af0832e8dd6b4e67081f500