### PR TITLE
Expand NUMU_CC region expressions to explicit filters

### DIFF
--- a/src/run/study_all.cpp
+++ b/src/run/study_all.cpp
@@ -8,7 +8,8 @@ using namespace analysis::dsl;
 int main() {
   auto s = Study("NUMU CC end-to-end")
     .data("config/catalogs/samples.json")
-    .region("NUMU_CC", where("QUALITY && NUMU_CC"))
+    // Use explicit filter expression instead of registry keys
+    .region("NUMU_CC", where("quality_event && has_muon"))
     .var("topological_score")
     .plot(
       perf("topological_score")

--- a/src/run/study_numucc_selection.cpp
+++ b/src/run/study_numucc_selection.cpp
@@ -7,7 +7,8 @@ using namespace analysis::dsl;
 int main() {
   auto s = Study("NuMu CC selection and purity")
                .data("config/catalogs/samples.json")
-               .region("NUMU_CC", where("QUALITY && NUMU_CC"))
+               // Expand selection rule names to concrete expression
+               .region("NUMU_CC", where("quality_event && has_muon"))
                .plot(cutflow()
                          .rule("NUMU_CC")
                          .in("NUMU_CC")

--- a/src/run/study_numucc_snapshot.cpp
+++ b/src/run/study_numucc_snapshot.cpp
@@ -8,7 +8,9 @@ int main() {
   auto study =
       Study("NuMu CC snapshot")
           .data("config/catalogs/samples.json")
-          .region("NUMU_CC", where("QUALITY && NUMU_CC"))
+          // Replace shorthand rule names with explicit selection expression
+          // so ROOT can compile the filter without undefined identifiers.
+          .region("NUMU_CC", where("quality_event && has_muon"))
           .var("run")
           .var("sub")
           .var("evt")

--- a/src/run/study_region_event_display.cpp
+++ b/src/run/study_region_event_display.cpp
@@ -6,7 +6,9 @@ using namespace analysis::dsl;
 int main() {
   auto study = Study("Region detector and semantic displays")
     .data("config/catalogs/samples.json")
-    .region("NUMU_CC", where("QUALITY && NUMU_CC"))
+    // Use concrete selection expression instead of symbolic rule names
+    // to avoid ROOT JIT errors from undefined identifiers.
+    .region("NUMU_CC", where("quality_event && has_muon"))
     .display(
       events().from("numi_on").in("NUMU_CC")
         .limit(5).size(800)


### PR DESCRIPTION
## Summary
- Replace symbolic selection rule names with explicit `quality_event && has_muon` expression in various study scripts to prevent ROOT JIT compile errors.

## Testing
- ⚠️ `cmake -S . -B build` *(missing ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c36bd6f21c832e98787b5a8ba577f0