### PR TITLE
Add NuMu preselection processor and rule

### DIFF
--- a/include/rarexsec/core/SelectionRegistry.h
+++ b/include/rarexsec/core/SelectionRegistry.h
@@ -67,6 +67,8 @@ class SelectionRegistry {
 
             {"MUON", {"Muon Selection", {"has_muon"}}},
 
+            {"NUMUPRESEL", {"NuMu Preselection", {"numu_presel"}}},
+
             {"NUMU_CC", {"NuMu CC Selection", {"has_muon", "n_pfps_gen2 > 1"}}},
 
             {"NUMU_CC_BREAKDOWN",

--- a/include/rarexsec/data/AnalysisDataLoader.h
+++ b/include/rarexsec/data/AnalysisDataLoader.h
@@ -14,6 +14,7 @@
 #include <rarexsec/data/IEventProcessor.h>
 #include <rarexsec/utils/Logger.h>
 #include <rarexsec/data/MuonSelectionProcessor.h>
+#include <rarexsec/data/NumuPreselectionProcessor.h>
 #include <rarexsec/data/ReconstructionProcessor.h>
 #include <rarexsec/data/RunConfigRegistry.h>
 #include <rarexsec/data/SampleDefinition.h>
@@ -136,7 +137,8 @@ class AnalysisDataLoader {
                 std::make_unique<WeightProcessor>(sample_json, total_pot_, total_triggers_),
                 std::make_unique<TruthChannelProcessor>(), std::make_unique<BlipProcessor>(),
                 std::make_unique<MuonSelectionProcessor>(),
-                std::make_unique<ReconstructionProcessor>());
+                std::make_unique<ReconstructionProcessor>(),
+                std::make_unique<NumuPreselectionProcessor>());
             processors_.push_back(std::move(pipeline));
 
             auto &proc = *processors_.back();

--- a/include/rarexsec/data/NumuPreselectionProcessor.h
+++ b/include/rarexsec/data/NumuPreselectionProcessor.h
@@ -1,0 +1,36 @@
+#ifndef NUMU_PRESELECTION_PROCESSOR_H
+#define NUMU_PRESELECTION_PROCESSOR_H
+
+#include <rarexsec/data/IEventProcessor.h>
+#include <rarexsec/data/SampleTypes.h>
+
+namespace analysis {
+
+class NumuPreselectionProcessor : public IEventProcessor {
+public:
+  ROOT::RDF::RNode process(ROOT::RDF::RNode df,
+                           SampleOrigin st) const override {
+    auto proc_df =
+        df.Define("nslice", "num_slices")
+            .Define("_opfilter_pe_beam", "optical_filter_pe_beam")
+            .Define("_opfilter_pe_veto", "optical_filter_pe_veto")
+            .Define("reco_nu_vtx_sce_z", "reco_neutrino_vertex_sce_z")
+            .Define("bnbdata",
+                    [st]() { return st == SampleOrigin::kData ? 1 : 0; })
+            .Define("extdata",
+                    [st]() { return st == SampleOrigin::kExternal ? 1 : 0; });
+
+    auto presel_df = proc_df.Define(
+        "numu_presel",
+        "nslice == 1 && ((_opfilter_pe_beam > 0 && _opfilter_pe_veto < 20) || "
+        "bnbdata == 1 || extdata == 1) && "
+        "(reco_nu_vtx_sce_z < 675 || reco_nu_vtx_sce_z > 775) && "
+        "topological_score > 0.06");
+
+    return next_ ? next_->process(presel_df, st) : presel_df;
+  }
+};
+
+} // namespace analysis
+
+#endif


### PR DESCRIPTION
## Summary
- Implement `NumuPreselectionProcessor` to calculate `numu_presel` based on slice count, optical filter, fiducial z-gap and topological score
- Wire the NuMu preselection processor into the data loading chain
- Register `NUMUPRESEL` selection rule referencing the new `numu_presel` flag

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c332a2630c832eae2ef014225f4d3a