### PR TITLE
Simplify event display image titles

### DIFF
--- a/src/plug/plotting/EventDisplayPlugin.cc
+++ b/src/plug/plotting/EventDisplayPlugin.cc
@@ -188,10 +188,9 @@ public:
                                const std::vector<int> &sem) {
               std::string tag =
                   formatTag(cfg_copy.file_pattern, plane, run, sub, evt);
-              std::string title = "Plane " + plane + " Detector (" +
-                                  std::to_string(run) + " Run, " +
-                                  std::to_string(sub) + " SubRun, " +
-                                  std::to_string(evt) + " Event)";
+              std::string title =
+                  "Run " + std::to_string(run) + ", SubRun " +
+                  std::to_string(sub) + ", Event " + std::to_string(evt);
               auto out_file = out_dir / (tag + ".png");
               if (cfg_copy.mode == "semantic") {
                 SemanticDisplay s(tag, title, sem, cfg_copy.image_size,


### PR DESCRIPTION
## Summary
- Update event display plugin so saved images use title format `Run <>, SubRun <>, Event <>`

## Testing
- `cmake -S . -B build` *(fails: could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c432fc37e4832e94c6ec44b1b7d01b