### PR TITLE
Add study script for region event displays

### DIFF
--- a/src/run/CMakeLists.txt
+++ b/src/run/CMakeLists.txt
@@ -10,6 +10,9 @@ add_executable(study_slice_cluster_fraction
 add_executable(study_neutrino_vertex
   study_neutrino_vertex.cpp)
 
+add_executable(study_region_event_display
+  study_region_event_display.cpp)
+
 target_link_libraries(study_topo_score PRIVATE
   core
   plug
@@ -70,5 +73,20 @@ target_link_libraries(study_neutrino_vertex PRIVATE
   TMVA
   dl)
 
-set_target_properties(study_topo_score study_all study_slice_cluster_fraction study_neutrino_vertex PROPERTIES
+target_link_libraries(study_region_event_display PRIVATE
+  core
+  plug
+  data
+  hist
+  plot
+  syst
+  utils
+  Eigen3::Eigen
+  nlohmann_json::nlohmann_json
+  ${ROOT_LIBRARIES}
+  TBB::tbb
+  TMVA
+  dl)
+
+set_target_properties(study_topo_score study_all study_slice_cluster_fraction study_neutrino_vertex study_region_event_display PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")

--- a/src/run/study_region_event_display.cpp
+++ b/src/run/study_region_event_display.cpp
@@ -1,0 +1,25 @@
+#include <rarexsec/flow/Study.h>
+#include <rarexsec/flow/Where.h>
+#include <rarexsec/flow/EventDisplayBuilder.h>
+using namespace analysis::dsl;
+
+int main() {
+  auto study = Study("Region detector and semantic displays")
+    .data("config/catalogs/samples.json")
+    .region("NUMU_CC", where("QUALITY && NUMU_CC"))
+    .display(
+      events().from("numi_on").in("NUMU_CC")
+        .limit(5).size(800)
+        .mode(detector())
+        .out("plots/event_displays/detector")
+    )
+    .display(
+      events().from("numi_on").in("NUMU_CC")
+        .limit(5).size(800)
+        .mode(semantic())
+        .out("plots/event_displays/semantic")
+    );
+
+  study.run("/tmp/event_displays.root");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add study_region_event_display executable to create detector and semantic images for a selected NUMU_CC region
- wire new executable into run CMake configuration

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by ROOT)*


------
https://chatgpt.com/codex/tasks/task_e_68c33f0ff1d0832eaf63e07c17261d8f