### PR TITLE
Fix event variable registry static usage

### DIFF
--- a/include/rarexsec/data/VariableRegistry.h
+++ b/include/rarexsec/data/VariableRegistry.h
@@ -49,12 +49,12 @@ public:
   }
 
   static std::vector<std::string> eventVariables(SampleOrigin type) {
-    auto vars = this->collectBaseGroups();
-    
-    if (type == SampleOrigin::kMonteCarlo || type == SampleOrigin::kDirt)
-      this->appendMonteCarloGroups(vars);
+    auto vars = collectBaseGroups();
 
-    return {vars.begin(), vars.end()};
+    if (type == SampleOrigin::kMonteCarlo || type == SampleOrigin::kDirt)
+      appendMonteCarloGroups(vars);
+
+    return std::vector<std::string>(vars.begin(), vars.end());
   }
 
 private:


### PR DESCRIPTION
## Summary
- Correct static eventVariables implementation to avoid `this` usage
- Return a vector from unordered set explicitly

## Testing
- `cmake ..` *(fails: could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c4261a0948832ead12eca83711654b