### PR TITLE
Remove outdated MCS momentum variable

### DIFF
--- a/include/rarexsec/data/MuonSelectionProcessor.h
+++ b/include/rarexsec/data/MuonSelectionProcessor.h
@@ -119,8 +119,6 @@ private:
                              {"track_distance_to_vertex", "muon_mask"})
                     .Define("muon_pfp_generation_v", filter_uint,
                             {"pfp_generations", "muon_mask"})
-                     .Define("muon_trk_mcs_muon_mom_v", filter_float,
-                             {"trk_mcs_muon_mom_v", "muon_mask"})
                      .Define("muon_trk_range_muon_mom_v", filter_float,
                              {"trk_range_muon_mom_v", "muon_mask"})
                      .Define("muon_track_costheta", filter_costheta,

--- a/include/rarexsec/data/VariableRegistry.h
+++ b/include/rarexsec/data/VariableRegistry.h
@@ -462,8 +462,7 @@ private:
         "track_end_y",         "track_end_z",
         "track_theta",         "track_phi",
         "track_calo_energy_u", "track_calo_energy_v",
-        "track_calo_energy_y", "trk_mcs_muon_mom_v",
-        "trk_range_muon_mom_v"};
+        "track_calo_energy_y", "trk_range_muon_mom_v"};
 
     return v;
   }
@@ -489,7 +488,6 @@ private:
                                                "muon_trk_length_v",
                                                "muon_trk_distance_v",
                                                "muon_pfp_generation_v",
-                                               "muon_trk_mcs_muon_mom_v",
                                                "muon_trk_range_muon_mom_v",
                                                "muon_track_costheta",
                                                "base_event_weight",


### PR DESCRIPTION
## Summary
- stop requesting nonexistent `trk_mcs_muon_mom_v` column
- drop derived `muon_trk_mcs_muon_mom_v` field from muon selection

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: Could not find package ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c421575fa8832e82945415c66ca936