### PR TITLE
chore: standardize flow headers

### DIFF
--- a/include/rarexsec/flow/EventDisplayBuilder.h
+++ b/include/rarexsec/flow/EventDisplayBuilder.h
@@ -1,83 +1,127 @@
 #pragma once
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <rarexsec/plug/PluginSpec.h>
 #include <string>
 #include <vector>
-#include <optional>
-#include <nlohmann/json.hpp>
-#include <rarexsec/plug/PluginSpec.h>
 
 namespace analysis::dsl {
 
 struct DisplayMode {
-  std::string kind;
-  double overlay_alpha = 1.0;
+    std::string kind;
+    double overlay_alpha = 1.0;
 
-  DisplayMode& alpha(double a){ overlay_alpha = a; return *this; }
-  double alpha() const { return overlay_alpha; }
+    DisplayMode &alpha(double a) {
+        overlay_alpha = a;
+        return *this;
+    }
+    double alpha() const { return overlay_alpha; }
 };
-inline DisplayMode detector(){ return {"detector"}; }
-inline DisplayMode semantic(){ return {"semantic"}; }
-inline DisplayMode overlay(){ return {"overlay"}; }
+inline DisplayMode detector() { return {"detector"}; }
+inline DisplayMode semantic() { return {"semantic"}; }
+inline DisplayMode overlay() { return {"overlay"}; }
 
 enum class Direction { Asc, Desc };
-static constexpr Direction asc  = Direction::Asc;
+static constexpr Direction asc = Direction::Asc;
 static constexpr Direction desc = Direction::Desc;
 
 class EventDisplayBuilder {
-public:
-  EventDisplayBuilder& from(std::string s){ sample_ = std::move(s); return *this; }
-  EventDisplayBuilder& in(std::string r){ region_ = std::move(r); return *this; }
-  EventDisplayBuilder& where(std::string expr){ selection_expr_ = std::move(expr); return *this; }
+  public:
+    EventDisplayBuilder &from(std::string s) {
+        sample_ = std::move(s);
+        return *this;
+    }
+    EventDisplayBuilder &in(std::string r) {
+        region_ = std::move(r);
+        return *this;
+    }
+    EventDisplayBuilder &where(std::string expr) {
+        selection_expr_ = std::move(expr);
+        return *this;
+    }
 
-  EventDisplayBuilder& planes(std::vector<std::string> ps){ planes_ = std::move(ps); return *this; }
-  EventDisplayBuilder& size(int px){ image_size_ = px; return *this; }
-  EventDisplayBuilder& out(std::string dir){ out_dir_ = std::move(dir); return *this; }
-  EventDisplayBuilder& name(std::string pattern){ file_pattern_ = std::move(pattern); return *this; }
+    EventDisplayBuilder &planes(std::vector<std::string> ps) {
+        planes_ = std::move(ps);
+        return *this;
+    }
+    EventDisplayBuilder &size(int px) {
+        image_size_ = px;
+        return *this;
+    }
+    EventDisplayBuilder &out(std::string dir) {
+        out_dir_ = std::move(dir);
+        return *this;
+    }
+    EventDisplayBuilder &name(std::string pattern) {
+        file_pattern_ = std::move(pattern);
+        return *this;
+    }
 
-  EventDisplayBuilder& limit(int n){ n_events_ = n; return *this; }
-  EventDisplayBuilder& seed(unsigned s){ seed_ = s; return *this; }
-  EventDisplayBuilder& orderBy(std::string var, Direction d){
-    order_by_ = std::move(var); order_desc_ = (d == Direction::Desc); return *this;
-  }
-  EventDisplayBuilder& manifest(std::string path){ manifest_path_ = std::move(path); return *this; }
+    EventDisplayBuilder &limit(int n) {
+        n_events_ = n;
+        return *this;
+    }
+    EventDisplayBuilder &seed(unsigned s) {
+        seed_ = s;
+        return *this;
+    }
+    EventDisplayBuilder &orderBy(std::string var, Direction d) {
+        order_by_ = std::move(var);
+        order_desc_ = (d == Direction::Desc);
+        return *this;
+    }
+    EventDisplayBuilder &manifest(std::string path) {
+        manifest_path_ = std::move(path);
+        return *this;
+    }
 
-  EventDisplayBuilder& mode(DisplayMode m){ mode_ = m; return *this; }
+    EventDisplayBuilder &mode(DisplayMode m) {
+        mode_ = m;
+        return *this;
+    }
 
-  nlohmann::json to_json() const {
-    nlohmann::json j {
-      {"sample", sample_},
-      {"region", region_},
-      {"n_events", n_events_},
-      {"image_size", image_size_},
-      {"output_directory", out_dir_},
-      {"mode", mode_.kind}
-    };
-    if(mode_.kind == "overlay") j["overlay_alpha"] = mode_.alpha();
-    if(!planes_.empty()) j["planes"] = planes_;
-    if(selection_expr_) j["selection_expr"] = *selection_expr_;
-    if(!file_pattern_.empty()) j["file_pattern"] = file_pattern_;
-    if(seed_) j["seed"] = *seed_;
-    if(order_by_) { j["order_by"] = *order_by_; j["order_desc"] = order_desc_; }
-    if(!manifest_path_.empty()) j["manifest"] = manifest_path_;
-    return j;
-  }
+    nlohmann::json to_json() const {
+        nlohmann::json j{{"sample", sample_},
+                         {"region", region_},
+                         {"n_events", n_events_},
+                         {"image_size", image_size_},
+                         {"output_directory", out_dir_},
+                         {"mode", mode_.kind}};
+        if (mode_.kind == "overlay")
+            j["overlay_alpha"] = mode_.alpha();
+        if (!planes_.empty())
+            j["planes"] = planes_;
+        if (selection_expr_)
+            j["selection_expr"] = *selection_expr_;
+        if (!file_pattern_.empty())
+            j["file_pattern"] = file_pattern_;
+        if (seed_)
+            j["seed"] = *seed_;
+        if (order_by_) {
+            j["order_by"] = *order_by_;
+            j["order_desc"] = order_desc_;
+        }
+        if (!manifest_path_.empty())
+            j["manifest"] = manifest_path_;
+        return j;
+    }
 
-private:
-  std::string sample_;
-  std::string region_;
-  std::optional<std::string> selection_expr_;
-  std::vector<std::string> planes_;
-  int image_size_ = 800;
-  std::string out_dir_ = "./plots/event_displays";
-  std::string file_pattern_ = "{plane}_{run}_{sub}_{evt}";
-  int n_events_ = 1;
-  std::optional<unsigned> seed_;
-  std::optional<std::string> order_by_;
-  bool order_desc_ = true;
-  std::string manifest_path_;
-  DisplayMode mode_ = detector();
+  private:
+    std::string sample_;
+    std::string region_;
+    std::optional<std::string> selection_expr_;
+    std::vector<std::string> planes_;
+    int image_size_ = 800;
+    std::string out_dir_ = "./plots/event_displays";
+    std::string file_pattern_ = "{plane}_{run}_{sub}_{evt}";
+    int n_events_ = 1;
+    std::optional<unsigned> seed_;
+    std::optional<std::string> order_by_;
+    bool order_desc_ = true;
+    std::string manifest_path_;
+    DisplayMode mode_ = detector();
 };
 
-inline EventDisplayBuilder events(){ return {}; }
+inline EventDisplayBuilder events() { return {}; }
 
-} // namespace analysis::dsl
-
+}

--- a/include/rarexsec/flow/PlotBuilders.h
+++ b/include/rarexsec/flow/PlotBuilders.h
@@ -1,108 +1,177 @@
 #pragma once
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
-#include <nlohmann/json.hpp>
 
 namespace analysis::dsl {
 
 struct PlotDef {
-  std::string kind;             // "stack" | "roc" | ...
-  std::string variable;
-  std::string region;           // optional default
-  std::string signal_group;     // optional
-  std::string channel_column;   // ROC/perf
-  bool logy = false;
+    std::string kind;
+    std::string variable;
+    std::string region;
+    std::string signal_group;
+    std::string channel_column;
+    bool logy = false;
 
-  PlotDef& in(std::string r){ region = std::move(r); return *this; }
-  PlotDef& signal(std::string s){ signal_group = std::move(s); return *this; }
-  PlotDef& channel(std::string c){ channel_column = std::move(c); return *this; }
-  PlotDef& logY(){ logy = true; return *this; }
+    PlotDef &in(std::string r) {
+        region = std::move(r);
+        return *this;
+    }
+    PlotDef &signal(std::string s) {
+        signal_group = std::move(s);
+        return *this;
+    }
+    PlotDef &channel(std::string c) {
+        channel_column = std::move(c);
+        return *this;
+    }
+    PlotDef &logY() {
+        logy = true;
+        return *this;
+    }
 };
 
-inline PlotDef stack(std::string v){
-  return PlotDef{"stack", std::move(v), "", "", ""};
+inline PlotDef stack(std::string v) {
+    return PlotDef{"stack", std::move(v), "", "", ""};
 }
-inline PlotDef roc(std::string v){
-  return PlotDef{"roc", std::move(v), "", "", ""};
+inline PlotDef roc(std::string v) {
+    return PlotDef{"roc", std::move(v), "", "", ""};
 }
 
-// Cut direction helpers for Performance plots
 namespace dir {
-  static constexpr const char* gt = "GreaterThan";
-  static constexpr const char* lt = "LessThan";
+static constexpr const char *gt = "GreaterThan";
+static constexpr const char *lt = "LessThan";
 }
 
-// -------- Performance (PerformancePlotPlugin) -----------------------------
 class PerformanceBuilder {
-public:
-  explicit PerformanceBuilder(std::string var): variable_(std::move(var)) {}
+  public:
+    explicit PerformanceBuilder(std::string var) : variable_(std::move(var)) {}
 
-  PerformanceBuilder& in(std::string region){ region_ = std::move(region); return *this; }
-  PerformanceBuilder& channel(std::string col){ channel_column_ = std::move(col); return *this; }
-  PerformanceBuilder& signal(std::string grp){ signal_group_ = std::move(grp); return *this; }
-  PerformanceBuilder& bins(int n, double mn, double mx){ n_bins_=n; min_=mn; max_=mx; return *this; }
-  PerformanceBuilder& cut(const char* d){ cut_dir_ = d; return *this; }
-  PerformanceBuilder& name(std::string n){ plot_name_ = std::move(n); return *this; }
-  PerformanceBuilder& out(std::string d){ out_dir_ = std::move(d); return *this; }
-  PerformanceBuilder& where_all(std::vector<std::string> clauses){ clauses_ = std::move(clauses); return *this; }
+    PerformanceBuilder &in(std::string region) {
+        region_ = std::move(region);
+        return *this;
+    }
+    PerformanceBuilder &channel(std::string col) {
+        channel_column_ = std::move(col);
+        return *this;
+    }
+    PerformanceBuilder &signal(std::string grp) {
+        signal_group_ = std::move(grp);
+        return *this;
+    }
+    PerformanceBuilder &bins(int n, double mn, double mx) {
+        n_bins_ = n;
+        min_ = mn;
+        max_ = mx;
+        return *this;
+    }
+    PerformanceBuilder &cut(const char *d) {
+        cut_dir_ = d;
+        return *this;
+    }
+    PerformanceBuilder &name(std::string n) {
+        plot_name_ = std::move(n);
+        return *this;
+    }
+    PerformanceBuilder &out(std::string d) {
+        out_dir_ = std::move(d);
+        return *this;
+    }
+    PerformanceBuilder &where_all(std::vector<std::string> clauses) {
+        clauses_ = std::move(clauses);
+        return *this;
+    }
 
-  nlohmann::json to_json() const {
-    nlohmann::json j{
-      {"region", region_},
-      {"channel_column", channel_column_},
-      {"signal_group",   signal_group_},
-      {"variable",       variable_},
-      {"output_directory", out_dir_},
-      {"plot_name",        plot_name_},
-      {"n_bins", n_bins_}, {"min", min_}, {"max", max_},
-      {"cut_direction",    cut_dir_}
-    };
-    if (!clauses_.empty()) j["clauses"] = clauses_;
-    return j;
-  }
-private:
-  std::string region_, channel_column_, signal_group_, variable_;
-  std::string out_dir_{"plots"}, plot_name_{"performance_plot"};
-  int n_bins_{100}; double min_{0.0}, max_{1.0};
-  const char* cut_dir_ = dir::gt;
-  std::vector<std::string> clauses_;
+    nlohmann::json to_json() const {
+        nlohmann::json j{{"region", region_},
+                         {"channel_column", channel_column_},
+                         {"signal_group", signal_group_},
+                         {"variable", variable_},
+                         {"output_directory", out_dir_},
+                         {"plot_name", plot_name_},
+                         {"n_bins", n_bins_},
+                         {"min", min_},
+                         {"max", max_},
+                         {"cut_direction", cut_dir_}};
+        if (!clauses_.empty())
+            j["clauses"] = clauses_;
+        return j;
+    }
+
+  private:
+    std::string region_, channel_column_, signal_group_, variable_;
+    std::string out_dir_{"plots"}, plot_name_{"performance_plot"};
+    int n_bins_{100};
+    double min_{0.0}, max_{1.0};
+    const char *cut_dir_ = dir::gt;
+    std::vector<std::string> clauses_;
 };
-inline PerformanceBuilder perf(std::string variable){ return PerformanceBuilder(std::move(variable)); }
+inline PerformanceBuilder perf(std::string variable) {
+    return PerformanceBuilder(std::move(variable));
+}
 
-// -------- CutFlow (CutFlowPlotPlugin) -------------------------------------
 class CutFlowBuilder {
-public:
-  CutFlowBuilder& rule(std::string r){ selection_rule_ = std::move(r); return *this; }
-  CutFlowBuilder& in(std::string r){ region_ = std::move(r); return *this; }
-  CutFlowBuilder& signal(std::string g){ signal_group_ = std::move(g); return *this; }
-  CutFlowBuilder& channel(std::string c){ channel_column_ = std::move(c); return *this; }
-  CutFlowBuilder& initial(std::string lab){ initial_label_ = std::move(lab); return *this; }
-  CutFlowBuilder& steps(std::vector<std::string> c){ clauses_ = std::move(c); return *this; }
-  CutFlowBuilder& name(std::string n){ plot_name_ = std::move(n); return *this; }
-  CutFlowBuilder& logY(bool v=true){ log_y_ = v; return *this; }
-  CutFlowBuilder& out(std::string d){ out_dir_ = std::move(d); return *this; }
+  public:
+    CutFlowBuilder &rule(std::string r) {
+        selection_rule_ = std::move(r);
+        return *this;
+    }
+    CutFlowBuilder &in(std::string r) {
+        region_ = std::move(r);
+        return *this;
+    }
+    CutFlowBuilder &signal(std::string g) {
+        signal_group_ = std::move(g);
+        return *this;
+    }
+    CutFlowBuilder &channel(std::string c) {
+        channel_column_ = std::move(c);
+        return *this;
+    }
+    CutFlowBuilder &initial(std::string lab) {
+        initial_label_ = std::move(lab);
+        return *this;
+    }
+    CutFlowBuilder &steps(std::vector<std::string> c) {
+        clauses_ = std::move(c);
+        return *this;
+    }
+    CutFlowBuilder &name(std::string n) {
+        plot_name_ = std::move(n);
+        return *this;
+    }
+    CutFlowBuilder &logY(bool v = true) {
+        log_y_ = v;
+        return *this;
+    }
+    CutFlowBuilder &out(std::string d) {
+        out_dir_ = std::move(d);
+        return *this;
+    }
 
-  nlohmann::json to_json() const {
-    nlohmann::json j{
-      {"selection_rule", selection_rule_},
-      {"region", region_},
-      {"signal_group", signal_group_},
-      {"channel_column", channel_column_},
-      {"initial_label", initial_label_},
-      {"plot_name", plot_name_},
-      {"output_directory", out_dir_},
-      {"log_y", log_y_},
-    };
-    if (!clauses_.empty()) j["clauses"] = clauses_;
-    return j;
-  }
-private:
-  std::string selection_rule_, region_, signal_group_, channel_column_;
-  std::string initial_label_{"All events"}, plot_name_{"cutflow"};
-  std::string out_dir_{"plots"};
-  bool log_y_{false};
-  std::vector<std::string> clauses_;
+    nlohmann::json to_json() const {
+        nlohmann::json j{
+            {"selection_rule", selection_rule_},
+            {"region", region_},
+            {"signal_group", signal_group_},
+            {"channel_column", channel_column_},
+            {"initial_label", initial_label_},
+            {"plot_name", plot_name_},
+            {"output_directory", out_dir_},
+            {"log_y", log_y_},
+        };
+        if (!clauses_.empty())
+            j["clauses"] = clauses_;
+        return j;
+    }
+
+  private:
+    std::string selection_rule_, region_, signal_group_, channel_column_;
+    std::string initial_label_{"All events"}, plot_name_{"cutflow"};
+    std::string out_dir_{"plots"};
+    bool log_y_{false};
+    std::vector<std::string> clauses_;
 };
-inline CutFlowBuilder cutflow(){ return {}; }
+inline CutFlowBuilder cutflow() { return {}; }
 
-} // namespace analysis::dsl
+}

--- a/include/rarexsec/flow/SnapshotBuilder.h
+++ b/include/rarexsec/flow/SnapshotBuilder.h
@@ -1,27 +1,38 @@
 #pragma once
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
-#include <nlohmann/json.hpp>
 
 namespace analysis::dsl {
 
 class SnapshotBuilder {
-public:
-  SnapshotBuilder& rule(std::string r){ selection_rule_ = std::move(r); return *this; }
-  SnapshotBuilder& out(std::string d){ out_dir_ = std::move(d); return *this; }
-  SnapshotBuilder& columns(std::vector<std::string> cs){ cols_ = std::move(cs); return *this; }
+  public:
+    SnapshotBuilder &rule(std::string r) {
+        selection_rule_ = std::move(r);
+        return *this;
+    }
+    SnapshotBuilder &out(std::string d) {
+        out_dir_ = std::move(d);
+        return *this;
+    }
+    SnapshotBuilder &columns(std::vector<std::string> cs) {
+        cols_ = std::move(cs);
+        return *this;
+    }
 
-  nlohmann::json to_json() const {
-    nlohmann::json j{{"selection_rule", selection_rule_},
-                     {"output_directory", out_dir_}};
-    if (!cols_.empty()) j["columns"] = cols_;
-    return j;
-  }
-private:
-  std::string selection_rule_;
-  std::string out_dir_{"snapshots"};
-  std::vector<std::string> cols_;
+    nlohmann::json to_json() const {
+        nlohmann::json j{{"selection_rule", selection_rule_},
+                         {"output_directory", out_dir_}};
+        if (!cols_.empty())
+            j["columns"] = cols_;
+        return j;
+    }
+
+  private:
+    std::string selection_rule_;
+    std::string out_dir_{"snapshots"};
+    std::vector<std::string> cols_;
 };
-inline SnapshotBuilder snapshot(){ return {}; }
+inline SnapshotBuilder snapshot() { return {}; }
 
-} // namespace analysis::dsl
+}

--- a/include/rarexsec/flow/Study.h
+++ b/include/rarexsec/flow/Study.h
@@ -1,182 +1,218 @@
 #pragma once
-#include <string>
-#include <vector>
-#include <utility>
-#include <unordered_set>
 #include <nlohmann/json.hpp>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
-// The original implementation relied on the full plugin and preset
-// infrastructure.  To make the backend lighter we only depend on the basic
-// PluginSpec/Args types and directly build the specification lists used by the
-// PipelineRunner.  This keeps the user facing DSL intact while avoiding the
-// indirection of PipelineBuilder and PresetRegistry.
-#include <rarexsec/plug/PluginSpec.h>
-#include <rarexsec/plug/PluginArgs.h>
-#include <rarexsec/plug/PipelineRunner.h>
 #include "EventDisplayBuilder.h"
 #include "PlotBuilders.h"
 #include "SnapshotBuilder.h"
+#include <rarexsec/plug/PipelineRunner.h>
+#include <rarexsec/plug/PluginArgs.h>
+#include <rarexsec/plug/PluginSpec.h>
 
 namespace analysis::dsl {
 
 struct RegionDef {
-  std::string key;
-  std::string label;
-  std::string expr;
+    std::string key;
+    std::string label;
+    std::string expr;
 };
 
 struct VarDef {
-  std::string name;
-  std::string branch;
-  std::string label;
-  std::string stratum{"channel_definitions"};
-  std::vector<std::string> regions;
-  nlohmann::json binning{{"n", 100}, {"min", 0.0}, {"max", 1.0}};
+    std::string name;
+    std::string branch;
+    std::string label;
+    std::string stratum{"channel_definitions"};
+    std::vector<std::string> regions;
+    nlohmann::json binning{{"n", 100}, {"min", 0.0}, {"max", 1.0}};
 
-  explicit VarDef(std::string n) : name(std::move(n)), branch(name), label(name) {}
+    explicit VarDef(std::string n)
+        : name(std::move(n)), branch(name), label(name) {}
 
-  VarDef& as(std::string b) { branch = std::move(b); return *this; }
-  VarDef& titled(std::string l) { label = std::move(l); return *this; }
-  VarDef& stratify(std::string s) { stratum = std::move(s); return *this; }
-  VarDef& in(std::string r) { regions.push_back(std::move(r)); return *this; }
-  VarDef& bins_config(nlohmann::json b) { binning = std::move(b); return *this; }
-  VarDef& bins(int n, double mn, double mx) {
-    binning = {{"n", n}, {"min", mn}, {"max", mx}};
-    return *this;
-  }
+    VarDef &as(std::string b) {
+        branch = std::move(b);
+        return *this;
+    }
+    VarDef &titled(std::string l) {
+        label = std::move(l);
+        return *this;
+    }
+    VarDef &stratify(std::string s) {
+        stratum = std::move(s);
+        return *this;
+    }
+    VarDef &in(std::string r) {
+        regions.push_back(std::move(r));
+        return *this;
+    }
+    VarDef &bins_config(nlohmann::json b) {
+        binning = std::move(b);
+        return *this;
+    }
+    VarDef &bins(int n, double mn, double mx) {
+        binning = {{"n", n}, {"min", mn}, {"max", mx}};
+        return *this;
+    }
 };
 
 class Study {
-public:
-  explicit Study(std::string name) : name_(std::move(name)) {}
+  public:
+    explicit Study(std::string name) : name_(std::move(name)) {}
 
-  Study& data(std::string samples_json) {
-    samples_path_ = std::move(samples_json);
-    return *this;
-  }
-
-  Study& region(std::string key, std::string expression, std::string label="") {
-    if (label.empty()) label = key;
-    regions_.push_back(RegionDef{std::move(key), std::move(label), std::move(expression)});
-    return *this;
-  }
-
-  Study& var(std::string variable_name) {
-    variables_.emplace_back(std::move(variable_name));
-    return *this;
-  }
-
-  Study& var(VarDef v) {
-    variables_.push_back(std::move(v));
-    return *this;
-  }
-
-  Study& plot(PlotDef p) { plots_.push_back(std::move(p)); return *this; }
-  Study& plot(const PerformanceBuilder& p){ perf_.push_back(p.to_json()); return *this; }
-  Study& plot(const CutFlowBuilder& c){ cutflow_.push_back(c.to_json()); return *this; }
-  Study& display(const EventDisplayBuilder& ed){ displays_.push_back(ed.to_json()); return *this; }
-  Study& snapshot(const SnapshotBuilder& s){ snaps_.push_back(s.to_json()); return *this; }
-
-  void run(const std::string& out_root_path) const {
-    PluginSpecList analysis_specs;
-    PluginSpecList plot_specs;
-
-    // --- Regions -----------------------------------------------------------
-    nlohmann::json regions = nlohmann::json::array();
-    for (auto const& r : regions_) {
-      regions.push_back({
-          {"region_key", r.key},
-          {"label", r.label},
-          {"expression", r.expr}});
+    Study &data(std::string samples_json) {
+        samples_path_ = std::move(samples_json);
+        return *this;
     }
-    analysis_specs.push_back({"RegionsPlugin",
-                              {{"analysis_configs", {{"regions", regions}}}}});
 
-    // --- Variables ---------------------------------------------------------
-    if (!variables_.empty()) {
-      nlohmann::json vars_cfg = nlohmann::json::array();
-      for (auto const& v : variables_) {
-        nlohmann::json r = PluginArgs::array();
-        if (!v.regions.empty()) {
-          for (auto const& reg : v.regions) r.push_back(reg);
-        } else {
-          r.push_back(defaultRegionKey());
+    Study &region(std::string key, std::string expression,
+                  std::string label = "") {
+        if (label.empty())
+            label = key;
+        regions_.push_back(
+            RegionDef{std::move(key), std::move(label), std::move(expression)});
+        return *this;
+    }
+
+    Study &var(std::string variable_name) {
+        variables_.emplace_back(std::move(variable_name));
+        return *this;
+    }
+
+    Study &var(VarDef v) {
+        variables_.push_back(std::move(v));
+        return *this;
+    }
+
+    Study &plot(PlotDef p) {
+        plots_.push_back(std::move(p));
+        return *this;
+    }
+    Study &plot(const PerformanceBuilder &p) {
+        perf_.push_back(p.to_json());
+        return *this;
+    }
+    Study &plot(const CutFlowBuilder &c) {
+        cutflow_.push_back(c.to_json());
+        return *this;
+    }
+    Study &display(const EventDisplayBuilder &ed) {
+        displays_.push_back(ed.to_json());
+        return *this;
+    }
+    Study &snapshot(const SnapshotBuilder &s) {
+        snaps_.push_back(s.to_json());
+        return *this;
+    }
+
+    void run(const std::string &out_root_path) const {
+        PluginSpecList analysis_specs;
+        PluginSpecList plot_specs;
+
+        nlohmann::json regions = nlohmann::json::array();
+        for (auto const &r : regions_) {
+            regions.push_back({{"region_key", r.key},
+                               {"label", r.label},
+                               {"expression", r.expr}});
         }
-        vars_cfg.push_back({
-            {"name", v.name},
-            {"branch", v.branch},
-            {"label", v.label},
-            {"stratum", v.stratum},
-            {"regions", r},
-            {"bins", v.binning}});
-      }
-      analysis_specs.push_back({
-          "VariablesPlugin",
-          {{"analysis_configs", {{"variables", vars_cfg}}}}});
+        analysis_specs.push_back(
+            {"RegionsPlugin", {{"analysis_configs", {{"regions", regions}}}}});
+
+        if (!variables_.empty()) {
+            nlohmann::json vars_cfg = nlohmann::json::array();
+            for (auto const &v : variables_) {
+                nlohmann::json r = PluginArgs::array();
+                if (!v.regions.empty()) {
+                    for (auto const &reg : v.regions)
+                        r.push_back(reg);
+                } else {
+                    r.push_back(defaultRegionKey());
+                }
+                vars_cfg.push_back({{"name", v.name},
+                                    {"branch", v.branch},
+                                    {"label", v.label},
+                                    {"stratum", v.stratum},
+                                    {"regions", r},
+                                    {"bins", v.binning}});
+            }
+            analysis_specs.push_back(
+                {"VariablesPlugin",
+                 {{"analysis_configs", {{"variables", vars_cfg}}}}});
+        }
+
+        for (auto const &p : plots_) {
+            if (p.kind == "stack") {
+                PluginArgs args{
+                    {"plot_configs",
+                     {{"plots",
+                       nlohmann::json::array(
+                           {{{"variable", p.variable},
+                             {"region",
+                              p.region.empty() ? defaultRegionKey() : p.region},
+                             {"signal_group", p.signal_group},
+                             {"logy", p.logy}}})}}}};
+                plot_specs.push_back({"StackedPlotPlugin", std::move(args)});
+            } else if (p.kind == "roc") {
+                PluginArgs args{
+                    {"performance_plots",
+                     nlohmann::json::array(
+                         {{{"region",
+                            p.region.empty() ? defaultRegionKey() : p.region},
+                           {"channel_column", p.channel_column},
+                           {"signal_group", p.signal_group},
+                           {"variable", p.variable}}})}};
+                plot_specs.push_back(
+                    {"PerformancePlotPlugin", std::move(args)});
+            }
+        }
+
+        if (!perf_.empty())
+            plot_specs.push_back(
+                {"PerformancePlotPlugin",
+                 {{"plot_configs", {{"performance_plots", perf_}}}}});
+        if (!cutflow_.empty())
+            plot_specs.push_back({"CutFlowPlotPlugin",
+                                  {{"plot_configs", {{"plots", cutflow_}}}}});
+        if (!snaps_.empty())
+            analysis_specs.push_back(
+                {"SnapshotPlugin",
+                 {{"analysis_configs", {{"snapshots", snaps_}}}}});
+        if (!displays_.empty())
+            plot_specs.push_back(
+                {"EventDisplayPlugin",
+                 {{"plot_configs", {{"event_displays", displays_}}}}});
+
+        auto unique = [](PluginSpecList &v) {
+            std::unordered_set<std::string> seen;
+            PluginSpecList out;
+            out.reserve(v.size());
+            for (auto &s : v)
+                if (seen.insert(s.id).second)
+                    out.push_back(std::move(s));
+            v.swap(out);
+        };
+        unique(analysis_specs);
+        unique(plot_specs);
+
+        PipelineRunner runner(std::move(analysis_specs), std::move(plot_specs));
+        runner.run(samples_path_, out_root_path);
     }
 
-    // --- Simple plots ------------------------------------------------------
-    for (auto const& p : plots_) {
-      if (p.kind == "stack") {
-        PluginArgs args{{"plot_configs", {{"plots", nlohmann::json::array({{
-                                          {"variable", p.variable},
-                                          {"region", p.region.empty() ? defaultRegionKey() : p.region},
-                                          {"signal_group", p.signal_group},
-                                          {"logy", p.logy}}})}}}};
-        plot_specs.push_back({"StackedPlotPlugin", std::move(args)});
-      } else if (p.kind == "roc") {
-        PluginArgs args{{"performance_plots", nlohmann::json::array({{
-                                          {"region", p.region.empty() ? defaultRegionKey() : p.region},
-                                          {"channel_column", p.channel_column},
-                                          {"signal_group", p.signal_group},
-                                          {"variable", p.variable}}})}};
-        plot_specs.push_back({"PerformancePlotPlugin", std::move(args)});
-      }
+  private:
+    std::string defaultRegionKey() const {
+        return regions_.empty() ? std::string{} : regions_.front().key;
     }
 
-    if (!perf_.empty())
-      plot_specs.push_back({"PerformancePlotPlugin",
-                            {{"plot_configs", {{"performance_plots", perf_}}}}});
-    if (!cutflow_.empty())
-      plot_specs.push_back({"CutFlowPlotPlugin",
-                            {{"plot_configs", {{"plots", cutflow_}}}}});
-    if (!snaps_.empty())
-      analysis_specs.push_back({"SnapshotPlugin",
-                                {{"analysis_configs", {{"snapshots", snaps_}}}}});
-    if (!displays_.empty())
-      plot_specs.push_back({"EventDisplayPlugin",
-                            {{"plot_configs", {{"event_displays", displays_}}}}});
-
-    // De-duplicate specs by plugin id.
-    auto unique = [](PluginSpecList& v) {
-      std::unordered_set<std::string> seen;
-      PluginSpecList out;
-      out.reserve(v.size());
-      for (auto& s : v) if (seen.insert(s.id).second) out.push_back(std::move(s));
-      v.swap(out);
-    };
-    unique(analysis_specs);
-    unique(plot_specs);
-
-    PipelineRunner runner(std::move(analysis_specs), std::move(plot_specs));
-    runner.run(samples_path_, out_root_path);
-  }
-
-private:
-  std::string defaultRegionKey() const {
-    return regions_.empty() ? std::string{} : regions_.front().key;
-  }
-
-  std::string name_;
-  std::string samples_path_;
-  std::vector<RegionDef> regions_;
-  std::vector<VarDef> variables_;
-  std::vector<PlotDef> plots_;
-  std::vector<nlohmann::json> perf_;
-  std::vector<nlohmann::json> cutflow_;
-  std::vector<nlohmann::json> snaps_;
-  std::vector<nlohmann::json> displays_;
+    std::string name_;
+    std::string samples_path_;
+    std::vector<RegionDef> regions_;
+    std::vector<VarDef> variables_;
+    std::vector<PlotDef> plots_;
+    std::vector<nlohmann::json> perf_;
+    std::vector<nlohmann::json> cutflow_;
+    std::vector<nlohmann::json> snaps_;
+    std::vector<nlohmann::json> displays_;
 };
 
-} // namespace analysis::dsl
-
+}

--- a/include/rarexsec/flow/Where.h
+++ b/include/rarexsec/flow/Where.h
@@ -5,5 +5,4 @@ namespace analysis::dsl {
 
 inline std::string where(std::string expr) { return expr; }
 
-} // namespace analysis::dsl
-
+}


### PR DESCRIPTION
## Summary
- reformat flow DSL headers with 4-space indentation
- drop all comments from flow headers

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c328c474fc832eb8c1336f3638d8e6