### PR TITLE
Improve semantic display palette

### DIFF
--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -15,57 +15,71 @@
 namespace analysis {
 
 class SemanticDisplay : public IEventDisplay {
-  public:
-    SemanticDisplay(std::string tag, std::string title, std::vector<int> data,
-                    int image_size, std::string output_directory)
-        : IEventDisplay(std::move(tag), std::move(title), image_size,
-                        std::move(output_directory)),
-          data_(std::move(data)) {}
+public:
+  SemanticDisplay(std::string tag, std::string title, std::vector<int> data,
+                  int image_size, std::string output_directory)
+      : IEventDisplay(std::move(tag), std::move(title), image_size,
+                      std::move(output_directory)),
+        data_(std::move(data)) {}
 
-  protected:
-    void draw(TCanvas &canvas) override {
-        const int palette_size = 10;
-        const int palette_step = 2;
-        const int bin_offset = 1;
-        const int stats_off = 0;
-        const double z_min = -0.5;
-        const double z_max = 9.5;
+protected:
+  void draw(TCanvas &canvas) override {
+    constexpr int palette_size = 15;
+    const int palette[palette_size] = {
+        kGray,      // Empty
+        kGray + 1,  // Cosmic
+        kBlue,      // Muon
+        kMagenta,   // Electron
+        kCyan,      // Photon
+        kRed,       // ChargedPion
+        kOrange,    // NeutralPion
+        kYellow,    // Neutron
+        kGreen,     // Proton
+        kTeal,      // ChargedKaon
+        kAzure,     // NeutralKaon
+        kViolet,    // Lambda
+        kPink,      // ChargedSigma
+        kSpring,    // NeutralSigma
+        kBlack      // Other
+    };
+    constexpr int bin_offset = 1;
+    constexpr int stats_off = 0;
+    constexpr double z_min = -0.5;
+    constexpr double z_max = palette_size - 0.5;
 
-        hist_ = std::make_unique<TH2F>(tag_.c_str(), title_.c_str(), image_size_, 0,
-                                       image_size_, image_size_, 0, image_size_);
+    hist_ = std::make_unique<TH2F>(tag_.c_str(), title_.c_str(), image_size_, 0,
+                                   image_size_, image_size_, 0, image_size_);
 
-        int palette[palette_size];
-        for (int i = 0; i < palette_size; ++i)
-            palette[i] = kWhite + (i > 0 ? i * palette_step : 0);
-        gStyle->SetPalette(palette_size, palette);
+    gStyle->SetPalette(palette_size, palette);
 
-        for (int r = 0; r < image_size_; ++r) {
-            for (int c = 0; c < image_size_; ++c) {
-                hist_->SetBinContent(c + bin_offset, r + bin_offset,
-                                     data_[r * image_size_ + c]);
-            }
-        }
-
-        hist_->SetStats(stats_off);
-        hist_->GetZaxis()->SetRangeUser(z_min, z_max);
-        canvas.SetTicks(0, 0);
-        hist_->GetXaxis()->SetTitle("Local Wire Coordinate");
-        hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
-        hist_->GetXaxis()->CenterTitle(true);
-        hist_->GetYaxis()->CenterTitle(true);
-        hist_->GetXaxis()->SetTickLength(0);
-        hist_->GetYaxis()->SetTickLength(0);
-        hist_->GetXaxis()->SetLabelSize(0);
-        hist_->GetYaxis()->SetLabelSize(0);
-        hist_->Draw("COL");
+    for (int r = 0; r < image_size_; ++r) {
+      for (int c = 0; c < image_size_; ++c) {
+        hist_->SetBinContent(c + bin_offset, r + bin_offset,
+                             data_[r * image_size_ + c]);
+      }
     }
 
-  private:
-    std::vector<int> data_;
-    std::unique_ptr<TH2F> hist_;
+    hist_->SetStats(stats_off);
+    hist_->GetZaxis()->SetRangeUser(z_min, z_max);
+    canvas.SetFillColor(kGray);
+    canvas.SetFrameFillColor(kGray);
+    canvas.SetTicks(0, 0);
+    hist_->GetXaxis()->SetTitle("Local Wire Coordinate");
+    hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
+    hist_->GetXaxis()->CenterTitle(true);
+    hist_->GetYaxis()->CenterTitle(true);
+    hist_->GetXaxis()->SetTickLength(0);
+    hist_->GetYaxis()->SetTickLength(0);
+    hist_->GetXaxis()->SetLabelSize(0);
+    hist_->GetYaxis()->SetLabelSize(0);
+    hist_->Draw("COL");
+  }
+
+private:
+  std::vector<int> data_;
+  std::unique_ptr<TH2F> hist_;
 };
 
 } // namespace analysis
 
 #endif
-


### PR DESCRIPTION
## Summary
- provide 15-color palette for semantic event displays
- extend semantic display range to cover all labels
- use neutral grey background for empty pixels and canvas

## Testing
- `source .setup.sh` *(fails: /cvmfs/uboone.opensciencegrid.org/products/setup_uboone_mcc9.sh: No such file or directory)*
- `source .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68c42f61c138832eb4bad14c1675934d