### PR TITLE
Log and preload plugin libraries

### DIFF
--- a/libplug/PluginHost.h
+++ b/libplug/PluginHost.h
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <cstdlib>
 #include "Logger.h"
 #include "PluginRegistry.h"
 
@@ -13,7 +14,12 @@ namespace analysis {
 template <class Interface, class Ctx>
 class PluginHost {
 public:
-  explicit PluginHost(Ctx* ctx = nullptr) : ctx_(ctx) {}
+  explicit PluginHost(Ctx* ctx = nullptr) : ctx_(ctx) {
+    if (const char* dir = std::getenv("ANALYSIS_PLUGIN_DIR")) {
+      log::info("PluginHost", "preloading", dir);
+      loadDirectory(dir, /*recurse=*/false);
+    }
+  }
 
   void loadDirectory(const std::string& dir, bool recurse = false) {
     namespace fs = std::filesystem;
@@ -56,6 +62,7 @@ public:
       }
     }
     if (!plugin) throw std::runtime_error("No registered plugin: " + name);
+    log::info("PluginHost", "registered", name);
     plugins_.push_back(std::move(plugin));
   }
 


### PR DESCRIPTION
## Summary
- Preload plugin directory from `ANALYSIS_PLUGIN_DIR` when constructing plugin hosts
- Log each plugin registration for easier debugging

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa41fd704832e88bc18fa0e2b40bc