### PR TITLE
Add run-dependent software trigger to MC preselection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Common selection regions can be added via presets. The framework provides a
 number of built‑in options:
 
 - `EMPTY` – no event selection (`NONE` rule)
-- `QUALITY` – requires the `quality_event` preselection
+- `QUALITY` – requires the `quality_event` preselection. For Monte Carlo
+  samples this includes a run‑dependent software trigger: runs before 16880 use
+  `software_trigger_pre` while later runs use `software_trigger_post`.
 - `MUON` – selects events containing a reconstructed muon
 - `NUMU_CC` – selects charged-current νµ events
 - `QUALITY_NUMU_CC` – combines the quality preselection with the νµ CC rule

--- a/include/rarexsec/data/NumuPreselectionProcessor.h
+++ b/include/rarexsec/data/NumuPreselectionProcessor.h
@@ -16,20 +16,36 @@ public:
             .Define("_opfilter_pe_veto", "optical_filter_pe_veto")
             .Define("reco_nu_vtx_sce_x", "reco_neutrino_vertex_sce_x")
             .Define("reco_nu_vtx_sce_y", "reco_neutrino_vertex_sce_y")
-            .Define("reco_nu_vtx_sce_z", "reco_neutrino_vertex_sce_z")
-            .Define("bnbdata",
-                    [st]() { return st == SampleOrigin::kData ? 1 : 0; })
-            .Define("extdata",
-                    [st]() { return st == SampleOrigin::kExternal ? 1 : 0; });
+            .Define("reco_nu_vtx_sce_z", "reco_neutrino_vertex_sce_z");
+
+    if (st == SampleOrigin::kMonteCarlo) {
+        proc_df = proc_df.Define(
+            "software_trigger",
+            [](unsigned run, int pre, int post) {
+                return run < 16880 ? pre > 0 : post > 0;
+            },
+            {"run", "software_trigger_pre", "software_trigger_post"});
+    } else {
+        proc_df = proc_df.Define("software_trigger", []() { return true; });
+    }
+
+    proc_df = proc_df
+                 .Define("bnbdata", [st]() { return st == SampleOrigin::kData ? 1 : 0; })
+                 .Define("extdata", [st]() { return st == SampleOrigin::kExternal ? 1 : 0; });
 
     auto presel_df = proc_df.Define(
         "numu_presel",
-        "nslice == 1 && ((_opfilter_pe_beam > 0 && _opfilter_pe_veto < 20) || "
-        "bnbdata == 1 || extdata == 1) && "
-        "reco_nu_vtx_sce_x > 5 && reco_nu_vtx_sce_x < 251 && "
-        "reco_nu_vtx_sce_y > -110 && reco_nu_vtx_sce_y < 110 && "
-        "(reco_nu_vtx_sce_z < 675 || reco_nu_vtx_sce_z > 775) && "
-        "topological_score > 0.06");
+        [st](int nslice, float pe_beam, float pe_veto, float x, float y, float z,
+             float topo, int bnb, int ext, bool swtrig) {
+            return nslice == 1 && ((pe_beam > 0 && pe_veto < 20) || bnb == 1 ||
+                                   ext == 1) &&
+                   x > 5 && x < 251 && y > -110 && y < 110 &&
+                   (z < 675 || z > 775) && topo > 0.06 &&
+                   (st == SampleOrigin::kMonteCarlo ? swtrig : true);
+        },
+        {"nslice", "_opfilter_pe_beam", "_opfilter_pe_veto",
+         "reco_nu_vtx_sce_x", "reco_nu_vtx_sce_y", "reco_nu_vtx_sce_z",
+         "topological_score", "bnbdata", "extdata", "software_trigger"});
 
     return next_ ? next_->process(presel_df, st) : presel_df;
   }

--- a/include/rarexsec/data/ReconstructionProcessor.h
+++ b/include/rarexsec/data/ReconstructionProcessor.h
@@ -25,13 +25,25 @@ class ReconstructionProcessor : public IEventProcessor {
                                       [](const ROOT::RVec<unsigned> &gens) { return ROOT::VecOps::Sum(gens == 3u); },
                                       {"pfp_generations"});
 
-        auto quality_df = gen3_df.Define(
+        ROOT::RDF::RNode swtrig_df(gen3_df);
+        if (st == SampleOrigin::kMonteCarlo) {
+            swtrig_df = gen3_df.Define(
+                "software_trigger",
+                [](unsigned run, int pre, int post) {
+                    return run < 16880 ? pre > 0 : post > 0;
+                },
+                {"run", "software_trigger_pre", "software_trigger_post"});
+        } else {
+            swtrig_df = gen3_df.Define("software_trigger", []() { return true; });
+        }
+
+        auto quality_df = swtrig_df.Define(
             "quality_event",
-            "in_reco_fiducial && "
-            "num_slices == 1 && "
-            "selection_pass && "
-            "optical_filter_pe_beam > 20"
-        );
+            [st](bool in_fid, int nslices, bool sel_pass, float pe_beam, bool swtrig) {
+                return in_fid && nslices == 1 && sel_pass && pe_beam > 20 &&
+                       (st == SampleOrigin::kMonteCarlo ? swtrig : true);
+            },
+            {"in_reco_fiducial", "num_slices", "selection_pass", "optical_filter_pe_beam", "software_trigger"});
 
         return next_ ? next_->process(quality_df, st) : quality_df;
     }


### PR DESCRIPTION
## Summary
- compute run-dependent software trigger for Monte Carlo samples using pre/post thresholds around run 16880
- require MC events to pass the software trigger in both quality and νμ preselection stages

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOT)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c34b49f790832e8b4d6d12e5fe4dfb