### PR TITLE
Check output directory before hadd

### DIFF
--- a/config/scripts/build-catalog.py
+++ b/config/scripts/build-catalog.py
@@ -248,6 +248,24 @@ def process_sample_entry(
         )
         return False
     output_file = processed_analysis_path / f"{sample_key}.root"
+    output_dir = output_file.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if not os.access(output_dir, os.W_OK):
+        print(
+            f"    Error: Output directory '{output_dir}' is not writable. "
+            "Ensure it exists and you have write permission.",
+            file=sys.stderr,
+        )
+        return False
+    if output_file.exists():
+        try:
+            output_file.unlink()
+        except OSError as exc:
+            print(
+                f"    Error: Cannot remove existing file '{output_file}': {exc}",
+                file=sys.stderr,
+            )
+            return False
     entry["relative_path"] = output_file.name
     root_files = list(list_root_files(input_dir))
     if not root_files:


### PR DESCRIPTION
## Summary
- Validate and create the HADD output directory, aborting early if it's not writable
- Remove existing output files before running `hadd`

## Testing
- `python -m py_compile config/scripts/build-catalog.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c33ca639b4832ea151d47bcdb4d009