### PR TITLE
Refine event display styling

### DIFF
--- a/include/rarexsec/plot/DetectorDisplay.h
+++ b/include/rarexsec/plot/DetectorDisplay.h
@@ -14,9 +14,9 @@ namespace analysis {
 
 class DetectorDisplay : public IEventDisplay {
   public:
-    DetectorDisplay(std::string tag, std::vector<float> data, int image_size,
-                    std::string output_directory)
-        : IEventDisplay(std::move(tag), image_size,
+    DetectorDisplay(std::string tag, std::string title, std::vector<float> data,
+                    int image_size, std::string output_directory)
+        : IEventDisplay(std::move(tag), std::move(title), image_size,
                         std::move(output_directory)),
           data_(std::move(data)) {}
 
@@ -27,7 +27,7 @@ class DetectorDisplay : public IEventDisplay {
         const float min_val = 1;
         const float max_val = 1000;
 
-        hist_ = std::make_unique<TH2F>(tag_.c_str(), tag_.c_str(), image_size_, 0,
+        hist_ = std::make_unique<TH2F>(tag_.c_str(), title_.c_str(), image_size_, 0,
                                        image_size_, image_size_, 0, image_size_);
 
         for (int r = 0; r < image_size_; ++r) {
@@ -39,10 +39,17 @@ class DetectorDisplay : public IEventDisplay {
         }
 
         canvas.SetLogz();
+        canvas.SetTicks(0, 0);
         hist_->SetMinimum(min_val);
         hist_->SetMaximum(max_val);
-        hist_->GetXaxis()->SetTitle("Wire");
-        hist_->GetYaxis()->SetTitle("Time");
+        hist_->GetXaxis()->SetTitle("Local Wire Coordinate");
+        hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
+        hist_->GetXaxis()->CenterTitle(true);
+        hist_->GetYaxis()->CenterTitle(true);
+        hist_->GetXaxis()->SetTickLength(0);
+        hist_->GetYaxis()->SetTickLength(0);
+        hist_->GetXaxis()->SetLabelSize(0);
+        hist_->GetYaxis()->SetLabelSize(0);
         hist_->Draw("COL");
     }
 

--- a/include/rarexsec/plot/IEventDisplay.h
+++ b/include/rarexsec/plot/IEventDisplay.h
@@ -13,8 +13,9 @@ namespace analysis {
 
 class IEventDisplay {
   public:
-    IEventDisplay(std::string tag, int image_size, std::string output_directory)
-        : tag_(std::move(tag)), image_size_(image_size),
+    IEventDisplay(std::string tag, std::string title, int image_size,
+                  std::string output_directory)
+        : tag_(std::move(tag)), title_(std::move(title)), image_size_(image_size),
           output_directory_(std::move(output_directory)) {}
 
     virtual ~IEventDisplay() = default;
@@ -24,7 +25,8 @@ class IEventDisplay {
 
         log::info("EventDisplay", "Saving", tag_, "to", output_directory_);
 
-        TCanvas canvas(tag_.c_str(), tag_.c_str(), image_size_, image_size_);
+        TCanvas canvas(tag_.c_str(), title_.c_str(), image_size_, image_size_);
+        canvas.SetCanvasSize(image_size_, image_size_);
         this->draw(canvas);
         canvas.Update();
         canvas.SaveAs((output_directory_ + "/" + tag_ + "." + format).c_str());
@@ -34,6 +36,7 @@ class IEventDisplay {
     virtual void draw(TCanvas &canvas) = 0;
 
     std::string tag_;
+    std::string title_;
     int image_size_;
     std::string output_directory_;
 };

--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -16,14 +16,14 @@ namespace analysis {
 
 class SemanticDisplay : public IEventDisplay {
   public:
-    SemanticDisplay(std::string tag, std::vector<int> data, int image_size,
-                    std::string output_directory)
-        : IEventDisplay(std::move(tag), image_size,
+    SemanticDisplay(std::string tag, std::string title, std::vector<int> data,
+                    int image_size, std::string output_directory)
+        : IEventDisplay(std::move(tag), std::move(title), image_size,
                         std::move(output_directory)),
           data_(std::move(data)) {}
 
   protected:
-    void draw(TCanvas &) override {
+    void draw(TCanvas &canvas) override {
         const int palette_size = 10;
         const int palette_step = 2;
         const int bin_offset = 1;
@@ -31,7 +31,7 @@ class SemanticDisplay : public IEventDisplay {
         const double z_min = -0.5;
         const double z_max = 9.5;
 
-        hist_ = std::make_unique<TH2F>(tag_.c_str(), tag_.c_str(), image_size_, 0,
+        hist_ = std::make_unique<TH2F>(tag_.c_str(), title_.c_str(), image_size_, 0,
                                        image_size_, image_size_, 0, image_size_);
 
         int palette[palette_size];
@@ -48,8 +48,15 @@ class SemanticDisplay : public IEventDisplay {
 
         hist_->SetStats(stats_off);
         hist_->GetZaxis()->SetRangeUser(z_min, z_max);
-        hist_->GetXaxis()->SetTitle("Time");
-        hist_->GetYaxis()->SetTitle("Wire");
+        canvas.SetTicks(0, 0);
+        hist_->GetXaxis()->SetTitle("Local Wire Coordinate");
+        hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
+        hist_->GetXaxis()->CenterTitle(true);
+        hist_->GetYaxis()->CenterTitle(true);
+        hist_->GetXaxis()->SetTickLength(0);
+        hist_->GetYaxis()->SetTickLength(0);
+        hist_->GetXaxis()->SetLabelSize(0);
+        hist_->GetYaxis()->SetLabelSize(0);
         hist_->Draw("COL");
     }
 

--- a/src/plug/plotting/EventDisplayPlugin.cc
+++ b/src/plug/plotting/EventDisplayPlugin.cc
@@ -172,12 +172,18 @@ class EventDisplayPlugin : public IPlotPlugin {
                                    const std::vector<float>& det,
                                    const std::vector<int>& sem){
                     std::string tag = formatTag(cfg_copy.file_pattern, plane, run, sub, evt);
+                    std::string title = "Plane " + plane + " Detector (" +
+                                        std::to_string(run) + " Run, " +
+                                        std::to_string(sub) + " SubRun, " +
+                                        std::to_string(evt) + " Event)";
                     auto out_file = out_dir / (tag + ".png");
                     if (cfg_copy.mode == "semantic") {
-                        SemanticDisplay s(tag, sem, cfg_copy.image_size, out_dir.string());
+                        SemanticDisplay s(tag, title, sem, cfg_copy.image_size,
+                                          out_dir.string());
                         s.drawAndSave();
                     } else {
-                        DetectorDisplay d(tag, det, cfg_copy.image_size, out_dir.string());
+                        DetectorDisplay d(tag, title, det, cfg_copy.image_size,
+                                          out_dir.string());
                         d.drawAndSave();
                     }
                     log::info("EventDisplayPlugin", "Saved event display:", out_file.string());


### PR DESCRIPTION
## Summary
- allow event displays to carry a descriptive title and exact canvas size
- remove axis ticks, centre axis labels, and rename axes to local coordinates
- include run/subrun/event in detector plane titles

## Testing
- `cmake -S . -B build` *(fails: could not find package configuration file provided by ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c42c87da80832e8b2384c67889ddb9