### PR TITLE
Demonstrate PerformancePlotPlugin in pipeline example

### DIFF
--- a/ana/pipeline_runner_example.cpp
+++ b/ana/pipeline_runner_example.cpp
@@ -31,6 +31,15 @@ int main() {
                                           {"signal_group",
                                            "inclusive_strange_channels"}}})}}}});
 
+  // Plot the ROC curve and significance improvement for the topological score
+  builder.add(Target::Plot, "PerformancePlotPlugin",
+              {{"performance_plots",
+                PluginArgs::array({{{"region", "PRE_TOPO"},
+                                     {"channel_column", "incl_channel"},
+                                     {"signal_group",
+                                      "inclusive_strange_channels"},
+                                     {"variable", "topological_score"}}})}});
+
   auto analysis_specs = builder.analysisSpecs();
   auto plot_specs = builder.plotSpecs();
 


### PR DESCRIPTION
## Summary
- Showcase PerformancePlotPlugin in pipeline_runner_example to draw ROC and significance-improvement curves for the topological score

## Testing
- ❌ `cmake -S . -B build` (missing ROOTConfig.cmake)
- ⚠️ `apt-get update` (403 forbidden when attempting to install ROOT)


------
https://chatgpt.com/codex/tasks/task_e_68bf9f558fd4832e9987537db085ec4a