### PR TITLE
Ensure muon selection defines has_muon when track data absent

### DIFF
--- a/include/rarexsec/data/MuonSelectionProcessor.h
+++ b/include/rarexsec/data/MuonSelectionProcessor.h
@@ -14,7 +14,9 @@ public:
   ROOT::RDF::RNode process(ROOT::RDF::RNode df,
                            SampleOrigin st) const override {
     if (!df.HasColumn("trk_score_v")) {
-      return next_ ? next_->process(df, st) : df;
+      auto no_mu_df = df.Define("n_muons_tot", []() { return 0; })
+                          .Define("has_muon", []() { return false; });
+      return next_ ? next_->process(no_mu_df, st) : no_mu_df;
     }
 
     auto muon_mask_df = this->buildMuonMask(df);


### PR DESCRIPTION
## Summary
- Avoid undefined identifier errors by defining `n_muons_tot` and `has_muon` even when track information is missing

## Testing
- ❌ `cmake -S . -B build` *(missing ROOT dependency)*


------
https://chatgpt.com/codex/tasks/task_e_68c3fe92aed8832ea7cbb4dcfbd53376