### PR TITLE
Rename preselection processor

### DIFF
--- a/include/rarexsec/data/AnalysisDataLoader.h
+++ b/include/rarexsec/data/AnalysisDataLoader.h
@@ -14,7 +14,7 @@
 #include <rarexsec/data/IEventProcessor.h>
 #include <rarexsec/utils/Logger.h>
 #include <rarexsec/data/MuonSelectionProcessor.h>
-#include <rarexsec/data/NumuPreselectionProcessor.h>
+#include <rarexsec/data/PreselectionProcessor.h>
 #include <rarexsec/data/ReconstructionProcessor.h>
 #include <rarexsec/data/RunConfigRegistry.h>
 #include <rarexsec/data/SampleDefinition.h>
@@ -138,7 +138,7 @@ class AnalysisDataLoader {
                 std::make_unique<TruthChannelProcessor>(), std::make_unique<BlipProcessor>(),
                 std::make_unique<MuonSelectionProcessor>(),
                 std::make_unique<ReconstructionProcessor>(),
-                std::make_unique<NumuPreselectionProcessor>());
+                std::make_unique<PreselectionProcessor>());
             processors_.push_back(std::move(pipeline));
 
             auto &proc = *processors_.back();

--- a/include/rarexsec/data/PreselectionProcessor.h
+++ b/include/rarexsec/data/PreselectionProcessor.h
@@ -1,5 +1,5 @@
-#ifndef NUMU_PRESELECTION_PROCESSOR_H
-#define NUMU_PRESELECTION_PROCESSOR_H
+#ifndef PRESELECTION_PROCESSOR_H
+#define PRESELECTION_PROCESSOR_H
 
 #include "ROOT/RVec.hxx"
 #include <rarexsec/data/IEventProcessor.h>
@@ -7,7 +7,7 @@
 
 namespace analysis {
 
-class NumuPreselectionProcessor : public IEventProcessor {
+class PreselectionProcessor : public IEventProcessor {
 public:
   ROOT::RDF::RNode process(ROOT::RDF::RNode df,
                            SampleOrigin st) const override {


### PR DESCRIPTION
## Summary
- rename NumuPreselectionProcessor to PreselectionProcessor
- update AnalysisDataLoader to use new PreselectionProcessor

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68c4227fc4ac832e8c4f7798c32e5400