### PR TITLE
docs: explain blinded z fiducial cut

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The selection is defined in terms of the following variables:
 - neutrino vertex inside the fiducial volume:
   - `reco_nu_vtx_sce_x` in `[5, 251]` cm
   - `reco_nu_vtx_sce_y` in `[-110, 110]` cm
-  - `reco_nu_vtx_sce_z < 675` cm or `reco_nu_vtx_sce_z > 775` cm
+  - `reco_nu_vtx_sce_z` in `[20, 986]` cm, excluding the central region `675 < z < 775` cm for blinding
 - at least 70% of reconstructed hits in the neutrino slice are within the fiducial volume (contained fraction ≥ 0.7)
 - at least 50% of reconstructed hits in the neutrino slice are associated with a Pandora PFParticle (associated hits fraction ≥ 0.5)
 - `topological_score > 0.06`


### PR DESCRIPTION
## Summary
- Document z-bound fiducial range with 100 cm blinding in the README

## Testing
- `source .container.sh` (fails: /cvmfs/.../shell_apptainer.sh missing)
- `source .setup.sh` (fails: /cvmfs products and setup commands missing)
- `source .build.sh` (fails: FindROOT.cmake not found)


------
https://chatgpt.com/codex/tasks/task_e_68c3547d5870832e97cb37e9f97740a2