### PR TITLE
Skip systematics setup when unused

### DIFF
--- a/include/rarexsec/core/VariableProcessor.h
+++ b/include/rarexsec/core/VariableProcessor.h
@@ -7,100 +7,101 @@
 
 #include <rarexsec/core/AnalysisDefinition.h>
 #include <rarexsec/core/AnalysisResult.h>
-#include <rarexsec/hist/HistogramFactory.h>
 #include <rarexsec/core/ISampleProcessor.h>
-#include <rarexsec/utils/Logger.h>
 #include <rarexsec/core/RegionAnalysis.h>
 #include <rarexsec/core/RegionHandle.h>
 #include <rarexsec/core/VariableResult.h>
+#include <rarexsec/hist/HistogramFactory.h>
+#include <rarexsec/utils/Logger.h>
 
 #include <ROOT/RDataFrame.hxx>
 
 namespace analysis {
-    
+
 template <typename SysProc> class VariableProcessor {
-  public:
-    VariableProcessor(AnalysisDefinition& def, SysProc& sys_proc,
-                        HistogramFactory& factory)
-        : analysis_definition_(def),
-            systematics_processor_(sys_proc),
-            histogram_factory_(factory) {}
+public:
+  VariableProcessor(AnalysisDefinition &def, SysProc &sys_proc,
+                    HistogramFactory &factory)
+      : analysis_definition_(def), systematics_processor_(sys_proc),
+        histogram_factory_(factory) {}
 
-    void process(
-        const RegionHandle& region_handle,
-        RegionAnalysis& region_analysis,
-        std::unordered_map<SampleKey, std::unique_ptr<ISampleProcessor>>& sample_processors,
-        std::unordered_map<SampleKey, ROOT::RDF::RNode>& monte_carlo_nodes) {
+  void
+  process(const RegionHandle &region_handle, RegionAnalysis &region_analysis,
+          std::unordered_map<SampleKey, std::unique_ptr<ISampleProcessor>>
+              &sample_processors,
+          std::unordered_map<SampleKey, ROOT::RDF::RNode> &monte_carlo_nodes) {
+    log::info("VariableProcessor::process",
+              "Iterating across observable variables...");
+
+    const auto &vars = region_handle.vars();
+    const auto total_vars = vars.size();
+
+    for (std::size_t index = 0; index < total_vars; ++index) {
+      const auto &var_key = vars[index];
+      const auto &variable_handle = analysis_definition_.variable(var_key);
+      const auto &binning = variable_handle.binning();
+      const auto model = binning.toTH1DModel();
+
+      VariableResult result;
+      result.binning_ = binning;
+
+      log::info("VariableProcessor::process", "Deploying variable pipeline (",
+                index + 1, "/", total_vars, "):", var_key.str());
+
+      log::info("VariableProcessor::process", "Executing sample processors...");
+      for (auto &entry : sample_processors) {
+        entry.second->book(histogram_factory_, binning, model);
+      }
+
+      if (systematics_processor_.hasStrategies()) {
         log::info("VariableProcessor::process",
-                    "Iterating across observable variables...");
-
-        const auto& vars = region_handle.vars();
-        const auto total_vars = vars.size();
-
-        for (std::size_t index = 0; index < total_vars; ++index) {
-            const auto& var_key = vars[index];
-            const auto& variable_handle = analysis_definition_.variable(var_key);
-            const auto& binning = variable_handle.binning();
-            const auto model = binning.toTH1DModel();
-
-            VariableResult result;
-            result.binning_ = binning;
-
-            log::info("VariableProcessor::process",
-                        "Deploying variable pipeline (", index + 1, "/", total_vars,
-                        "):", var_key.str());
-
-            log::info("VariableProcessor::process", "Executing sample processors...");
-            for (auto &entry : sample_processors) {
-                entry.second->book(histogram_factory_, binning, model);
-            }
-
-            log::info("VariableProcessor::process", "Registering systematic variations...");
-            for (auto &entry : monte_carlo_nodes) {
-                systematics_processor_.bookSystematics(
-                    entry.first, entry.second, binning, model);
-            }
-
-            log::info("VariableProcessor::process", "Persisting results...");
-            std::size_t total_handles = 0;
-            for (auto &entry : sample_processors) {
-                total_handles += entry.second->expectedHandleCount();
-            }
-            std::vector<ROOT::RDF::RResultHandle> handles;
-            handles.reserve(total_handles);
-            for (auto &entry : sample_processors) {
-                entry.second->collectHandles(handles);
-            }
-            ROOT::RDF::RunGraphs(handles);
-            for (auto &entry : sample_processors) {
-                entry.second->contributeTo(result);
-            }
-
-            if (systematics_processor_.hasSystematics() || !result.raw_detvar_hists_.empty()) {
-                log::info("VariableProcessor::process",
-                          "Computing systematic covariances");
-                //systematics_processor_.processSystematics(result);
-            } else {
-                log::info("VariableProcessor::process",
-                          "No systematics found. Skipping covariance calculation.");
-            }
-            systematics_processor_.clearFutures();
-
-            AnalysisResult::printSummary(result);
-            region_analysis.addFinalVariable(var_key, std::move(result));
-
-            log::info("VariableProcessor::process",
-                        "Variable pipeline concluded (", index + 1, "/", total_vars,
-                        "):", var_key.str());
+                  "Registering systematic variations...");
+        for (auto &entry : monte_carlo_nodes) {
+          systematics_processor_.bookSystematics(entry.first, entry.second,
+                                                 binning, model);
         }
-    }
+      }
 
-  private:
-    AnalysisDefinition& analysis_definition_;
-    SysProc& systematics_processor_;
-    HistogramFactory& histogram_factory_;
+      log::info("VariableProcessor::process", "Persisting results...");
+      std::size_t total_handles = 0;
+      for (auto &entry : sample_processors) {
+        total_handles += entry.second->expectedHandleCount();
+      }
+      std::vector<ROOT::RDF::RResultHandle> handles;
+      handles.reserve(total_handles);
+      for (auto &entry : sample_processors) {
+        entry.second->collectHandles(handles);
+      }
+      ROOT::RDF::RunGraphs(handles);
+      for (auto &entry : sample_processors) {
+        entry.second->contributeTo(result);
+      }
+
+      if (systematics_processor_.hasSystematics() ||
+          !result.raw_detvar_hists_.empty()) {
+        log::info("VariableProcessor::process",
+                  "Computing systematic covariances");
+        // systematics_processor_.processSystematics(result);
+      } else {
+        log::info("VariableProcessor::process",
+                  "No systematics found. Skipping covariance calculation.");
+      }
+      systematics_processor_.clearFutures();
+
+      AnalysisResult::printSummary(result);
+      region_analysis.addFinalVariable(var_key, std::move(result));
+
+      log::info("VariableProcessor::process", "Variable pipeline concluded (",
+                index + 1, "/", total_vars, "):", var_key.str());
+    }
+  }
+
+private:
+  AnalysisDefinition &analysis_definition_;
+  SysProc &systematics_processor_;
+  HistogramFactory &histogram_factory_;
 };
 
-}
+} // namespace analysis
 
 #endif

--- a/include/rarexsec/syst/SystematicsProcessor.h
+++ b/include/rarexsec/syst/SystematicsProcessor.h
@@ -5,157 +5,186 @@
 #include <cmath>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
-#include <unordered_map>
-#include <vector>
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
-#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #include <TMatrixDSym.h>
 
-#include <rarexsec/utils/Logger.h>
+#include <rarexsec/data/VariableRegistry.h>
 #include <rarexsec/hist/BinnedHistogram.h>
 #include <rarexsec/syst/SystematicStrategy.h>
-#include <rarexsec/data/VariableRegistry.h>
+#include <rarexsec/utils/Logger.h>
 
 namespace analysis {
 
 class SystematicsProcessor {
-  public:
-    SystematicsProcessor(const VariableRegistry &registry, bool store_universe_hists = false)
-        : SystematicsProcessor(SystematicsProcessor::createKnobs(registry),
-                               SystematicsProcessor::createUniverses(registry),
-                               store_universe_hists) {}
+public:
+  SystematicsProcessor(const VariableRegistry &registry,
+                       bool store_universe_hists = false)
+      : SystematicsProcessor(SystematicsProcessor::createKnobs(registry),
+                             SystematicsProcessor::createUniverses(registry),
+                             store_universe_hists) {}
 
-    SystematicsProcessor(std::vector<KnobDef> knob_definitions, std::vector<UniverseDef> universe_definitions,
-                         bool store_universe_hists = false)
-        : knob_definitions_(std::move(knob_definitions)), universe_definitions_(std::move(universe_definitions)),
-          store_universe_hists_(store_universe_hists) {
-        log::debug("SystematicsProcessor", "Initialised with", knob_definitions_.size(), "weight knobs and",
-                   universe_definitions_.size(), "universe variations");
+  SystematicsProcessor(std::vector<KnobDef> knob_definitions,
+                       std::vector<UniverseDef> universe_definitions,
+                       bool store_universe_hists = false)
+      : knob_definitions_(std::move(knob_definitions)),
+        universe_definitions_(std::move(universe_definitions)),
+        store_universe_hists_(store_universe_hists) {
+    if (!knob_definitions_.empty() || !universe_definitions_.empty()) {
+      log::debug("SystematicsProcessor", "Initialised with",
+                 knob_definitions_.size(), "weight knobs and",
+                 universe_definitions_.size(), "universe variations");
+    }
+  }
+
+  void addStrategy(std::unique_ptr<SystematicStrategy> strat) {
+    systematic_strategies_.emplace_back(std::move(strat));
+  }
+
+  std::vector<std::unique_ptr<SystematicStrategy>> &strategies() {
+    return systematic_strategies_;
+  }
+
+  bool hasStrategies() const { return !systematic_strategies_.empty(); }
+
+  const std::vector<KnobDef> &knobDefinitions() const {
+    return knob_definitions_;
+  }
+
+  const std::vector<UniverseDef> &universeDefinitions() const {
+    return universe_definitions_;
+  }
+
+  bool storeUniverseHists() const { return store_universe_hists_; }
+
+  void bookSystematics(const SampleKey &sample_key, ROOT::RDF::RNode &rnode,
+                       const BinningDefinition &binning,
+                       const ROOT::RDF::TH1DModel &model) {
+    log::debug("SystematicsProcessor::bookSystematics",
+               "Booking variations for sample", sample_key.str());
+    for (const auto &strategy : systematic_strategies_) {
+      log::debug("SystematicsProcessor::bookSystematics", "-> Strategy",
+                 strategy->getName());
+      strategy->bookVariations(sample_key, rnode, binning, model,
+                               systematic_futures_);
+    }
+    log::debug("SystematicsProcessor::bookSystematics",
+               "Completed booking for sample", sample_key.str());
+  }
+
+  void processSystematics(VariableResult &result) {
+    if (!hasSystematics() && result.raw_detvar_hists_.empty()) {
+      log::info("SystematicsProcessor::processSystematics",
+                "No systematics found. Using statistical uncertainties only.");
+      combineCovariances(result);
+      return;
     }
 
-    void addStrategy(std::unique_ptr<SystematicStrategy> strat) {
-        systematic_strategies_.emplace_back(std::move(strat));
+    log::debug("SystematicsProcessor::processSystematics",
+               "Commencing covariance calculations");
+    for (const auto &strategy : systematic_strategies_) {
+      VariableResult local_result = result;
+      SystematicKey key{strategy->getName()};
+      log::debug("SystematicsProcessor::processSystematics",
+                 "Computing covariance for", key.str());
+      auto cov = strategy->computeCovariance(local_result, systematic_futures_);
+      sanitiseMatrix(cov);
+      log::debug("SystematicsProcessor::processSystematics", key.str(),
+                 "matrix size", cov.GetNrows(), "x", cov.GetNcols());
+      result.covariance_matrices_.insert_or_assign(key, cov);
+    }
+    combineCovariances(result);
+    log::debug("SystematicsProcessor::processSystematics",
+               "Covariance calculation complete");
+  }
+
+  void clearFutures() { systematic_futures_.variations.clear(); }
+
+  bool hasSystematics() const {
+    return !systematic_futures_.variations.empty();
+  }
+
+private:
+  static void sanitiseMatrix(TMatrixDSym &m) {
+    const int rows = m.GetNrows();
+    const int cols = m.GetNcols();
+    tbb::parallel_for(tbb::blocked_range<int>(0, rows),
+                      [&](const tbb::blocked_range<int> &r) {
+                        for (int i = r.begin(); i != r.end(); ++i) {
+                          const int max_col = std::min(i + 1, cols);
+                          for (int j = 0; j < max_col; ++j) {
+                            double &val = m(i, j);
+                            if (!std::isfinite(val))
+                              val = 0.0;
+                          }
+                        }
+                      });
+  }
+
+  static void combineCovariances(VariableResult &result) {
+    const int n_bins = result.total_mc_hist_.getNumberOfBins();
+    if (n_bins <= 0)
+      return;
+
+    result.total_covariance_.ResizeTo(n_bins, n_bins);
+    result.total_covariance_ = result.total_mc_hist_.hist.covariance();
+
+    log::debug("SystematicsProcessor::combineCovariances",
+               "Combining covariance matrices");
+    for (const auto &[name, cov_matrix] : result.covariance_matrices_) {
+      if (cov_matrix.GetNrows() == n_bins) {
+        TMatrixDSym cov = cov_matrix;
+        SystematicsProcessor::sanitiseMatrix(cov);
+        log::debug("SystematicsProcessor::combineCovariances", "Adding matrix",
+                   name.str());
+        result.total_covariance_ += cov;
+      } else {
+        log::warn("SystematicsProcessor::combineCovariances",
+                  "Skipping systematic", name.str(),
+                  "due to incompatible matrix size (", cov_matrix.GetNrows(),
+                  "x", cov_matrix.GetNcols(), "vs expected", n_bins, "x",
+                  n_bins, ")");
+      }
     }
 
-    std::vector<std::unique_ptr<SystematicStrategy>>& strategies() {
-        return systematic_strategies_;
+    SystematicsProcessor::sanitiseMatrix(result.total_covariance_);
+
+    result.nominal_with_band_ = result.total_mc_hist_;
+    result.nominal_with_band_.hist.shifts.resize(n_bins, 0);
+    result.nominal_with_band_.addCovariance(result.total_covariance_);
+  }
+
+  static std::vector<KnobDef> createKnobs(const VariableRegistry &registry) {
+    std::vector<KnobDef> out;
+    out.reserve(registry.knobVariations().size());
+    for (const auto &[name, cols] : registry.knobVariations()) {
+      out.push_back({name, cols.first, cols.second});
     }
+    return out;
+  }
 
-    const std::vector<KnobDef>& knobDefinitions() const { return knob_definitions_; }
-
-    const std::vector<UniverseDef>& universeDefinitions() const { return universe_definitions_; }
-
-    bool storeUniverseHists() const { return store_universe_hists_; }
-
-    void bookSystematics(const SampleKey &sample_key, ROOT::RDF::RNode &rnode, const BinningDefinition &binning,
-                         const ROOT::RDF::TH1DModel &model) {
-        log::debug("SystematicsProcessor::bookSystematics", "Booking variations for sample", sample_key.str());
-        for (const auto &strategy : systematic_strategies_) {
-            log::debug("SystematicsProcessor::bookSystematics", "-> Strategy", strategy->getName());
-            strategy->bookVariations(sample_key, rnode, binning, model, systematic_futures_);
-        }
-        log::debug("SystematicsProcessor::bookSystematics", "Completed booking for sample", sample_key.str());
+  static std::vector<UniverseDef>
+  createUniverses(const VariableRegistry &registry) {
+    std::vector<UniverseDef> out;
+    out.reserve(registry.multiUniverseVariations().size());
+    for (const auto &[name, count] : registry.multiUniverseVariations()) {
+      out.push_back({name, name, count});
     }
+    return out;
+  }
 
-    void processSystematics(VariableResult &result) {
-        if (!hasSystematics() && result.raw_detvar_hists_.empty()) {
-            log::info("SystematicsProcessor::processSystematics",
-                      "No systematics found. Using statistical uncertainties only.");
-            combineCovariances(result);
-            return;
-        }
-
-        log::debug("SystematicsProcessor::processSystematics", "Commencing covariance calculations");
-        for (const auto &strategy : systematic_strategies_) {
-            VariableResult local_result = result;
-            SystematicKey key{strategy->getName()};
-            log::debug("SystematicsProcessor::processSystematics", "Computing covariance for", key.str());
-            auto cov = strategy->computeCovariance(local_result, systematic_futures_);
-            sanitiseMatrix(cov);
-            log::debug("SystematicsProcessor::processSystematics", key.str(), "matrix size", cov.GetNrows(), "x",
-                       cov.GetNcols());
-            result.covariance_matrices_.insert_or_assign(key, cov);
-        }
-        combineCovariances(result);
-        log::debug("SystematicsProcessor::processSystematics", "Covariance calculation complete");
-    }
-
-    void clearFutures() { systematic_futures_.variations.clear(); }
-
-    bool hasSystematics() const { return !systematic_futures_.variations.empty(); }
-
-  private:
-    static void sanitiseMatrix(TMatrixDSym &m) {
-        const int rows = m.GetNrows();
-        const int cols = m.GetNcols();
-        tbb::parallel_for(tbb::blocked_range<int>(0, rows),
-                          [&](const tbb::blocked_range<int> &r) {
-            for (int i = r.begin(); i != r.end(); ++i) {
-                const int max_col = std::min(i + 1, cols);
-                for (int j = 0; j < max_col; ++j) {
-                    double &val = m(i, j);
-                    if (!std::isfinite(val)) val = 0.0;
-                }
-            }
-        });
-    }
-
-    static void combineCovariances(VariableResult &result) {
-        const int n_bins = result.total_mc_hist_.getNumberOfBins();
-        if (n_bins <= 0) return;
-
-        result.total_covariance_.ResizeTo(n_bins, n_bins);
-        result.total_covariance_ = result.total_mc_hist_.hist.covariance();
-
-        log::debug("SystematicsProcessor::combineCovariances", "Combining covariance matrices");
-        for (const auto &[name, cov_matrix] : result.covariance_matrices_) {
-            if (cov_matrix.GetNrows() == n_bins) {
-                TMatrixDSym cov = cov_matrix;
-                SystematicsProcessor::sanitiseMatrix(cov);
-                log::debug("SystematicsProcessor::combineCovariances", "Adding matrix", name.str());
-                result.total_covariance_ += cov;
-            } else {
-                log::warn("SystematicsProcessor::combineCovariances", "Skipping systematic", name.str(),
-                          "due to incompatible matrix size (", cov_matrix.GetNrows(), "x", cov_matrix.GetNcols(),
-                          "vs expected", n_bins, "x", n_bins, ")");
-            }
-        }
-
-        SystematicsProcessor::sanitiseMatrix(result.total_covariance_);
-
-        result.nominal_with_band_ = result.total_mc_hist_;
-        result.nominal_with_band_.hist.shifts.resize(n_bins, 0);
-        result.nominal_with_band_.addCovariance(result.total_covariance_);
-    }
-
-    static std::vector<KnobDef> createKnobs(const VariableRegistry &registry) {
-        std::vector<KnobDef> out;
-        out.reserve(registry.knobVariations().size());
-        for (const auto &[name, cols] : registry.knobVariations()) {
-            out.push_back({name, cols.first, cols.second});
-        }
-        return out;
-    }
-
-    static std::vector<UniverseDef> createUniverses(const VariableRegistry &registry) {
-        std::vector<UniverseDef> out;
-        out.reserve(registry.multiUniverseVariations().size());
-        for (const auto &[name, count] : registry.multiUniverseVariations()) {
-            out.push_back({name, name, count});
-        }
-        return out;
-    }
-
-    std::vector<std::unique_ptr<SystematicStrategy>> systematic_strategies_;
-    std::vector<KnobDef> knob_definitions_;
-    std::vector<UniverseDef> universe_definitions_;
-    bool store_universe_hists_;
-    SystematicFutures systematic_futures_;
+  std::vector<std::unique_ptr<SystematicStrategy>> systematic_strategies_;
+  std::vector<KnobDef> knob_definitions_;
+  std::vector<UniverseDef> universe_definitions_;
+  bool store_universe_hists_;
+  SystematicFutures systematic_futures_;
 };
 
-}
+} // namespace analysis
 
 #endif


### PR DESCRIPTION
## Summary
- Avoid logging systematics setup when no knobs or universes are defined
- Only register and book systematic variations when strategies are present
- Create the `SystematicsProcessor` only if systematics plugins are configured

## Testing
- `bash -lc "source .build.sh"` *(fails: could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c40a35bd64832e8af5e3240f365a40