### PR TITLE
Add ROC AUC and significance improvement plotting

### DIFF
--- a/ana/pipeline_runner_example.cpp
+++ b/ana/pipeline_runner_example.cpp
@@ -12,13 +12,17 @@ int main() {
   // Build a simple pipeline programmatically
   builder.region("EMPTY");
   builder.variable("TEST_TOPOLOGICAL_SCORE");
-  //builder.variable("RECO_NEUTRINO_VERTEX");
-  builder.preset("STACKED_PLOTS_LOG",
-                 {{"plot_configs",
-                   {{"plots",
-                     PluginArgs::array({{{"signal_group",
-                                           "inclusive_strange_channels"}}})}}}});
-  //builder.uniqueById();
+  // Configure a performance plot for the topological score
+  builder.add(
+      Target::Plot, "PerformancePlotPlugin",
+      {{"plot_configs",
+        {{"performance_plots",
+          PluginArgs::array({{{"region", "EMPTY"},
+                               {"channel_column", "channel_definitions"},
+                               {"signal_group", "inclusive_strange_channels"},
+                               {"variable", "topological_score"},
+                               {"plot_name", "topological_score_performance"},
+                               {"output_directory", "./plots"}}})}}}});
 
   auto analysis_specs = builder.analysisSpecs();
   auto plot_specs = builder.plotSpecs();

--- a/libplot/PerformancePlot.h
+++ b/libplot/PerformancePlot.h
@@ -6,6 +6,8 @@
 
 #include "TCanvas.h"
 #include "TGraph.h"
+#include "TLatex.h"
+#include "TString.h"
 
 #include "IHistogramPlot.h"
 
@@ -15,10 +17,12 @@ class PerformancePlot : public IHistogramPlot {
   public:
     PerformancePlot(std::string plot_name, std::vector<double> signal_eff,
                     std::vector<double> background_rej,
-                    std::string output_directory = "plots")
+                    std::string output_directory = "plots",
+                    double auc = -1.0)
         : IHistogramPlot(std::move(plot_name), std::move(output_directory)),
           signal_eff_(std::move(signal_eff)),
-          background_rej_(std::move(background_rej)) {}
+          background_rej_(std::move(background_rej)),
+          auc_(auc) {}
 
   protected:
     void draw(TCanvas &canvas) override {
@@ -43,11 +47,22 @@ class PerformancePlot : public IHistogramPlot {
         graph.GetXaxis()->SetLimits(axis_min, axis_max);
         graph.GetYaxis()->SetRangeUser(axis_min, axis_max);
         graph.DrawClone("ALP");
+
+        if (auc_ >= 0.0) {
+            TLatex latex;
+            latex.SetNDC();
+            const double x = 0.6;
+            const double y = 0.2;
+            const double text_size = 0.04;
+            latex.SetTextSize(text_size);
+            latex.DrawLatex(x, y, Form("AUC = %.3f", auc_));
+        }
     }
 
   private:
     std::vector<double> signal_eff_;
     std::vector<double> background_rej_;
+    double auc_;
 };
 
 }

--- a/libplot/SignificanceImprovementPlot.h
+++ b/libplot/SignificanceImprovementPlot.h
@@ -1,0 +1,57 @@
+#ifndef SIGNIFICANCEIMPROVEMENTPLOT_H
+#define SIGNIFICANCEIMPROVEMENTPLOT_H
+
+#include <string>
+#include <vector>
+#include <algorithm>
+
+#include "TCanvas.h"
+#include "TGraph.h"
+
+#include "IHistogramPlot.h"
+
+namespace analysis {
+
+class SignificanceImprovementPlot : public IHistogramPlot {
+  public:
+    SignificanceImprovementPlot(std::string plot_name, std::vector<double> signal_eff,
+                                std::vector<double> significance_improvement,
+                                std::string output_directory = "plots")
+        : IHistogramPlot(std::move(plot_name), std::move(output_directory)),
+          signal_eff_(std::move(signal_eff)),
+          significance_improvement_(std::move(significance_improvement)) {}
+
+  protected:
+    void draw(TCanvas &canvas) override {
+        canvas.cd();
+        int n = signal_eff_.size();
+        TGraph graph(n);
+        for (int i = 0; i < n; ++i)
+            graph.SetPoint(i, signal_eff_[i], significance_improvement_[i]);
+
+        const int colour_offset = 1;
+        const int line_width = 2;
+        const int marker_style = 20;
+        const double axis_min = 0.0;
+
+        graph.SetLineColor(kBlue + colour_offset);
+        graph.SetLineWidth(line_width);
+        graph.SetMarkerColor(kBlue + colour_offset);
+        graph.SetMarkerStyle(marker_style);
+        graph.GetXaxis()->SetTitle("Signal Efficiency");
+        graph.GetYaxis()->SetTitle("S/#sqrt{B} (relative)");
+        graph.GetXaxis()->SetLimits(axis_min, 1.0);
+        double max_val = *std::max_element(significance_improvement_.begin(),
+                                           significance_improvement_.end());
+        graph.GetYaxis()->SetRangeUser(axis_min, max_val * 1.05);
+        graph.DrawClone("ALP");
+    }
+
+  private:
+    std::vector<double> signal_eff_;
+    std::vector<double> significance_improvement_;
+};
+
+} // namespace analysis
+
+#endif


### PR DESCRIPTION
## Summary
- Annotate performance plots with area-under-curve (AUC)
- Add SignificanceImprovementPlot and render SIC alongside ROC
- Compute AUC and significance improvement within PerformancePlotPlugin
- Demonstrate PerformancePlotPlugin usage in pipeline_runner_example

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68bf985c3c88832ea35509b4818c00c9