### PR TITLE
Disable IMT during plotting to prevent event display crash

### DIFF
--- a/include/rarexsec/plug/PipelineRunner.h
+++ b/include/rarexsec/plug/PipelineRunner.h
@@ -130,6 +130,9 @@ inline void plotBeamline(RunConfigRegistry &run_config_registry,
 inline void runPlotting(const nlohmann::json &samples,
                         const PluginSpecList &plot_specs,
                         const AnalysisResult &result) {
+  ROOT::DisableImplicitMT();
+  log::info("analysis::runPlotting",
+            "Implicit multithreading disabled; running single-threaded.");
   std::string ntuple_dir = samples.at("ntupledir").get<std::string>();
   log::info("analysis::runPlotting", "Configuration loaded for",
             samples.at("beamlines").size(), "beamlines.");


### PR DESCRIPTION
## Summary
- Disable ROOT implicit multithreading before plotting so all frames and plugins run single-threaded

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68c40dd40078832ea6a3e101fb2f0dfe