### PR TITLE
Remove overlay display mode from event displays

### DIFF
--- a/include/rarexsec/flow/EventDisplayBuilder.h
+++ b/include/rarexsec/flow/EventDisplayBuilder.h
@@ -9,17 +9,9 @@ namespace analysis::dsl {
 
 struct DisplayMode {
   std::string kind;
-  double overlay_alpha = 1.0;
-
-  DisplayMode &alpha(double a) {
-    overlay_alpha = a;
-    return *this;
-  }
-  double alpha() const { return overlay_alpha; }
 };
 inline DisplayMode detector() { return {"detector"}; }
 inline DisplayMode semantic() { return {"semantic"}; }
-inline DisplayMode overlay() { return {"overlay"}; }
 
 enum class Direction { Asc, Desc };
 static constexpr Direction asc = Direction::Asc;
@@ -87,8 +79,6 @@ public:
                      {"image_size", image_size_},
                      {"output_directory", out_dir_},
                      {"mode", mode_.kind}};
-    if (mode_.kind == "overlay")
-      j["overlay_alpha"] = mode_.alpha();
     if (!planes_.empty())
       j["planes"] = planes_;
     if (selection_expr_)

--- a/src/run/study_all.cpp
+++ b/src/run/study_all.cpp
@@ -38,7 +38,7 @@ int main() {
       events().from("numi_on").in("NUMU_CC")
         .limit(12).size(900)
         .planes({"U","V","W"})
-        .mode(overlay().alpha(0.35))
+        .mode(detector())
         .out("plots/event_displays")
     )
     .snapshot(


### PR DESCRIPTION
## Summary
- drop unused overlay display mode and alpha handling from EventDisplayBuilder
- update study_all example to use detector mode

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: command not found/setup scripts missing)*
- `source .build.sh` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c43078e560832ebeffee86c1d99aa7