### PR TITLE
Skip catalog entries for runs with no samples

### DIFF
--- a/config/scripts/build-catalog.py
+++ b/config/scripts/build-catalog.py
@@ -450,6 +450,10 @@ def main() -> None:
                 logging.warning("No POT provided for %s:%s (on-beam).", beam_key, run)
 
             samples_in = run_details.get("samples", []) or []
+            if not samples_in:
+                logging.info("Skipping %s:%s (no samples).", beam_key, run)
+                continue
+
             samples_out = []
 
             for sample in samples_in:


### PR DESCRIPTION
## Summary
- avoid adding run configurations with empty sample lists to generated catalogs

## Testing
- `python -m py_compile config/scripts/build-catalog.py`
- `python config/scripts/build-catalog.py --recipe config/analysis-recipe.json` *(fails: ModuleNotFoundError: No module named 'uproot')*
- `pip install uproot` *(fails: Could not find a version that satisfies the requirement uproot)*

------
https://chatgpt.com/codex/tasks/task_e_68c36037a9bc832eb34626ffea6e04a0