### PR TITLE
Add NuMu selection with CRT cuts

### DIFF
--- a/include/rarexsec/core/SelectionRegistry.h
+++ b/include/rarexsec/core/SelectionRegistry.h
@@ -93,6 +93,18 @@ class SelectionRegistry {
                "has_muon",
                "n_pfps_gen2 > 1"}}},
 
+            {"NUMUSEL",
+             {"NuMu Selection",
+              {"NUMUPRESEL",
+               "n_muons_tot > 0"}}},
+
+            {"NUMUSEL_CRT",
+             {"NuMu Selection with CRT cuts",
+              {"NUMUPRESEL",
+               "n_muons_tot > 0",
+               "(crtveto != 1 || crthitpe < 100)",
+               "_closestNuCosmicDist > 5"}}},
+
             {"ALL_EVENTS", {"All Events", {}}},
             {"NONE", {"No Preselection", {}}}};
 

--- a/include/rarexsec/data/MuonSelectionProcessor.h
+++ b/include/rarexsec/data/MuonSelectionProcessor.h
@@ -96,8 +96,9 @@ class MuonSelectionProcessor : public IEventProcessor {
                                           {"track_theta", "muon_mask"});
 
         auto count_df = mu_cos_df.Define("n_muons", "ROOT::VecOps::Sum(muon_mask)");
+        auto tot_df = count_df.Define("n_muons_tot", "n_muons");
 
-        return count_df.Define("has_muon", "n_muons > 0");
+        return tot_df.Define("has_muon", "n_muons > 0");
     }
 };
 

--- a/include/rarexsec/data/VariableRegistry.h
+++ b/include/rarexsec/data/VariableRegistry.h
@@ -250,6 +250,8 @@ private:
                                                "event_total_hits",
                                                "crt_veto",
                                                "crt_hit_pe",
+                                               "crtveto",
+                                               "crthitpe",
                                                "pfp_slice_indices",
                                                "backtracked_pdg_codes",
                                                "backtracked_energies",
@@ -304,7 +306,8 @@ private:
                                                "slice_topological_scores",
                                                "topological_score",
                                                "slice_cluster_fraction",
-                                               "slice_contained_fraction"};
+                                               "slice_contained_fraction",
+                                               "_closestNuCosmicDist"};
 
     return v;
   }
@@ -470,7 +473,8 @@ private:
     static const std::vector<std::string> v = {
         "in_reco_fiducial",  "n_pfps_gen2",
         "n_pfps_gen3",       "quality_event",
-        "n_muons",           "has_muon",
+        "n_muons",           "n_muons_tot",
+        "has_muon",
         "muon_track_length", "muon_track_costheta",
         "base_event_weight", "nominal_event_weight",
         "in_fiducial",       "mc_n_strange",


### PR DESCRIPTION
## Summary
- add NUMUSEL and NUMUSEL_CRT selection rules
- expose CRT and cosmic distance variables through variable registry
- provide n_muons_tot in muon selection processor

## Testing
- `cmake -S . -B build` *(fails: Could not find package ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c332a2c270832e81b839e38e250c24