### PR TITLE
Add study for muon neutrino CC selection and purity

### DIFF
--- a/src/run/CMakeLists.txt
+++ b/src/run/CMakeLists.txt
@@ -12,9 +12,12 @@ add_executable(study_neutrino_vertex
 
 add_executable(study_numucc_snapshot
   study_numucc_snapshot.cpp)
-  
+
 add_executable(study_region_event_display
   study_region_event_display.cpp)
+
+add_executable(study_numucc_selection
+  study_numucc_selection.cpp)
 
 target_link_libraries(study_topo_score PRIVATE
   core
@@ -107,6 +110,22 @@ target_link_libraries(study_region_event_display PRIVATE
   TMVA
   dl)
 
+target_link_libraries(study_numucc_selection PRIVATE
+  core
+  plug
+  data
+  hist
+  plot
+  syst
+  utils
+  Eigen3::Eigen
+  nlohmann_json::nlohmann_json
+  ${ROOT_LIBRARIES}
+  TBB::tbb
+  TMVA
+  dl)
+
 
 
 set_target_properties(study_topo_score study_all study_slice_cluster_fraction study_neutrino_vertex study_region_event_display study_numucc_snapshot PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
+set_target_properties(study_numucc_selection PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")

--- a/src/run/study_numucc_selection.cpp
+++ b/src/run/study_numucc_selection.cpp
@@ -1,0 +1,23 @@
+#include <rarexsec/flow/PlotBuilders.h>
+#include <rarexsec/flow/Study.h>
+#include <rarexsec/flow/Where.h>
+
+using namespace analysis::dsl;
+
+int main() {
+  auto s = Study("NuMu CC selection and purity")
+               .data("config/catalogs/samples.json")
+               .region("NUMU_CC", where("QUALITY && NUMU_CC"))
+               .plot(cutflow()
+                         .rule("NUMU_CC")
+                         .in("NUMU_CC")
+                         .channel("incl_channel")
+                         .signal("inclusive_strange_channels")
+                         .initial("All events")
+                         .steps({"QUALITY", "VTX", "TOPO", "PID"})
+                         .name("numu_cc_selection")
+                         .out("plots/selection"));
+
+  s.run("/tmp/numu_cc_selection.root");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Add standalone study to produce cutflow with efficiency and purity for NuMu CC selection
- Register new executable in build system

## Testing
- `bash -lc 'source .build.sh'` *(fails: CMake cannot find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c35c3d5f34832e84c8c05f085a48ac