### PR TITLE
Fix DSL naming conflicts and add overlay display mode

### DIFF
--- a/include/workflow/Display.h
+++ b/include/workflow/Display.h
@@ -9,9 +9,14 @@ namespace analysis::dsl {
 
 struct DisplayMode {
   std::string kind;
+  double overlay_alpha = 1.0;
+
+  DisplayMode& alpha(double a){ overlay_alpha = a; return *this; }
+  double alpha() const { return overlay_alpha; }
 };
 inline DisplayMode detector(){ return {"detector"}; }
 inline DisplayMode semantic(){ return {"semantic"}; }
+inline DisplayMode overlay(){ return {"overlay"}; }
 
 enum class Direction { Asc, Desc };
 static constexpr Direction asc  = Direction::Asc;
@@ -46,6 +51,7 @@ public:
       {"output_directory", out_dir_},
       {"mode", mode_.kind}
     };
+    if(mode_.kind == "overlay") j["overlay_alpha"] = mode_.alpha();
     if(!planes_.empty()) j["planes"] = planes_;
     if(selection_expr_) j["selection_expr"] = *selection_expr_;
     if(!file_pattern_.empty()) j["file_pattern"] = file_pattern_;

--- a/include/workflow/Plots.h
+++ b/include/workflow/Plots.h
@@ -19,8 +19,12 @@ struct PlotDef {
   PlotDef& logY(){ logy = true; return *this; }
 };
 
-inline PlotDef stack(std::string v){ return PlotDef{"stack", std::move(v)}; }
-inline PlotDef roc(std::string v){ return PlotDef{"roc", std::move(v)}; }
+inline PlotDef stack(std::string v){
+  return PlotDef{"stack", std::move(v), "", "", ""};
+}
+inline PlotDef roc(std::string v){
+  return PlotDef{"roc", std::move(v), "", "", ""};
+}
 
 // Cut direction helpers for Performance plots
 namespace dir {

--- a/include/workflow/Study.h
+++ b/include/workflow/Study.h
@@ -31,7 +31,7 @@ struct VarDef {
   std::string label;
   std::string stratum{"channel_definitions"};
   std::vector<std::string> regions;
-  nlohmann::json bins{{"n", 100}, {"min", 0.0}, {"max", 1.0}};
+  nlohmann::json binning{{"n", 100}, {"min", 0.0}, {"max", 1.0}};
 
   explicit VarDef(std::string n) : name(std::move(n)), branch(name), label(name) {}
 
@@ -39,9 +39,9 @@ struct VarDef {
   VarDef& titled(std::string l) { label = std::move(l); return *this; }
   VarDef& stratify(std::string s) { stratum = std::move(s); return *this; }
   VarDef& in(std::string r) { regions.push_back(std::move(r)); return *this; }
-  VarDef& bins_config(nlohmann::json b) { bins = std::move(b); return *this; }
+  VarDef& bins_config(nlohmann::json b) { binning = std::move(b); return *this; }
   VarDef& bins(int n, double mn, double mx) {
-    bins = {{"n", n}, {"min", mn}, {"max", mx}};
+    binning = {{"n", n}, {"min", mn}, {"max", mx}};
     return *this;
   }
 };
@@ -108,7 +108,7 @@ public:
             {"label", v.label},
             {"stratum", v.stratum},
             {"regions", r},
-            {"bins", v.bins}});
+            {"bins", v.binning}});
       }
       analysis_specs.push_back({
           "VariablesPlugin",


### PR DESCRIPTION
## Summary
- Initialize missing PlotDef fields for stack and ROC helpers
- Rename VarDef bins member to avoid conflict and update serialization
- Add overlay display mode with configurable alpha and JSON output

## Testing
- `cmake ..` *(fails: ROOT package not found)*
- `apt-get update` *(fails: repository signatures unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b50cffac832ea9be360304c5d7d3