### PR TITLE
Remove muon momentum positivity requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,8 @@ The selection is defined in terms of the following variables:
   - start/end inside fiducial volume:
     - `muon_trk_start_x_v[i]`, `muon_trk_end_x_v[i]` in `[5, 251]` cm
     - `muon_trk_start_y_v[i]`, `muon_trk_end_y_v[i]` in `[-110, 110]` cm
-    - `muon_trk_start_z_v[i]`, `muon_trk_end_z_v[i]` in `[20, 986]` cm
+  - `muon_trk_start_z_v[i]`, `muon_trk_end_z_v[i]` in `[20, 986]` cm
   - `muon_pfp_generation_v[i] == 2`
-  - `muon_trk_mcs_muon_mom_v[i] > 0` and `muon_trk_range_muon_mom_v[i] > 0`
   - `pfp_num_plane_hits_U[i] > 0 && pfp_num_plane_hits_V[i] > 0 &&
     pfp_num_plane_hits_Y[i] > 0`
 - event-level: `has_muon` and `n_pfps_gen2 > 1`

--- a/include/rarexsec/data/MuonSelectionProcessor.h
+++ b/include/rarexsec/data/MuonSelectionProcessor.h
@@ -50,8 +50,7 @@ private:
                            end_z[i] > min_z && end_z[i] < max_z;
             mask[i] =
                 (scores[i] > 0.8f && llr[i] > 0.2f && lengths[i] > 10.0f &&
-                 dists[i] < 4.0f && gens[i] == 2 && mcs[i] > 0.0f &&
-                 range[i] > 0.0f && fid_start && fid_end &&
+                 dists[i] < 4.0f && gens[i] == 2 && fid_start && fid_end &&
                  hits_u[i] > 0 && hits_v[i] > 0 && hits_y[i] > 0);
           }
           return mask;


### PR DESCRIPTION
## Summary
- drop positive-momentum cuts from the muon selection mask
- update README to reflect removal of the muon momentum positivity requirement

## Testing
- `cmake .. && make -j$(nproc) && ctest` *(fails: Could not find package configuration file provided by "ROOT" - ROOT not installed)*
- `apt-get update` *(fails: repository InRelease files 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c34f70eb70832eb0e770ed013fd054