### PR TITLE
Add study for slice cluster fraction

### DIFF
--- a/src/run/CMakeLists.txt
+++ b/src/run/CMakeLists.txt
@@ -4,6 +4,9 @@ add_executable(study_topo_score
 add_executable(study_all
   study_all.cpp)
 
+add_executable(study_slice_cluster_fraction
+  study_slice_cluster_fraction.cpp)
+
 target_link_libraries(study_topo_score PRIVATE
   libcore
   libplug
@@ -34,5 +37,20 @@ target_link_libraries(study_all PRIVATE
   TMVA
   dl)
 
-set_target_properties(study_topo_score study_all PROPERTIES
+target_link_libraries(study_slice_cluster_fraction PRIVATE
+  libcore
+  libplug
+  libdata
+  libhist
+  libplot
+  libsyst
+  libutils
+  Eigen3::Eigen
+  nlohmann_json::nlohmann_json
+  ${ROOT_LIBRARIES}
+  TBB::tbb
+  TMVA
+  dl)
+
+set_target_properties(study_topo_score study_all study_slice_cluster_fraction PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")

--- a/src/run/study_slice_cluster_fraction.cpp
+++ b/src/run/study_slice_cluster_fraction.cpp
@@ -1,0 +1,25 @@
+#include <rarexsec/flow/Study.h>
+#include <rarexsec/flow/Where.h>
+#include <rarexsec/flow/PlotBuilders.h>
+using namespace analysis::dsl;
+
+int main() {
+  auto study = Study("Slice Cluster Fraction")
+    .data("config/data/samples.json")
+    .region("SINGLE_SLICE", where("in_reco_fiducial && (num_slices == 1)"))
+    .var("slice_cluster_fraction")
+    .plot(stack("slice_cluster_fraction").in("SINGLE_SLICE").signal("inclusive_strange_channels").logY())
+    .plot(
+      perf("slice_cluster_fraction")
+        .in("SINGLE_SLICE")
+        .channel("incl_channel")
+        .signal("inclusive_strange_channels")
+        .bins(50, 0.0, 1.0)
+        .cut(dir::gt)
+        .name("slice_cluster_fraction_perf")
+        .out("plots/perf")
+    );
+
+  study.run("/tmp/slice_cluster_fraction.root");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add an example Study that analyses the `slice_cluster_fraction` variable with stack and performance plots
- build the new study via CMake

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOT package)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c32d8fc7a8832e94c2925344b19392