### PR TITLE
Guard software_trigger redefinition when branch exists

### DIFF
--- a/include/rarexsec/data/NumuPreselectionProcessor.h
+++ b/include/rarexsec/data/NumuPreselectionProcessor.h
@@ -45,7 +45,7 @@ public:
       } else if (!proc_df.HasColumn("software_trigger")) {
         proc_df = proc_df.Define("software_trigger", []() { return true; });
       }
-    } else {
+    } else if (!proc_df.HasColumn("software_trigger")) {
       proc_df = proc_df.Define("software_trigger", []() { return true; });
     }
 

--- a/include/rarexsec/data/ReconstructionProcessor.h
+++ b/include/rarexsec/data/ReconstructionProcessor.h
@@ -47,7 +47,7 @@ class ReconstructionProcessor : public IEventProcessor {
             } else if (!gen3_df.HasColumn("software_trigger")) {
                 swtrig_df = gen3_df.Define("software_trigger", []() { return true; });
             }
-        } else {
+        } else if (!gen3_df.HasColumn("software_trigger")) {
             swtrig_df = gen3_df.Define("software_trigger", []() { return true; });
         }
 


### PR DESCRIPTION
## Summary
- Avoid redefining `software_trigger` when the branch already exists in `ReconstructionProcessor`
- Skip adding `software_trigger` for data samples if present in `NumuPreselectionProcessor`

## Testing
- `cmake -S . -B build` *(fails: could not find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c3698dc22c832eb5bce3c0d32c6f3a