### PR TITLE
Remove TBB-dependent sample processing

### DIFF
--- a/libapp/DataProcessor.h
+++ b/libapp/DataProcessor.h
@@ -19,13 +19,11 @@ class DataProcessor : public ISampleProcessor {
         handles.emplace_back(data_future_);
     }
 
-    VariableResult contribute(const BinningDefinition &binning) override {
-        VariableResult local;
-        local.binning_ = binning;
+    void contributeTo(VariableResult &result) override {
         if (data_future_.GetPtr()) {
-            local.data_hist_ = BinnedHistogram::createFromTH1D(binning, *data_future_.GetPtr());
+            result.data_hist_ =
+                result.data_hist_ + BinnedHistogram::createFromTH1D(result.binning_, *data_future_.GetPtr());
         }
-        return local;
     }
 
   private:

--- a/libapp/ISampleProcessor.h
+++ b/libapp/ISampleProcessor.h
@@ -3,7 +3,6 @@
 
 #include "VariableResult.h"
 #include "HistogramFactory.h"
-#include "BinningDefinition.h"
 #include <ROOT/RDataFrame.hxx>
 #include <vector>
 #include <cstddef>
@@ -19,8 +18,7 @@ class ISampleProcessor {
 
     virtual void collectHandles(std::vector<ROOT::RDF::RResultHandle> &handles) = 0;
 
-    virtual VariableResult contribute(const BinningDefinition &binning) = 0;
-
+    virtual void contributeTo(VariableResult &result) = 0;
     virtual std::size_t expectedHandleCount() const = 0;
 };
 

--- a/libapp/MonteCarloProcessor.h
+++ b/libapp/MonteCarloProcessor.h
@@ -43,29 +43,24 @@ class MonteCarloProcessor : public ISampleProcessor {
         }
     }
 
-    VariableResult contribute(const BinningDefinition &binning) override {
-        log::info("MonteCarloProcessor::contribute", "Contributing histograms from sample:", sample_key_.str());
-
-        VariableResult local;
-        local.binning_ = binning;
+    void contributeTo(VariableResult &result) override {
+        log::info("MonteCarloProcessor::contributeTo", "Contributing histograms from sample:", sample_key_.str());
 
         for (auto &[stratum_key, future] : nominal_futures_) {
             if (future.GetPtr()) {
-                auto hist = BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
+                auto hist = BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
                 ChannelKey channel_key{stratum_key.str()};
-                local.strat_hists_[channel_key] = local.strat_hists_[channel_key] + hist;
-                local.total_mc_hist_ = local.total_mc_hist_ + hist;
+                result.strat_hists_[channel_key] = result.strat_hists_[channel_key] + hist;
+                result.total_mc_hist_ = result.total_mc_hist_ + hist;
             }
         }
 
         for (auto &[var_key, future] : variation_futures_) {
             if (future.GetPtr()) {
-                auto hist = BinnedHistogram::createFromTH1D(binning, *future.GetPtr());
-                local.raw_detvar_hists_[sample_key_][var_key] = hist;
+                auto hist = BinnedHistogram::createFromTH1D(result.binning_, *future.GetPtr());
+                result.raw_detvar_hists_[sample_key_][var_key] = hist;
             }
         }
-
-        return local;
     }
 
   private:

--- a/tests/test_monte_carlo_processor.cpp
+++ b/tests/test_monte_carlo_processor.cpp
@@ -10,7 +10,7 @@
 
 using namespace analysis;
 
-TEST_CASE("MonteCarloProcessor parallel contribute") {
+TEST_CASE("MonteCarloProcessor parallel contributeTo") {
     std::vector<double> edges{0.0, 1.0, 2.0};
     BinningDefinition binning(edges, "x", "x", {}, "inclusive_strange_channels");
     auto model = binning.toTH1DModel();
@@ -35,6 +35,8 @@ TEST_CASE("MonteCarloProcessor parallel contribute") {
     HistogramFactory factory;
     proc.book(factory, binning, model);
 
+    VariableResult result;
+    result.binning_ = binning;
     std::vector<ROOT::RDF::RResultHandle> handles;
     proc.collectHandles(handles);
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 26, 0)
@@ -44,7 +46,7 @@ TEST_CASE("MonteCarloProcessor parallel contribute") {
         h.GetResultPtr();
     }
 #endif
-    auto result = proc.contribute(binning);
+    proc.contributeTo(result);
 
     ChannelKey c10{StratumKey{"10"}.str()};
     ChannelKey c11{StratumKey{"11"}.str()};


### PR DESCRIPTION
## Summary
- revert parallel sample processing that required TBB
- restore `contributeTo` API across sample processors

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bf904fbc68832e8dd7cd32d561cc7d