### PR TITLE
Decouple canvas resolution from data grid in event displays

### DIFF
--- a/include/rarexsec/flow/EventDisplayBuilder.h
+++ b/include/rarexsec/flow/EventDisplayBuilder.h
@@ -8,14 +8,14 @@
 namespace analysis::dsl {
 
 struct DisplayMode {
-    std::string kind;
-    double overlay_alpha = 1.0;
+  std::string kind;
+  double overlay_alpha = 1.0;
 
-    DisplayMode &alpha(double a) {
-        overlay_alpha = a;
-        return *this;
-    }
-    double alpha() const { return overlay_alpha; }
+  DisplayMode &alpha(double a) {
+    overlay_alpha = a;
+    return *this;
+  }
+  double alpha() const { return overlay_alpha; }
 };
 inline DisplayMode detector() { return {"detector"}; }
 inline DisplayMode semantic() { return {"semantic"}; }
@@ -26,102 +26,102 @@ static constexpr Direction asc = Direction::Asc;
 static constexpr Direction desc = Direction::Desc;
 
 class EventDisplayBuilder {
-  public:
-    EventDisplayBuilder &from(std::string s) {
-        sample_ = std::move(s);
-        return *this;
-    }
-    EventDisplayBuilder &in(std::string r) {
-        region_ = std::move(r);
-        return *this;
-    }
-    EventDisplayBuilder &where(std::string expr) {
-        selection_expr_ = std::move(expr);
-        return *this;
-    }
+public:
+  EventDisplayBuilder &from(std::string s) {
+    sample_ = std::move(s);
+    return *this;
+  }
+  EventDisplayBuilder &in(std::string r) {
+    region_ = std::move(r);
+    return *this;
+  }
+  EventDisplayBuilder &where(std::string expr) {
+    selection_expr_ = std::move(expr);
+    return *this;
+  }
 
-    EventDisplayBuilder &planes(std::vector<std::string> ps) {
-        planes_ = std::move(ps);
-        return *this;
-    }
-    EventDisplayBuilder &size(int px) {
-        image_size_ = px;
-        return *this;
-    }
-    EventDisplayBuilder &out(std::string dir) {
-        out_dir_ = std::move(dir);
-        return *this;
-    }
-    EventDisplayBuilder &name(std::string pattern) {
-        file_pattern_ = std::move(pattern);
-        return *this;
-    }
+  EventDisplayBuilder &planes(std::vector<std::string> ps) {
+    planes_ = std::move(ps);
+    return *this;
+  }
+  EventDisplayBuilder &size(int px) {
+    image_size_ = px;
+    return *this;
+  }
+  EventDisplayBuilder &out(std::string dir) {
+    out_dir_ = std::move(dir);
+    return *this;
+  }
+  EventDisplayBuilder &name(std::string pattern) {
+    file_pattern_ = std::move(pattern);
+    return *this;
+  }
 
-    EventDisplayBuilder &limit(int n) {
-        n_events_ = n;
-        return *this;
-    }
-    EventDisplayBuilder &seed(unsigned s) {
-        seed_ = s;
-        return *this;
-    }
-    EventDisplayBuilder &orderBy(std::string var, Direction d) {
-        order_by_ = std::move(var);
-        order_desc_ = (d == Direction::Desc);
-        return *this;
-    }
-    EventDisplayBuilder &manifest(std::string path) {
-        manifest_path_ = std::move(path);
-        return *this;
-    }
+  EventDisplayBuilder &limit(int n) {
+    n_events_ = n;
+    return *this;
+  }
+  EventDisplayBuilder &seed(unsigned s) {
+    seed_ = s;
+    return *this;
+  }
+  EventDisplayBuilder &orderBy(std::string var, Direction d) {
+    order_by_ = std::move(var);
+    order_desc_ = (d == Direction::Desc);
+    return *this;
+  }
+  EventDisplayBuilder &manifest(std::string path) {
+    manifest_path_ = std::move(path);
+    return *this;
+  }
 
-    EventDisplayBuilder &mode(DisplayMode m) {
-        mode_ = m;
-        return *this;
-    }
+  EventDisplayBuilder &mode(DisplayMode m) {
+    mode_ = m;
+    return *this;
+  }
 
-    nlohmann::json to_json() const {
-        nlohmann::json j{{"sample", sample_},
-                         {"region", region_},
-                         {"n_events", n_events_},
-                         {"image_size", image_size_},
-                         {"output_directory", out_dir_},
-                         {"mode", mode_.kind}};
-        if (mode_.kind == "overlay")
-            j["overlay_alpha"] = mode_.alpha();
-        if (!planes_.empty())
-            j["planes"] = planes_;
-        if (selection_expr_)
-            j["selection_expr"] = *selection_expr_;
-        if (!file_pattern_.empty())
-            j["file_pattern"] = file_pattern_;
-        if (seed_)
-            j["seed"] = *seed_;
-        if (order_by_) {
-            j["order_by"] = *order_by_;
-            j["order_desc"] = order_desc_;
-        }
-        if (!manifest_path_.empty())
-            j["manifest"] = manifest_path_;
-        return j;
+  nlohmann::json to_json() const {
+    nlohmann::json j{{"sample", sample_},
+                     {"region", region_},
+                     {"n_events", n_events_},
+                     {"image_size", image_size_},
+                     {"output_directory", out_dir_},
+                     {"mode", mode_.kind}};
+    if (mode_.kind == "overlay")
+      j["overlay_alpha"] = mode_.alpha();
+    if (!planes_.empty())
+      j["planes"] = planes_;
+    if (selection_expr_)
+      j["selection_expr"] = *selection_expr_;
+    if (!file_pattern_.empty())
+      j["file_pattern"] = file_pattern_;
+    if (seed_)
+      j["seed"] = *seed_;
+    if (order_by_) {
+      j["order_by"] = *order_by_;
+      j["order_desc"] = order_desc_;
     }
+    if (!manifest_path_.empty())
+      j["manifest"] = manifest_path_;
+    return j;
+  }
 
-  private:
-    std::string sample_;
-    std::string region_;
-    std::optional<std::string> selection_expr_;
-    std::vector<std::string> planes_;
-    int image_size_ = 512;
-    std::string out_dir_ = "./plots/event_displays";
-    std::string file_pattern_ = "{plane}_{run}_{sub}_{evt}";
-    int n_events_ = 1;
-    std::optional<unsigned> seed_;
-    std::optional<std::string> order_by_;
-    bool order_desc_ = true;
-    std::string manifest_path_;
-    DisplayMode mode_ = detector();
+private:
+  std::string sample_;
+  std::string region_;
+  std::optional<std::string> selection_expr_;
+  std::vector<std::string> planes_;
+  int image_size_ = 1024;
+  std::string out_dir_ = "./plots/event_displays";
+  std::string file_pattern_ = "{plane}_{run}_{sub}_{evt}";
+  int n_events_ = 1;
+  std::optional<unsigned> seed_;
+  std::optional<std::string> order_by_;
+  bool order_desc_ = true;
+  std::string manifest_path_;
+  DisplayMode mode_ = detector();
 };
 
 inline EventDisplayBuilder events() { return {}; }
 
-}
+} // namespace analysis::dsl

--- a/include/rarexsec/plot/DetectorDisplay.h
+++ b/include/rarexsec/plot/DetectorDisplay.h
@@ -1,6 +1,7 @@
 #ifndef DETECTORDISPLAY_H
 #define DETECTORDISPLAY_H
 
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -13,51 +14,55 @@
 namespace analysis {
 
 class DetectorDisplay : public IEventDisplay {
-  public:
-    DetectorDisplay(std::string tag, std::string title, std::vector<float> data,
-                    int image_size, std::string output_directory)
-        : IEventDisplay(std::move(tag), std::move(title), image_size,
-                        std::move(output_directory)),
-          data_(std::move(data)) {}
+public:
+  DetectorDisplay(std::string tag, std::string title, std::vector<float> data,
+                  int canvas_size, std::string output_directory)
+      : IEventDisplay(std::move(tag), std::move(title), canvas_size,
+                      std::move(output_directory)),
+        data_(std::move(data)) {}
 
-  protected:
-    void draw(TCanvas &canvas) override {
-        const int bin_offset = 1;
-        const float threshold = 4;
-        const float min_val = 1;
-        const float max_val = 1000;
+protected:
+  void draw(TCanvas &canvas) override {
+    const int bin_offset = 1;
+    const float threshold = 4;
+    const float min_val = 1;
+    const float max_val = 1000;
 
-        hist_ = std::make_unique<TH2F>(tag_.c_str(), title_.c_str(), image_size_, 0,
-                                       image_size_, image_size_, 0, image_size_);
+    int dim = static_cast<int>(std::sqrt(data_.size()));
+    hist_ = std::make_unique<TH2F>(tag_.c_str(), title_.c_str(), dim, 0, dim,
+                                   dim, 0, dim);
 
-        for (int r = 0; r < image_size_; ++r) {
-            for (int c = 0; c < image_size_; ++c) {
-                float v = data_[r * image_size_ + c];
-                hist_->SetBinContent(c + bin_offset, r + bin_offset,
-                                     v > threshold ? v : min_val);
-            }
-        }
-
-        canvas.SetLogz();
-        canvas.SetTicks(0, 0);
-        hist_->SetMinimum(min_val);
-        hist_->SetMaximum(max_val);
-        hist_->GetXaxis()->SetTitle("Local Wire Coordinate");
-        hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
-        hist_->GetXaxis()->CenterTitle(true);
-        hist_->GetYaxis()->CenterTitle(true);
-        hist_->GetXaxis()->SetTickLength(0);
-        hist_->GetYaxis()->SetTickLength(0);
-        hist_->GetXaxis()->SetLabelSize(0);
-        hist_->GetYaxis()->SetLabelSize(0);
-        hist_->Draw("COL");
+    for (int r = 0; r < dim; ++r) {
+      for (int c = 0; c < dim; ++c) {
+        float v = data_[r * dim + c];
+        hist_->SetBinContent(c + bin_offset, r + bin_offset,
+                             v > threshold ? v : min_val);
+      }
     }
 
+    canvas.SetLogz();
+    canvas.SetTicks(0, 0);
+    hist_->SetStats(false);
+    hist_->SetMinimum(min_val);
+    hist_->SetMaximum(max_val);
+    hist_->GetXaxis()->SetTitle("Local Wire Coordinate");
+    hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
+    hist_->GetXaxis()->CenterTitle(true);
+    hist_->GetYaxis()->CenterTitle(true);
+    hist_->GetXaxis()->SetTickLength(0);
+    hist_->GetYaxis()->SetTickLength(0);
+    hist_->GetXaxis()->SetLabelSize(0);
+    hist_->GetYaxis()->SetLabelSize(0);
+    hist_->GetXaxis()->SetAxisColor(0);
+    hist_->GetYaxis()->SetAxisColor(0);
+    hist_->Draw("COL");
+  }
+
 private:
-    std::vector<float> data_;
-    std::unique_ptr<TH2F> hist_;
+  std::vector<float> data_;
+  std::unique_ptr<TH2F> hist_;
 };
 
-} 
+} // namespace analysis
 
 #endif

--- a/include/rarexsec/plot/IEventDisplay.h
+++ b/include/rarexsec/plot/IEventDisplay.h
@@ -12,35 +12,40 @@
 namespace analysis {
 
 class IEventDisplay {
-  public:
-    IEventDisplay(std::string tag, std::string title, int image_size,
-                  std::string output_directory)
-        : tag_(std::move(tag)), title_(std::move(title)), image_size_(image_size),
-          output_directory_(std::move(output_directory)) {}
+public:
+  IEventDisplay(std::string tag, std::string title, int canvas_size,
+                std::string output_directory)
+      : tag_(std::move(tag)), title_(std::move(title)),
+        canvas_size_(canvas_size),
+        output_directory_(std::move(output_directory)) {}
 
-    virtual ~IEventDisplay() = default;
+  virtual ~IEventDisplay() = default;
 
-    void drawAndSave(const std::string &format = "png") {
-        gSystem->mkdir(output_directory_.c_str(), true);
+  void drawAndSave(const std::string &format = "png") {
+    gSystem->mkdir(output_directory_.c_str(), true);
 
-        log::info("EventDisplay", "Saving", tag_, "to", output_directory_);
+    log::info("EventDisplay", "Saving", tag_, "to", output_directory_);
 
-        TCanvas canvas(tag_.c_str(), title_.c_str(), image_size_, image_size_);
-        canvas.SetCanvasSize(image_size_, image_size_);
-        this->draw(canvas);
-        canvas.Update();
-        canvas.SaveAs((output_directory_ + "/" + tag_ + "." + format).c_str());
-    }
+    TCanvas canvas(tag_.c_str(), title_.c_str(), canvas_size_, canvas_size_);
+    canvas.SetCanvasSize(canvas_size_, canvas_size_);
+    canvas.SetBorderMode(0);
+    canvas.SetFrameBorderMode(0);
+    canvas.SetFrameLineColor(0);
+    canvas.SetFrameLineWidth(0);
+    this->draw(canvas);
+    canvas.Update();
+    canvas.SaveAs((output_directory_ + "/" + tag_ + "." + format).c_str());
+  }
 
-  protected:
-    virtual void draw(TCanvas &canvas) = 0;
+protected:
+  virtual void draw(TCanvas &canvas) = 0;
 
-    std::string tag_;
-    std::string title_;
-    int image_size_;
-    std::string output_directory_;
+  std::string tag_;
+  std::string title_;
+  int canvas_size_;
+  std::string output_directory_;
 };
 
-}
+} // namespace analysis
 
 #endif

--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -1,6 +1,7 @@
 #ifndef SEMANTICDISPLAY_H
 #define SEMANTICDISPLAY_H
 
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -15,57 +16,59 @@
 namespace analysis {
 
 class SemanticDisplay : public IEventDisplay {
-  public:
-    SemanticDisplay(std::string tag, std::string title, std::vector<int> data,
-                    int image_size, std::string output_directory)
-        : IEventDisplay(std::move(tag), std::move(title), image_size,
-                        std::move(output_directory)),
-          data_(std::move(data)) {}
+public:
+  SemanticDisplay(std::string tag, std::string title, std::vector<int> data,
+                  int canvas_size, std::string output_directory)
+      : IEventDisplay(std::move(tag), std::move(title), canvas_size,
+                      std::move(output_directory)),
+        data_(std::move(data)) {}
 
-  protected:
-    void draw(TCanvas &canvas) override {
-        const int palette_size = 10;
-        const int palette_step = 2;
-        const int bin_offset = 1;
-        const int stats_off = 0;
-        const double z_min = -0.5;
-        const double z_max = 9.5;
+protected:
+  void draw(TCanvas &canvas) override {
+    const int palette_size = 10;
+    const int palette_step = 2;
+    const int bin_offset = 1;
+    const int stats_off = 0;
+    const double z_min = -0.5;
+    const double z_max = 9.5;
 
-        hist_ = std::make_unique<TH2F>(tag_.c_str(), title_.c_str(), image_size_, 0,
-                                       image_size_, image_size_, 0, image_size_);
+    int dim = static_cast<int>(std::sqrt(data_.size()));
+    hist_ = std::make_unique<TH2F>(tag_.c_str(), title_.c_str(), dim, 0, dim,
+                                   dim, 0, dim);
 
-        int palette[palette_size];
-        for (int i = 0; i < palette_size; ++i)
-            palette[i] = kWhite + (i > 0 ? i * palette_step : 0);
-        gStyle->SetPalette(palette_size, palette);
+    int palette[palette_size];
+    for (int i = 0; i < palette_size; ++i)
+      palette[i] = kWhite + (i > 0 ? i * palette_step : 0);
+    gStyle->SetPalette(palette_size, palette);
 
-        for (int r = 0; r < image_size_; ++r) {
-            for (int c = 0; c < image_size_; ++c) {
-                hist_->SetBinContent(c + bin_offset, r + bin_offset,
-                                     data_[r * image_size_ + c]);
-            }
-        }
-
-        hist_->SetStats(stats_off);
-        hist_->GetZaxis()->SetRangeUser(z_min, z_max);
-        canvas.SetTicks(0, 0);
-        hist_->GetXaxis()->SetTitle("Local Wire Coordinate");
-        hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
-        hist_->GetXaxis()->CenterTitle(true);
-        hist_->GetYaxis()->CenterTitle(true);
-        hist_->GetXaxis()->SetTickLength(0);
-        hist_->GetYaxis()->SetTickLength(0);
-        hist_->GetXaxis()->SetLabelSize(0);
-        hist_->GetYaxis()->SetLabelSize(0);
-        hist_->Draw("COL");
+    for (int r = 0; r < dim; ++r) {
+      for (int c = 0; c < dim; ++c) {
+        hist_->SetBinContent(c + bin_offset, r + bin_offset,
+                             data_[r * dim + c]);
+      }
     }
 
-  private:
-    std::vector<int> data_;
-    std::unique_ptr<TH2F> hist_;
+    hist_->SetStats(stats_off);
+    hist_->GetZaxis()->SetRangeUser(z_min, z_max);
+    canvas.SetTicks(0, 0);
+    hist_->GetXaxis()->SetTitle("Local Wire Coordinate");
+    hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
+    hist_->GetXaxis()->CenterTitle(true);
+    hist_->GetYaxis()->CenterTitle(true);
+    hist_->GetXaxis()->SetTickLength(0);
+    hist_->GetYaxis()->SetTickLength(0);
+    hist_->GetXaxis()->SetLabelSize(0);
+    hist_->GetYaxis()->SetLabelSize(0);
+    hist_->GetXaxis()->SetAxisColor(0);
+    hist_->GetYaxis()->SetAxisColor(0);
+    hist_->Draw("COL");
+  }
+
+private:
+  std::vector<int> data_;
+  std::unique_ptr<TH2F> hist_;
 };
 
 } // namespace analysis
 
 #endif
-

--- a/src/plug/plotting/EventDisplayPlugin.cc
+++ b/src/plug/plotting/EventDisplayPlugin.cc
@@ -1,226 +1,252 @@
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <mutex>
-#include <atomic>
+#include <nlohmann/json.hpp>
 #include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
-#include <nlohmann/json.hpp>
 
 #include <ROOT/RConfig.h>
 #include <ROOT/RDataFrame.hxx>
 
-#include <rarexsec/plug/PluginRegistry.h>
-#include <rarexsec/data/AnalysisDataLoader.h>
-#include <rarexsec/utils/Logger.h>
-#include <rarexsec/plug/IPlotPlugin.h>
-#include <rarexsec/plot/DetectorDisplay.h>
-#include <rarexsec/plot/SemanticDisplay.h>
 #include <rarexsec/core/SelectionQuery.h>
 #include <rarexsec/core/SelectionRegistry.h>
+#include <rarexsec/data/AnalysisDataLoader.h>
+#include <rarexsec/plot/DetectorDisplay.h>
+#include <rarexsec/plot/SemanticDisplay.h>
+#include <rarexsec/plug/IPlotPlugin.h>
+#include <rarexsec/plug/PluginRegistry.h>
+#include <rarexsec/utils/Logger.h>
 
 namespace analysis {
 
 class EventDisplayPlugin : public IPlotPlugin {
-  public:
-    struct DisplayConfig {
-        std::string sample;
-        std::string region;
-        SelectionQuery selection;
-        std::optional<std::string> selection_expr;
-        int n_events{1};
-        int image_size{512};
-        std::filesystem::path output_directory{"./plots/event_displays"};
-        std::vector<std::string> planes{"U","V","W"};
-        std::string mode{"detector"};
-        std::string file_pattern{"{plane}_{run}_{sub}_{evt}"};
-        std::optional<unsigned> seed;
-        std::optional<std::string> order_by;
-        bool order_desc{true};
-        std::string manifest_path;
-    };
+public:
+  struct DisplayConfig {
+    std::string sample;
+    std::string region;
+    SelectionQuery selection;
+    std::optional<std::string> selection_expr;
+    int n_events{1};
+    int image_size{1024};
+    std::filesystem::path output_directory{"./plots/event_displays"};
+    std::vector<std::string> planes{"U", "V", "W"};
+    std::string mode{"detector"};
+    std::string file_pattern{"{plane}_{run}_{sub}_{evt}"};
+    std::optional<unsigned> seed;
+    std::optional<std::string> order_by;
+    bool order_desc{true};
+    std::string manifest_path;
+  };
 
-    EventDisplayPlugin(const PluginArgs &args, AnalysisDataLoader *loader) : loader_(loader) {
-        const auto &cfg = args.plot_configs;
-        if (!cfg.contains("event_displays") || !cfg.at("event_displays").is_array()) {
-            throw std::runtime_error("EventDisplayPlugin missing event_displays");
-        }
-        SelectionRegistry sel_reg;
-        for (auto const &ed : cfg.at("event_displays")) {
-            DisplayConfig dc;
-            dc.sample = ed.at("sample").get<std::string>();
-            dc.region = ed.value("region", std::string{});
-            dc.n_events = ed.value("n_events", 1);
-            dc.image_size = ed.value("image_size", 512);
-            dc.output_directory = ed.value("output_directory", std::string{"./plots/event_displays"});
-            dc.output_directory = std::filesystem::absolute(dc.output_directory).lexically_normal();
-            dc.planes = ed.value("planes", std::vector<std::string>{"U","V","W"});
-            dc.mode = ed.value("mode", std::string{"detector"});
-            dc.file_pattern = ed.value("file_pattern", std::string{"{plane}_{run}_{sub}_{evt}"});
-            if (ed.contains("seed")) dc.seed = ed.at("seed").get<unsigned>();
-            if (ed.contains("order_by")) {
-                dc.order_by = ed.at("order_by").get<std::string>();
-                dc.order_desc = ed.value("order_desc", true);
-            }
-            dc.manifest_path = ed.value("manifest", std::string{});
-            if (ed.contains("selection_expr")) dc.selection_expr = ed.at("selection_expr").get<std::string>();
-            if (!dc.region.empty()) {
-                try {
-                    dc.selection = sel_reg.get(dc.region);
-                } catch (const std::exception &) {
-                    log::error("EventDisplayPlugin", "Unknown region:", dc.region);
-                }
-            }
-            if (dc.selection_expr) {
-                dc.selection = SelectionQuery(*dc.selection_expr);
-            }
-            configs_.push_back(std::move(dc));
-        }
+  EventDisplayPlugin(const PluginArgs &args, AnalysisDataLoader *loader)
+      : loader_(loader) {
+    const auto &cfg = args.plot_configs;
+    if (!cfg.contains("event_displays") ||
+        !cfg.at("event_displays").is_array()) {
+      throw std::runtime_error("EventDisplayPlugin missing event_displays");
     }
+    SelectionRegistry sel_reg;
+    for (auto const &ed : cfg.at("event_displays")) {
+      DisplayConfig dc;
+      dc.sample = ed.at("sample").get<std::string>();
+      dc.region = ed.value("region", std::string{});
+      dc.n_events = ed.value("n_events", 1);
+      dc.image_size = ed.value("image_size", 1024);
+      dc.output_directory =
+          ed.value("output_directory", std::string{"./plots/event_displays"});
+      dc.output_directory =
+          std::filesystem::absolute(dc.output_directory).lexically_normal();
+      dc.planes = ed.value("planes", std::vector<std::string>{"U", "V", "W"});
+      dc.mode = ed.value("mode", std::string{"detector"});
+      dc.file_pattern =
+          ed.value("file_pattern", std::string{"{plane}_{run}_{sub}_{evt}"});
+      if (ed.contains("seed"))
+        dc.seed = ed.at("seed").get<unsigned>();
+      if (ed.contains("order_by")) {
+        dc.order_by = ed.at("order_by").get<std::string>();
+        dc.order_desc = ed.value("order_desc", true);
+      }
+      dc.manifest_path = ed.value("manifest", std::string{});
+      if (ed.contains("selection_expr"))
+        dc.selection_expr = ed.at("selection_expr").get<std::string>();
+      if (!dc.region.empty()) {
+        try {
+          dc.selection = sel_reg.get(dc.region);
+        } catch (const std::exception &) {
+          log::error("EventDisplayPlugin", "Unknown region:", dc.region);
+        }
+      }
+      if (dc.selection_expr) {
+        dc.selection = SelectionQuery(*dc.selection_expr);
+      }
+      configs_.push_back(std::move(dc));
+    }
+  }
 
-    void onPlot(const AnalysisResult &) override {
+  void onPlot(const AnalysisResult &) override {
 #if defined(R__HAS_IMPLICITMT)
-        if (ROOT::IsImplicitMTEnabled() && ROOT::GetThreadPoolSize() <= 1) {
-            ROOT::DisableImplicitMT();
-            log::info("EventDisplayPlugin",
-                      "Implicit multithreading not supported; running single-threaded.");
-        }
+    if (ROOT::IsImplicitMTEnabled() && ROOT::GetThreadPoolSize() <= 1) {
+      ROOT::DisableImplicitMT();
+      log::info(
+          "EventDisplayPlugin",
+          "Implicit multithreading not supported; running single-threaded.");
+    }
 #else
-        if (ROOT::IsImplicitMTEnabled()) {
-            ROOT::DisableImplicitMT();
-            log::info("EventDisplayPlugin",
-                      "ROOT built without multithreading; running single-threaded.");
-        }
+    if (ROOT::IsImplicitMTEnabled()) {
+      ROOT::DisableImplicitMT();
+      log::info("EventDisplayPlugin",
+                "ROOT built without multithreading; running single-threaded.");
+    }
 #endif
-        if (!loader_) {
-            log::error("EventDisplayPlugin::onPlot", "No AnalysisDataLoader context provided");
-            return;
-        }
-        for (auto const &cfg : configs_) {
-            auto &frames = loader_->getSampleFrames();
-            auto skey = SampleKey{cfg.sample};
-            auto it = frames.find(skey);
-            if (it == frames.end()) {
-                log::error("EventDisplayPlugin", "Unknown sample:", cfg.sample);
-                continue;
-            }
-            auto &sample = it->second;
-            auto df = sample.nominal_node_;
+    if (!loader_) {
+      log::error("EventDisplayPlugin::onPlot",
+                 "No AnalysisDataLoader context provided");
+      return;
+    }
+    for (auto const &cfg : configs_) {
+      auto &frames = loader_->getSampleFrames();
+      auto skey = SampleKey{cfg.sample};
+      auto it = frames.find(skey);
+      if (it == frames.end()) {
+        log::error("EventDisplayPlugin", "Unknown sample:", cfg.sample);
+        continue;
+      }
+      auto &sample = it->second;
+      auto df = sample.nominal_node_;
 
-            std::string filter = cfg.selection.str();
-            bool has_filter = filter.find_first_not_of(" \t\n\r") != std::string::npos;
-            if (has_filter)
-                df = df.Filter(filter);
+      std::string filter = cfg.selection.str();
+      bool has_filter =
+          filter.find_first_not_of(" \t\n\r") != std::string::npos;
+      if (has_filter)
+        df = df.Filter(filter);
 
-            if (cfg.order_by) {
-                log::warn("EventDisplayPlugin", "order_by not implemented; proceeding without ordering");
-            }
+      if (cfg.order_by) {
+        log::warn("EventDisplayPlugin",
+                  "order_by not implemented; proceeding without ordering");
+      }
 
-            auto limited = df.Range(static_cast<ULong64_t>(cfg.n_events));
-            std::filesystem::path out_dir = cfg.output_directory / cfg.sample;
+      auto limited = df.Range(static_cast<ULong64_t>(cfg.n_events));
+      std::filesystem::path out_dir = cfg.output_directory / cfg.sample;
 
-            // Ensure the output directory exists before processing events.  Using
-            // std::filesystem avoids relying solely on ROOT's gSystem which may
-            // fail silently on some platforms.
-            std::error_code ec;
-            std::filesystem::create_directories(out_dir, ec);
-            if (ec) {
-                log::error("EventDisplayPlugin", "Failed to create output directory:",
-                          out_dir.string(), ec.message());
-            }
+      // Ensure the output directory exists before processing events.  Using
+      // std::filesystem avoids relying solely on ROOT's gSystem which may
+      // fail silently on some platforms.
+      std::error_code ec;
+      std::filesystem::create_directories(out_dir, ec);
+      if (ec) {
+        log::error("EventDisplayPlugin",
+                   "Failed to create output directory:", out_dir.string(),
+                   ec.message());
+      }
 
-            nlohmann::json manifest = nlohmann::json::array();
-            std::mutex manifest_mutex;
-            std::atomic<size_t> saved{0};
+      nlohmann::json manifest = nlohmann::json::array();
+      std::mutex manifest_mutex;
+      std::atomic<size_t> saved{0};
 
-            const std::vector<std::string> cols{
-                "run","sub","evt",
-                "event_detector_image_u","event_detector_image_v","event_detector_image_w",
-                "semantic_image_u","semantic_image_v","semantic_image_w"
+      const std::vector<std::string> cols{"run",
+                                          "sub",
+                                          "evt",
+                                          "event_detector_image_u",
+                                          "event_detector_image_v",
+                                          "event_detector_image_w",
+                                          "semantic_image_u",
+                                          "semantic_image_v",
+                                          "semantic_image_w"};
+
+      auto cfg_copy = cfg; // capture by value
+
+      limited.ForeachSlot(
+          [&](unsigned /*slot*/, int run, int sub, int evt,
+              const std::vector<float> &det_u, const std::vector<float> &det_v,
+              const std::vector<float> &det_w, const std::vector<int> &sem_u,
+              const std::vector<int> &sem_v, const std::vector<int> &sem_w) {
+            auto formatTag = [](std::string pattern, const std::string &plane,
+                                int r, int s, int e) {
+              auto replace_all = [](std::string &str, const std::string &from,
+                                    const std::string &to) {
+                size_t pos = 0;
+                while ((pos = str.find(from, pos)) != std::string::npos) {
+                  str.replace(pos, from.size(), to);
+                  pos += to.size();
+                }
+              };
+              replace_all(pattern, "{plane}", plane);
+              replace_all(pattern, "{run}", std::to_string(r));
+              replace_all(pattern, "{sub}", std::to_string(s));
+              replace_all(pattern, "{evt}", std::to_string(e));
+              return pattern;
             };
 
-            auto cfg_copy = cfg; // capture by value
+            auto process = [&](const std::string &plane,
+                               const std::vector<float> &det,
+                               const std::vector<int> &sem) {
+              std::string tag =
+                  formatTag(cfg_copy.file_pattern, plane, run, sub, evt);
+              std::string title = "Plane " + plane + " Detector (" +
+                                  std::to_string(run) + " Run, " +
+                                  std::to_string(sub) + " SubRun, " +
+                                  std::to_string(evt) + " Event)";
+              auto out_file = out_dir / (tag + ".png");
+              if (cfg_copy.mode == "semantic") {
+                SemanticDisplay s(tag, title, sem, cfg_copy.image_size,
+                                  out_dir.string());
+                s.drawAndSave();
+              } else {
+                DetectorDisplay d(tag, title, det, cfg_copy.image_size,
+                                  out_dir.string());
+                d.drawAndSave();
+              }
+              log::info("EventDisplayPlugin",
+                        "Saved event display:", out_file.string());
+              if (!cfg_copy.manifest_path.empty()) {
+                std::lock_guard<std::mutex> lock(manifest_mutex);
+                manifest.push_back({{"run", run},
+                                    {"sub", sub},
+                                    {"evt", evt},
+                                    {"plane", plane},
+                                    {"file", out_file.string()}});
+              }
+              ++saved;
+            };
 
-            limited.ForeachSlot([&](unsigned /*slot*/, int run, int sub, int evt,
-                                     const std::vector<float>& det_u,
-                                     const std::vector<float>& det_v,
-                                     const std::vector<float>& det_w,
-                                     const std::vector<int>&   sem_u,
-                                     const std::vector<int>&   sem_v,
-                                     const std::vector<int>&   sem_w){
-
-                auto formatTag = [](std::string pattern, const std::string& plane, int r, int s, int e){
-                    auto replace_all = [](std::string &str, const std::string &from, const std::string &to){
-                        size_t pos = 0;
-                        while ((pos = str.find(from, pos)) != std::string::npos) {
-                            str.replace(pos, from.size(), to);
-                            pos += to.size();
-                        }
-                    };
-                    replace_all(pattern, "{plane}", plane);
-                    replace_all(pattern, "{run}", std::to_string(r));
-                    replace_all(pattern, "{sub}", std::to_string(s));
-                    replace_all(pattern, "{evt}", std::to_string(e));
-                    return pattern;
-                };
-
-                auto process = [&](const std::string& plane,
-                                   const std::vector<float>& det,
-                                   const std::vector<int>& sem){
-                    std::string tag = formatTag(cfg_copy.file_pattern, plane, run, sub, evt);
-                    std::string title = "Plane " + plane + " Detector (" +
-                                        std::to_string(run) + " Run, " +
-                                        std::to_string(sub) + " SubRun, " +
-                                        std::to_string(evt) + " Event)";
-                    auto out_file = out_dir / (tag + ".png");
-                    if (cfg_copy.mode == "semantic") {
-                        SemanticDisplay s(tag, title, sem, cfg_copy.image_size,
-                                          out_dir.string());
-                        s.drawAndSave();
-                    } else {
-                        DetectorDisplay d(tag, title, det, cfg_copy.image_size,
-                                          out_dir.string());
-                        d.drawAndSave();
-                    }
-                    log::info("EventDisplayPlugin", "Saved event display:", out_file.string());
-                    if (!cfg_copy.manifest_path.empty()) {
-                        std::lock_guard<std::mutex> lock(manifest_mutex);
-                        manifest.push_back({{"run",run},{"sub",sub},{"evt",evt},{"plane",plane},{"file",out_file.string()}});
-                    }
-                    ++saved;
-                };
-
-                for (auto const& plane : cfg_copy.planes) {
-                    if (plane == "U") process("U", det_u, sem_u);
-                    else if (plane == "V") process("V", det_v, sem_v);
-                    else if (plane == "W") process("W", det_w, sem_w);
-                }
-            }, cols);
-
-            if (!cfg.manifest_path.empty()) {
-                std::ofstream ofs(cfg.manifest_path);
-                ofs << manifest.dump(2);
-                log::info("EventDisplayPlugin", "Wrote event display manifest:", cfg.manifest_path);
+            for (auto const &plane : cfg_copy.planes) {
+              if (plane == "U")
+                process("U", det_u, sem_u);
+              else if (plane == "V")
+                process("V", det_v, sem_v);
+              else if (plane == "W")
+                process("W", det_w, sem_w);
             }
+          },
+          cols);
 
-            if (saved == 0) {
-                log::warn("EventDisplayPlugin", "No events matched selection for sample:",
-                          cfg.sample);
-            }
-        }
+      if (!cfg.manifest_path.empty()) {
+        std::ofstream ofs(cfg.manifest_path);
+        ofs << manifest.dump(2);
+        log::info("EventDisplayPlugin",
+                  "Wrote event display manifest:", cfg.manifest_path);
+      }
+
+      if (saved == 0) {
+        log::warn("EventDisplayPlugin",
+                  "No events matched selection for sample:", cfg.sample);
+      }
     }
+  }
 
-    static void setLegacyLoader(AnalysisDataLoader *ldr) { legacy_loader_ = ldr; }
-    static AnalysisDataLoader *legacyLoader() { return legacy_loader_; }
+  static void setLegacyLoader(AnalysisDataLoader *ldr) { legacy_loader_ = ldr; }
+  static AnalysisDataLoader *legacyLoader() { return legacy_loader_; }
 
-  private:
-    std::vector<DisplayConfig> configs_;
-    AnalysisDataLoader *loader_;
-    inline static AnalysisDataLoader *legacy_loader_ = nullptr;
+private:
+  std::vector<DisplayConfig> configs_;
+  AnalysisDataLoader *loader_;
+  inline static AnalysisDataLoader *legacy_loader_ = nullptr;
 };
 
 } // namespace analysis
@@ -229,15 +255,16 @@ ANALYSIS_REGISTER_PLUGIN(analysis::IPlotPlugin, analysis::AnalysisDataLoader,
                          "EventDisplayPlugin", analysis::EventDisplayPlugin)
 
 #ifdef BUILD_PLUGIN
-extern "C" analysis::IPlotPlugin *createEventDisplayPlugin(
-    const analysis::PluginArgs &args) {
-    return new analysis::EventDisplayPlugin(args,
-                                           analysis::EventDisplayPlugin::legacyLoader());
+extern "C" analysis::IPlotPlugin *
+createEventDisplayPlugin(const analysis::PluginArgs &args) {
+  return new analysis::EventDisplayPlugin(
+      args, analysis::EventDisplayPlugin::legacyLoader());
 }
-extern "C" analysis::IPlotPlugin *createPlotPlugin(const analysis::PluginArgs &args) {
-    return createEventDisplayPlugin(args);
+extern "C" analysis::IPlotPlugin *
+createPlotPlugin(const analysis::PluginArgs &args) {
+  return createEventDisplayPlugin(args);
 }
 extern "C" void setPluginContext(analysis::AnalysisDataLoader *loader) {
-    analysis::EventDisplayPlugin::setLegacyLoader(loader);
+  analysis::EventDisplayPlugin::setLegacyLoader(loader);
 }
 #endif


### PR DESCRIPTION
## Summary
- Separate canvas pixel size from data grid resolution in event display framework
- Derive detector and semantic display dimensions from input data vectors

## Testing
- `source .container.sh` *(fails: /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh: No such file or directory)*
- `source .setup.sh` *(fails: /cvmfs/uboone.opensciencegrid.org/products/setup_uboone_mcc9.sh: No such file or directory)*
- `source .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68c42e96df50832eb13a3e4f5f43f9e7