### PR TITLE
Add x/y fiducial cuts to numu preselection

### DIFF
--- a/include/rarexsec/data/NumuPreselectionProcessor.h
+++ b/include/rarexsec/data/NumuPreselectionProcessor.h
@@ -14,6 +14,8 @@ public:
         df.Define("nslice", "num_slices")
             .Define("_opfilter_pe_beam", "optical_filter_pe_beam")
             .Define("_opfilter_pe_veto", "optical_filter_pe_veto")
+            .Define("reco_nu_vtx_sce_x", "reco_neutrino_vertex_sce_x")
+            .Define("reco_nu_vtx_sce_y", "reco_neutrino_vertex_sce_y")
             .Define("reco_nu_vtx_sce_z", "reco_neutrino_vertex_sce_z")
             .Define("bnbdata",
                     [st]() { return st == SampleOrigin::kData ? 1 : 0; })
@@ -24,6 +26,8 @@ public:
         "numu_presel",
         "nslice == 1 && ((_opfilter_pe_beam > 0 && _opfilter_pe_veto < 20) || "
         "bnbdata == 1 || extdata == 1) && "
+        "reco_nu_vtx_sce_x > 5 && reco_nu_vtx_sce_x < 251 && "
+        "reco_nu_vtx_sce_y > -110 && reco_nu_vtx_sce_y < 110 && "
         "(reco_nu_vtx_sce_z < 675 || reco_nu_vtx_sce_z > 775) && "
         "topological_score > 0.06");
 

--- a/include/rarexsec/data/VariableRegistry.h
+++ b/include/rarexsec/data/VariableRegistry.h
@@ -470,6 +470,9 @@ private:
 
   static const std::vector<std::string> &processedEventVariables() {
     static const std::vector<std::string> v = {"in_reco_fiducial",
+                                               "reco_nu_vtx_sce_x",
+                                               "reco_nu_vtx_sce_y",
+                                               "reco_nu_vtx_sce_z",
                                                "n_pfps_gen2",
                                                "n_pfps_gen3",
                                                "quality_event",


### PR DESCRIPTION
## Summary
- include fiducial x/y vertex cuts in `NumuPreselectionProcessor`
- load new vertex coordinates in `VariableRegistry`

## Testing
- `source .setup.sh` *(fails: No such file or directory)*
- `cmake ..` *(fails: could not find ROOT package)*
- `ctest --output-on-failure` *(fails: No tests were found)*


------
https://chatgpt.com/codex/tasks/task_e_68c347b41580832e9e679058b25bdc93