### PR TITLE
Respect do_hadd flag in catalog builder

### DIFF
--- a/config/scripts/build_sample_catalog.py
+++ b/config/scripts/build_sample_catalog.py
@@ -320,8 +320,6 @@ def main() -> None:
             samples_out = []
             for sample in samples_in:
                 s = dict(sample)
-                # ignore legacy do_hadd/active if present
-                s.pop("do_hadd", None)
 
                 origin = s.get("sample_type", "unknown")
                 subset = infer_subset(s.get("sample_key", ""), origin)
@@ -343,7 +341,6 @@ def main() -> None:
                     new_vars = []
                     for dv in s["detector_variations"]:
                         dv2 = dict(dv)
-                        dv2.pop("do_hadd", None)
                         detvar = dv2.get("variation_type")
                         dv2["dataset_id"] = dataset_id(beamline, mode, run, origin, subset, stage_name, detvar)
                         process_sample_entry(


### PR DESCRIPTION
## Summary
- allow `do_hadd` flag to reach `process_sample_entry` in sample loop
- allow detector variation entries to forward `do_hadd`

## Testing
- `python -m pytest -q`
- `PYTHONPATH=/tmp python config/scripts/build_sample_catalog.py --recipe /tmp/test_recipe.json --runs run1 --xml /tmp/test_workflow.xml`

------
https://chatgpt.com/codex/tasks/task_e_68c3212ca104832eb69b8210d3a0d3e8