### PR TITLE
Handle missing sample in EventDisplayPlugin

### DIFF
--- a/src/plug/plotting/EventDisplayPlugin.cc
+++ b/src/plug/plotting/EventDisplayPlugin.cc
@@ -84,7 +84,14 @@ class EventDisplayPlugin : public IPlotPlugin {
             return;
         }
         for (auto const &cfg : configs_) {
-            auto &sample = loader_->getSampleFrames().at(SampleKey{cfg.sample});
+            auto &frames = loader_->getSampleFrames();
+            auto skey = SampleKey{cfg.sample};
+            auto it = frames.find(skey);
+            if (it == frames.end()) {
+                log::error("EventDisplayPlugin", "Unknown sample:", cfg.sample);
+                continue;
+            }
+            auto &sample = it->second;
             auto df = sample.nominal_node_;
 
             std::string filter = cfg.selection.str();


### PR DESCRIPTION
## Summary
- prevent EventDisplayPlugin from throwing when configured sample is absent

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: CMake could not find ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c406cc4fe0832ebfc216bceb226574