### PR TITLE
Ensure event display histograms persist until save

### DIFF
--- a/include/rarexsec/plot/DetectorDisplay.h
+++ b/include/rarexsec/plot/DetectorDisplay.h
@@ -1,6 +1,7 @@
 #ifndef DETECTORDISPLAY_H
 #define DETECTORDISPLAY_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -26,27 +27,28 @@ class DetectorDisplay : public IEventDisplay {
         const float min_val = 1;
         const float max_val = 1000;
 
-        TH2F hist(tag_.c_str(), tag_.c_str(), image_size_, 0, image_size_,
-                  image_size_, 0, image_size_);
+        hist_ = std::make_unique<TH2F>(tag_.c_str(), tag_.c_str(), image_size_, 0,
+                                       image_size_, image_size_, 0, image_size_);
 
         for (int r = 0; r < image_size_; ++r) {
             for (int c = 0; c < image_size_; ++c) {
                 float v = data_[r * image_size_ + c];
-                hist.SetBinContent(c + bin_offset, r + bin_offset,
-                                   v > threshold ? v : min_val);
+                hist_->SetBinContent(c + bin_offset, r + bin_offset,
+                                     v > threshold ? v : min_val);
             }
         }
 
         canvas.SetLogz();
-        hist.SetMinimum(min_val);
-        hist.SetMaximum(max_val);
-        hist.GetXaxis()->SetTitle("Wire");
-        hist.GetYaxis()->SetTitle("Time");
-        hist.Draw("COL");
+        hist_->SetMinimum(min_val);
+        hist_->SetMaximum(max_val);
+        hist_->GetXaxis()->SetTitle("Wire");
+        hist_->GetYaxis()->SetTitle("Time");
+        hist_->Draw("COL");
     }
 
 private:
     std::vector<float> data_;
+    std::unique_ptr<TH2F> hist_;
 };
 
 } 

--- a/include/rarexsec/plot/IEventDisplay.h
+++ b/include/rarexsec/plot/IEventDisplay.h
@@ -26,6 +26,7 @@ class IEventDisplay {
 
         TCanvas canvas(tag_.c_str(), tag_.c_str(), image_size_, image_size_);
         this->draw(canvas);
+        canvas.Update();
         canvas.SaveAs((output_directory_ + "/" + tag_ + "." + format).c_str());
     }
 

--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -1,6 +1,7 @@
 #ifndef SEMANTICDISPLAY_H
 #define SEMANTICDISPLAY_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -30,8 +31,8 @@ class SemanticDisplay : public IEventDisplay {
         const double z_min = -0.5;
         const double z_max = 9.5;
 
-        TH2F hist(tag_.c_str(), tag_.c_str(), image_size_, 0, image_size_,
-                  image_size_, 0, image_size_);
+        hist_ = std::make_unique<TH2F>(tag_.c_str(), tag_.c_str(), image_size_, 0,
+                                       image_size_, image_size_, 0, image_size_);
 
         int palette[palette_size];
         for (int i = 0; i < palette_size; ++i)
@@ -40,22 +41,24 @@ class SemanticDisplay : public IEventDisplay {
 
         for (int r = 0; r < image_size_; ++r) {
             for (int c = 0; c < image_size_; ++c) {
-                hist.SetBinContent(c + bin_offset, r + bin_offset,
-                                   data_[r * image_size_ + c]);
+                hist_->SetBinContent(c + bin_offset, r + bin_offset,
+                                     data_[r * image_size_ + c]);
             }
         }
 
-        hist.SetStats(stats_off);
-        hist.GetZaxis()->SetRangeUser(z_min, z_max);
-        hist.GetXaxis()->SetTitle("Time");
-        hist.GetYaxis()->SetTitle("Wire");
-        hist.Draw("COL");
+        hist_->SetStats(stats_off);
+        hist_->GetZaxis()->SetRangeUser(z_min, z_max);
+        hist_->GetXaxis()->SetTitle("Time");
+        hist_->GetYaxis()->SetTitle("Wire");
+        hist_->Draw("COL");
     }
 
   private:
     std::vector<int> data_;
+    std::unique_ptr<TH2F> hist_;
 };
 
-}
+} // namespace analysis
 
 #endif
+


### PR DESCRIPTION
## Summary
- Keep detector and semantic event display histograms alive until canvas save by storing them as `std::unique_ptr`
- Update IEventDisplay to refresh the canvas before saving

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c425658924832eb07b1baefc192adf