### PR TITLE
Ensure PerformancePlot plugin factory is exported

### DIFF
--- a/libplug/plotting/PerformancePlotPlugin.cc
+++ b/libplug/plotting/PerformancePlotPlugin.cc
@@ -222,8 +222,11 @@ ANALYSIS_REGISTER_PLUGIN(analysis::IPlotPlugin, analysis::AnalysisDataLoader,
                          "PerformancePlotPlugin", analysis::PerformancePlotPlugin)
 
 #ifdef BUILD_PLUGIN
-extern "C" analysis::IPlotPlugin *createPlotPlugin(const analysis::PluginArgs &args) {
+extern "C" analysis::IPlotPlugin *createPerformancePlotPlugin(const analysis::PluginArgs &args) {
     return new analysis::PerformancePlotPlugin(args, analysis::PerformancePlotPlugin::legacyLoader());
+}
+extern "C" analysis::IPlotPlugin *createPlotPlugin(const analysis::PluginArgs &args) {
+    return createPerformancePlotPlugin(args);
 }
 extern "C" void setPluginContext(analysis::AnalysisDataLoader *loader) {
     analysis::PerformancePlotPlugin::setLegacyLoader(loader);


### PR DESCRIPTION
## Summary
- Export plugin factory under `createPerformancePlotPlugin` and provide `createPlotPlugin` alias

## Testing
- `cmake -S . -B build` *(fails: could not find package configuration file provided by "ROOT")*
- `ctest --test-dir build --output-on-failure` *(no tests found due to configuration failure)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa741cb58832eb44544fe10972b17