### PR TITLE
Replace trk_distance_v with track_distance_to_vertex

### DIFF
--- a/include/rarexsec/data/MuonSelectionProcessor.h
+++ b/include/rarexsec/data/MuonSelectionProcessor.h
@@ -116,7 +116,7 @@ private:
                      .Define("muon_trk_length_v", filter_float,
                              {"track_length", "muon_mask"})
                      .Define("muon_trk_distance_v", filter_float,
-                             {"trk_distance_v", "muon_mask"})
+                             {"track_distance_to_vertex", "muon_mask"})
                     .Define("muon_pfp_generation_v", filter_uint,
                             {"pfp_generations", "muon_mask"})
                      .Define("muon_trk_mcs_muon_mom_v", filter_float,

--- a/include/rarexsec/data/VariableRegistry.h
+++ b/include/rarexsec/data/VariableRegistry.h
@@ -455,8 +455,8 @@ private:
 
   static const std::vector<std::string> &recoTrackVariables() {
     static const std::vector<std::string> v = {
-        "track_shower_scores", "trk_llr_pid_v",
-        "track_length",        "trk_distance_v",
+        "track_shower_scores",     "trk_llr_pid_v",
+        "track_length",            "track_distance_to_vertex",
         "track_start_x",       "track_start_y",
         "track_start_z",       "track_end_x",
         "track_end_y",         "track_end_z",


### PR DESCRIPTION
## Summary
- Update VariableRegistry and MuonSelectionProcessor to use `track_distance_to_vertex` instead of the missing `trk_distance_v`

## Testing
- `source .setup.sh` *(fails: /cvmfs/... No such file or directory)*
- `cmake ..` *(fails: Could not find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c41fa89d9c832e848f213159637ca3