### PR TITLE
Add analysis channel signal group

### DIFF
--- a/include/rarexsec/hist/StratifierRegistry.h
+++ b/include/rarexsec/hist/StratifierRegistry.h
@@ -60,7 +60,8 @@ public:
     signal_channel_groups_ = {
         {"inclusive_strange_channels", {10, 11}},
         {"exclusive_strange_channels",
-         {50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61}}};
+         {50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61}},
+        {"analysis_channel", {15, 16}}};
     log::info("StratifierRegistry::StratifierRegistry",
               "Registry initialised successfully.");
   }


### PR DESCRIPTION
## Summary
- add `analysis_channel` group pointing to keys 15 and 16

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c33fae2858832ebeb0e9074cd0a683