### PR TITLE
Rename aggregate script to build sample catalog

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -5,7 +5,7 @@ This directory contains configuration assets and helper scripts.
 - `data/` – static JSON/YAML files describing datasets and run
   configuration.  These files are consumed by the helper scripts and C++ study programs.
 - `scripts/` – Python modules that operate on the configuration data.  For
-  example, `aggregate_summary.py` reads definitions from
+  example, `build_sample_catalog.py` reads definitions from
   `data/data.json` and writes out `data/samples.json` using utilities from
   `sample_processing.py`.
 

--- a/config/scripts/build_sample_catalog.py
+++ b/config/scripts/build_sample_catalog.py
@@ -1,4 +1,4 @@
-# aggregate_samples.py
+# build_sample_catalog.py
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
- rename aggregate_summary.py to build_sample_catalog.py for clearer purpose
- update config documentation to reference new script name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3142f53b0832e891c080cb233466e