### PR TITLE
Make CutFlow calculations optional via plugin

### DIFF
--- a/include/rarexsec/core/AnalysisRunner.h
+++ b/include/rarexsec/core/AnalysisRunner.h
@@ -21,7 +21,6 @@
 #include <rarexsec/core/VariableResult.h>
 
 #include <rarexsec/core/SampleProcessorFactory.h>
-#include <rarexsec/core/CutFlowCalculator.h>
 #include <rarexsec/core/VariableProcessor.h>
 
 #include <rarexsec/plug/PluginAliases.h>
@@ -43,7 +42,6 @@ public:
       analysis_definition_(selection_registry_),
       systematics_processor_(sys_proc),
       sample_processor_factory_(data_loader_),
-      cut_flow_calculator_(data_loader_, analysis_definition_),
       histogram_factory_(std::move(factory)),
       variable_processor_(analysis_definition_, systematics_processor_, *histogram_factory_) {
 
@@ -84,7 +82,6 @@ public:
       auto [sample_processors, monte_carlo_nodes] =
           sample_processor_factory_.create(region_handle, region_analysis);
 
-      cut_flow_calculator_.compute(region_handle, region_analysis);
       variable_processor_.process(region_handle, region_analysis,
                                   sample_processors, monte_carlo_nodes);
 
@@ -118,7 +115,6 @@ private:
   SystematicsProcessor &systematics_processor_;
 
   SampleProcessorFactory<AnalysisDataLoader> sample_processor_factory_;
-  CutFlowCalculator<AnalysisDataLoader> cut_flow_calculator_;
   std::unique_ptr<HistogramFactory> histogram_factory_;
   VariableProcessor<SystematicsProcessor> variable_processor_;
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,7 @@ endfunction()
 add_plugin(RegionsPlugin plug/analytics/RegionsPlugin.cc "")
 add_plugin(SnapshotPlugin plug/analytics/SnapshotPlugin.cc "")
 add_plugin(VariablesPlugin plug/analytics/VariablesPlugin.cc "")
+add_plugin(CutFlowPlugin plug/analytics/CutFlowPlugin.cc "")
 add_plugin(StrategySelectionPlugin plug/systematics/StrategySelectionPlugin.cc "")
 
 add_plugin(EventDisplayPlugin plug/plotting/EventDisplayPlugin.cc "")

--- a/src/plug/analytics/CutFlowPlugin.cc
+++ b/src/plug/analytics/CutFlowPlugin.cc
@@ -1,0 +1,51 @@
+#include <rarexsec/plug/PluginRegistry.h>
+#include <rarexsec/plug/IAnalysisPlugin.h>
+#include <rarexsec/core/CutFlowCalculator.h>
+#include <rarexsec/core/AnalysisDefinition.h>
+#include <rarexsec/data/AnalysisDataLoader.h>
+#include <rarexsec/core/AnalysisResult.h>
+#include <rarexsec/utils/Logger.h>
+
+namespace analysis {
+
+class CutFlowPlugin : public IAnalysisPlugin {
+public:
+  CutFlowPlugin(const PluginArgs&, AnalysisDataLoader* ldr)
+      : loader_(ldr) {}
+
+  void onInitialisation(AnalysisDefinition& def, const SelectionRegistry&) override {
+    definition_ = &def;
+  }
+
+  void onFinalisation(const AnalysisResult& results) override {
+    if (!loader_ || !definition_) {
+      log::error("CutFlowPlugin::onFinalisation", "Missing context or definition");
+      return;
+    }
+    CutFlowCalculator<AnalysisDataLoader> calculator(*loader_, *definition_);
+    auto& mutable_results = const_cast<AnalysisResult&>(results);
+    auto& regions = mutable_results.regions();
+    for (const auto& region_handle : definition_->regions()) {
+      auto it = regions.find(region_handle.key_);
+      if (it != regions.end()) {
+        calculator.compute(region_handle, it->second);
+      }
+    }
+  }
+
+private:
+  AnalysisDataLoader* loader_{};
+  AnalysisDefinition* definition_{};
+};
+
+} // namespace analysis
+
+ANALYSIS_REGISTER_PLUGIN(analysis::IAnalysisPlugin, analysis::AnalysisDataLoader,
+                         "CutFlowPlugin", analysis::CutFlowPlugin)
+
+#ifdef BUILD_PLUGIN
+extern "C" analysis::IAnalysisPlugin* createCutFlowPlugin(const analysis::PluginArgs& args) {
+  return new analysis::CutFlowPlugin(args, nullptr);
+}
+#endif
+


### PR DESCRIPTION
## Summary
- Introduce `CutFlowPlugin` analysis plugin that runs the existing `CutFlowCalculator` when configured
- Stop calling the cut-flow calculator in `AnalysisRunner` so cut flows are computed only if the plugin is enabled
- Register the new plugin in the build system

## Testing
- `cmake -S . -B build` *(fails: could not find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c409f90ffc832e982f5b2e1a0fd9c9