### PR TITLE
Use 512px grid for event displays

### DIFF
--- a/include/rarexsec/flow/EventDisplayBuilder.h
+++ b/include/rarexsec/flow/EventDisplayBuilder.h
@@ -111,7 +111,7 @@ class EventDisplayBuilder {
     std::string region_;
     std::optional<std::string> selection_expr_;
     std::vector<std::string> planes_;
-    int image_size_ = 800;
+    int image_size_ = 512;
     std::string out_dir_ = "./plots/event_displays";
     std::string file_pattern_ = "{plane}_{run}_{sub}_{evt}";
     int n_events_ = 1;

--- a/src/plug/plotting/EventDisplayPlugin.cc
+++ b/src/plug/plotting/EventDisplayPlugin.cc
@@ -33,7 +33,7 @@ class EventDisplayPlugin : public IPlotPlugin {
         SelectionQuery selection;
         std::optional<std::string> selection_expr;
         int n_events{1};
-        int image_size{800};
+        int image_size{512};
         std::filesystem::path output_directory{"./plots/event_displays"};
         std::vector<std::string> planes{"U","V","W"};
         std::string mode{"detector"};
@@ -55,7 +55,7 @@ class EventDisplayPlugin : public IPlotPlugin {
             dc.sample = ed.at("sample").get<std::string>();
             dc.region = ed.value("region", std::string{});
             dc.n_events = ed.value("n_events", 1);
-            dc.image_size = ed.value("image_size", 800);
+            dc.image_size = ed.value("image_size", 512);
             dc.output_directory = ed.value("output_directory", std::string{"./plots/event_displays"});
             dc.output_directory = std::filesystem::absolute(dc.output_directory).lexically_normal();
             dc.planes = ed.value("planes", std::vector<std::string>{"U","V","W"});

--- a/src/run/study_region_event_display.cpp
+++ b/src/run/study_region_event_display.cpp
@@ -9,13 +9,13 @@ int main() {
     .region("NUMU_CC", where("quality_event && has_muon"))
     .display(
       events().from("mc_strangeness_run1_fhc").in("NUMU_CC")
-        .limit(5).size(800)
+        .limit(5).size(512)
         .mode(detector())
         .out("plots/event_displays/detector")
     )
     .display(
       events().from("mc_strangeness_run1_fhc").in("NUMU_CC")
-        .limit(5).size(800)
+        .limit(5).size(512)
         .mode(semantic())
         .out("plots/event_displays/semantic")
     );

--- a/src/run/study_topo_score.cpp
+++ b/src/run/study_topo_score.cpp
@@ -13,7 +13,7 @@ int main() {
     .plot(roc("topological_score").in("PRE_TOPO").channel("incl_channel").signal("inclusive_strange_channels"))
     .display(
       events().from("numi_on").in("PRE_TOPO")
-        .limit(12).size(800).planes({"U","V","W"})
+        .limit(12).size(512).planes({"U","V","W"})
         .mode(detector())
         .out("plots/event_displays")
         .name("{plane}_{run}_{sub}_{evt}")


### PR DESCRIPTION
## Summary
- Default event display image size set to 512×512 pixels
- Update plugin to expect 512px grid by default
- Adjust study run scripts to request 512px event displays

## Testing
- `source .setup.sh && source .build.sh` *(fails: missing ROOT and CVMFS environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c42a3543a8832eb9fb6c63d518aea2