### PR TITLE
Fix duplicate software trigger definition

### DIFF
--- a/include/rarexsec/data/NumuPreselectionProcessor.h
+++ b/include/rarexsec/data/NumuPreselectionProcessor.h
@@ -43,13 +43,13 @@ public:
             },
             {"run", "software_trigger_pre", "software_trigger_post"});
       } else if (proc_df.HasColumn("software_trigger")) {
-        proc_df = proc_df.Define("software_trigger", "software_trigger != 0");
+        proc_df = proc_df.Redefine("software_trigger", "software_trigger != 0");
       } else {
         proc_df = proc_df.Define("software_trigger", []() { return true; });
       }
     } else {
       if (proc_df.HasColumn("software_trigger")) {
-        proc_df = proc_df.Define("software_trigger", "software_trigger != 0");
+        proc_df = proc_df.Redefine("software_trigger", "software_trigger != 0");
       } else {
         proc_df = proc_df.Define("software_trigger", []() { return true; });
       }


### PR DESCRIPTION
## Summary
- avoid redefining `software_trigger` via `Define` in preselection processor by using `Redefine`

## Testing
- `cmake .. && make -j4 && ctest --output-on-failure` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68c4046ccf74832e91b96cc3a123c6fb