### PR TITLE
Use fixed catalog filename for studies

### DIFF
--- a/config/scripts/build-catalog.py
+++ b/config/scripts/build-catalog.py
@@ -375,9 +375,10 @@ def main() -> None:
     outdir = args.outdir
     outdir.mkdir(parents=True, exist_ok=True)
 
-    beam_scope = summarize_beams_for_name(list(runs_out.keys()))
-    runs_token = runset_token(runs_to_process)
-    out_name = f"{project}.{beam_scope}.{runs_token}.catalog.{tag}-g{sha}.json"
+    # Use a stable name for the catalog output so that downstream study
+    # programs can reference it without needing to know run- or
+    # beam-specific tokens.
+    out_name = "samples.json"
     out_path = outdir / out_name
 
     catalog = {

--- a/src/run/study_all.cpp
+++ b/src/run/study_all.cpp
@@ -7,7 +7,7 @@ using namespace analysis::dsl;
 
 int main() {
   auto s = Study("NUMU CC end-to-end")
-    .data("config/data/samples.json")
+    .data("config/catalogs/samples.json")
     .region("NUMU_CC", where("QUALITY && NUMU_CC"))
     .var("topological_score")
     .plot(

--- a/src/run/study_slice_cluster_fraction.cpp
+++ b/src/run/study_slice_cluster_fraction.cpp
@@ -5,7 +5,7 @@ using namespace analysis::dsl;
 
 int main() {
   auto study = Study("Slice Cluster Fraction")
-    .data("config/data/samples.json")
+    .data("config/catalogs/samples.json")
     .region("SINGLE_SLICE", where("in_reco_fiducial && (num_slices == 1)"))
     .var("slice_cluster_fraction")
     .plot(stack("slice_cluster_fraction").in("SINGLE_SLICE").signal("inclusive_strange_channels").logY())

--- a/src/run/study_topo_score.cpp
+++ b/src/run/study_topo_score.cpp
@@ -6,7 +6,7 @@ using namespace analysis::dsl;
 
 int main() {
   auto study = Study("Topo score")
-    .data("config/data/samples.json")
+    .data("config/catalogs/samples.json")
     .region("PRE_TOPO", where("in_reco_fiducial && (num_slices == 1) && (optical_filter_pe_beam > 20)"))
     .var("topological_score")
     .plot(stack("topological_score").in("PRE_TOPO").signal("inclusive_strange_channels").logY())


### PR DESCRIPTION
## Summary
- Emit `samples.json` as the catalog output instead of dynamically named files
- Update example study programs to load `config/catalogs/samples.json`

## Testing
- `python -m py_compile config/scripts/build-catalog.py`
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68c333fb9414832e84a84f34682aba82