### PR TITLE
Refactor selection ordering and tighten FV

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,35 +10,36 @@ source .build.sh
 
 ## Muon neutrino selection
 
-The selection is defined in terms of the following variables:
+The selection is applied in the following order:
 
-- `nslice == 1`
-- optical filter requirement for simulated events:
-  `(_opfilter_pe_beam > 0 && _opfilter_pe_veto < 20)`
-  (bypassed when `bnbdata == 1` or `extdata == 1`)
-- run‑dependent software trigger for Monte Carlo (falls back to the standard
-  `software_trigger` for BNB samples when the run‑dependent columns are
-  unavailable):
-  - before run 16880: `software_trigger_pre > 0` (or `software_trigger_pre_ext > 0` for NuMI)
-  - after run 16880: `software_trigger_post > 0` (or `software_trigger_post_ext > 0` for NuMI)
-- neutrino vertex inside the fiducial volume:
-  - `reco_nu_vtx_sce_x` in `[5, 251]` cm
-  - `reco_nu_vtx_sce_y` in `[-110, 110]` cm
-  - `reco_nu_vtx_sce_z` in `[20, 986]` cm, excluding the central region `675 < z < 775` cm for blinding
-- at least 70% of reconstructed hits in the neutrino slice are within the fiducial volume (contained fraction ≥ 0.7)
-- at least 50% of reconstructed hits in the neutrino slice are associated with a Pandora PFParticle (associated hits fraction ≥ 0.5)
-- `topological_score > 0.06`
-- muon candidate requirements (index `i` over `muon_*` vectors):
-  - `muon_trk_score_v[i] > 0.8` and `muon_trk_llr_pid_v[i] > 0.2`
-  - `muon_trk_length_v[i] > 10` cm and `muon_trk_distance_v[i] < 4` cm
-  - start/end inside fiducial volume:
-    - `muon_trk_start_x_v[i]`, `muon_trk_end_x_v[i]` in `[5, 251]` cm
-    - `muon_trk_start_y_v[i]`, `muon_trk_end_y_v[i]` in `[-110, 110]` cm
-  - `muon_trk_start_z_v[i]`, `muon_trk_end_z_v[i]` in `[20, 986]` cm
-  - `muon_pfp_generation_v[i] == 2`
-  - `pfp_num_plane_hits_U[i] > 0 && pfp_num_plane_hits_V[i] > 0 &&
-    pfp_num_plane_hits_Y[i] > 0`
-- event-level: `has_muon` and `n_pfps_gen2 > 1`
+1. **Dataset and trigger gates**
+   - For simulated events (`bnbdata == 0 && extdata == 0`): `_opfilter_pe_beam > 0` and `_opfilter_pe_veto < 20`.
+   - Run-dependent software trigger for Monte Carlo (falls back to the standard `software_trigger` when the run-dependent columns are unavailable):
+     - before run 16880: `software_trigger_pre > 0` (or `software_trigger_pre_ext > 0` for NuMI)
+     - after run 16880: `software_trigger_post > 0` (or `software_trigger_post_ext > 0` for NuMI)
+2. **Basic reconstruction checks**
+   - `nslice == 1`
+   - `topological_score > 0.06`
+   - optionally prune early: `n_pfps_gen2 > 1`
+3. **Neutrino-vertex fiducial volume**
+   - `reco_nu_vtx_sce_x` in `[5, 251]` cm
+   - `reco_nu_vtx_sce_y` in `[-110, 110]` cm
+   - `reco_nu_vtx_sce_z` in `[20, 986]` cm, excluding the central region `675 < z < 775` cm for blinding
+4. **Slice-level quality**
+   - at least 70% of reconstructed hits in the neutrino slice are within the fiducial volume (contained fraction ≥ 0.7)
+   - at least 50% of reconstructed hits in the neutrino slice are associated with a Pandora PFParticle (associated hits fraction ≥ 0.5)
+5. **Muon candidate requirements** (index `i` over `muon_*` vectors)
+   - `muon_trk_score_v[i] > 0.8` and `muon_trk_llr_pid_v[i] > 0.2`
+   - `muon_trk_length_v[i] > 10` cm and `muon_trk_distance_v[i] < 4` cm
+   - start and end inside the fiducial volume:
+     - `muon_trk_start_x_v[i]`, `muon_trk_end_x_v[i]` in `[5, 251]` cm
+     - `muon_trk_start_y_v[i]`, `muon_trk_end_y_v[i]` in `[-110, 110]` cm
+     - `muon_trk_start_z_v[i]`, `muon_trk_end_z_v[i]` in `[20, 986]` cm
+   - `muon_pfp_generation_v[i] == 2`
+   - `pfp_num_plane_hits_U[i] > 0 && pfp_num_plane_hits_V[i] > 0 && pfp_num_plane_hits_Y[i] > 0`
+6. **Event pass**
+   - `has_muon` := any `i` satisfying step 5
+   - ensure `n_pfps_gen2 > 1` if not already applied in step 2
 
 ## Run Periods
 

--- a/include/rarexsec/data/ReconstructionProcessor.h
+++ b/include/rarexsec/data/ReconstructionProcessor.h
@@ -10,16 +10,19 @@ namespace analysis {
 class ReconstructionProcessor : public IEventProcessor {
   public:
     ROOT::RDF::RNode process(ROOT::RDF::RNode df, SampleOrigin st) const override {
-        auto fid_df = df.Define("in_reco_fiducial", "reco_neutrino_vertex_sce_x > 5 && "
-                                                    "reco_neutrino_vertex_sce_x < 251 && "
-                                                    "reco_neutrino_vertex_sce_y > -110 && "
-                                                    "reco_neutrino_vertex_sce_y < 110 && "
-                                                    "reco_neutrino_vertex_sce_z > 20 && "
-                                                    "reco_neutrino_vertex_sce_z < 986");
+        auto base_df = df.Define("in_reco_fiducial",
+                                  "reco_neutrino_vertex_sce_x > 5 && "
+                                  "reco_neutrino_vertex_sce_x < 251 && "
+                                  "reco_neutrino_vertex_sce_y > -110 && "
+                                  "reco_neutrino_vertex_sce_y < 110 && "
+                                  "reco_neutrino_vertex_sce_z > 20 && "
+                                  "reco_neutrino_vertex_sce_z < 986 && "
+                                  "(reco_neutrino_vertex_sce_z < 675 || reco_neutrino_vertex_sce_z > 775)");
 
-        auto gen2_df =
-            fid_df.Define("n_pfps_gen2", [](const ROOT::RVec<unsigned> &gens) { return ROOT::VecOps::Sum(gens == 2u); },
-                          {"pfp_generations"});
+        auto gen2_df = base_df.Define(
+            "n_pfps_gen2",
+            [](const ROOT::RVec<unsigned> &gens) { return ROOT::VecOps::Sum(gens == 2u); },
+            {"pfp_generations"});
 
         auto gen3_df = gen2_df.Define("n_pfps_gen3",
                                       [](const ROOT::RVec<unsigned> &gens) { return ROOT::VecOps::Sum(gens == 3u); },
@@ -50,14 +53,25 @@ class ReconstructionProcessor : public IEventProcessor {
 
         auto quality_df = swtrig_df.Define(
             "quality_event",
-            [st](bool in_fid, int nslices, bool sel_pass, float pe_beam, bool swtrig,
+            [st](float pe_beam, float pe_veto, bool swtrig, int nslices,
+                 float topo, int n_gen2, float x, float y, float z,
                  float contained_frac, float associated_frac) {
-                return in_fid && nslices == 1 && sel_pass && pe_beam > 20 &&
-                       contained_frac >= 0.7 && associated_frac >= 0.5 &&
-                       (st == SampleOrigin::kMonteCarlo ? swtrig : true);
+                bool dataset_gate = (st == SampleOrigin::kMonteCarlo)
+                                        ? (pe_beam > 0.f && pe_veto < 20.f)
+                                        : true;
+                bool basic_reco = nslices == 1 && topo > 0.06f && n_gen2 > 1;
+                bool fv = x > 5.f && x < 251.f && y > -110.f && y < 110.f &&
+                          z > 20.f && z < 986.f &&
+                          (z < 675.f || z > 775.f);
+                bool slice_quality = contained_frac >= 0.7f && associated_frac >= 0.5f;
+                return dataset_gate && (st == SampleOrigin::kMonteCarlo ? swtrig : true) &&
+                       basic_reco && fv && slice_quality;
             },
-            {"in_reco_fiducial", "num_slices", "selection_pass", "optical_filter_pe_beam",
-             "software_trigger", "slice_contained_fraction", "slice_cluster_fraction"});
+            {"optical_filter_pe_beam", "optical_filter_pe_veto", "software_trigger",
+             "num_slices", "topological_score", "n_pfps_gen2",
+             "reco_neutrino_vertex_sce_x", "reco_neutrino_vertex_sce_y",
+             "reco_neutrino_vertex_sce_z", "slice_contained_fraction",
+             "slice_cluster_fraction"});
 
         return next_ ? next_->process(quality_df, st) : quality_df;
     }


### PR DESCRIPTION
## Summary
- Reorder and early-prune nu-mu preselection: apply dataset gates, run-dependent trigger, basic reconstruction, and unified fiducial-volume with z-gap
- Apply consistent fiducial-volume bounds and z-gap in reconstruction quality checks; require n_pfps_gen2 and slice quality metrics after dataset/trigger gates
- Document reordered selection logic in README

## Testing
- ❌ `source .container.sh` (No such file or directory)
- ❌ `source .setup.sh` (No such file or directory)
- ❌ `source .build.sh` (missing ROOT package)


------
https://chatgpt.com/codex/tasks/task_e_68c3586b25dc832eb78102c8c8d08fc4