### PR TITLE
Show fractional scaling factor in legend

### DIFF
--- a/libplot/StackedHistogramPlot.h
+++ b/libplot/StackedHistogramPlot.h
@@ -223,7 +223,7 @@ class StackedHistogramPlot : public IHistogramPlot {
             std::string sig_label = "Signal (overlay";
             if (signal_scale_ != 1.0) {
                 sig_label +=
-                    " (x" + this->formatWithCommas(signal_scale_, 0) + ")";
+                    " (x" + this->formatWithCommas(signal_scale_, 2) + ")";
             }
             sig_label += ")";
             legend_->AddEntry(h_sig, sig_label.c_str(), "l");


### PR DESCRIPTION
## Summary
- Display signal scaling factors with two decimal precision in stacked histogram legends.

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory; setup command not found)*
- `bash .build.sh` *(fails: Could not find package ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68bf95e4dc48832e9d081f60722aef4f