### PR TITLE
Fix run target properties configuration

### DIFF
--- a/src/run/CMakeLists.txt
+++ b/src/run/CMakeLists.txt
@@ -143,5 +143,20 @@ target_link_libraries(study_numucc_selection PRIVATE
   dl)
 
 
-set_target_properties(study_topo_score study_all study_slice_cluster_fraction study_neutrino_vertex study_region_event_display study_numucc_snapsho study_neutrino_energy PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
-set_target_properties(study_numucc_selection PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin")
+set_target_properties(
+  study_topo_score
+  study_all
+  study_slice_cluster_fraction
+  study_neutrino_vertex
+  study_region_event_display
+  study_numucc_snapshot
+  study_neutrino_energy
+  PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin"
+)
+
+set_target_properties(
+  study_numucc_selection
+  PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin"
+)


### PR DESCRIPTION
## Summary
- format `set_target_properties` in `src/run` to correctly list run targets and set a common runtime output directory

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3665f9964832e8a22601e1bfe6b95