### PR TITLE
Align event display title and axes

### DIFF
--- a/include/rarexsec/plot/DetectorDisplay.h
+++ b/include/rarexsec/plot/DetectorDisplay.h
@@ -49,6 +49,9 @@ protected:
     hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
     hist_->GetXaxis()->CenterTitle(true);
     hist_->GetYaxis()->CenterTitle(true);
+    constexpr double axis_offset = 1.2;
+    hist_->GetXaxis()->SetTitleOffset(axis_offset);
+    hist_->GetYaxis()->SetTitleOffset(axis_offset);
     hist_->GetXaxis()->SetTickLength(0);
     hist_->GetYaxis()->SetTickLength(0);
     hist_->GetXaxis()->SetLabelSize(0);

--- a/include/rarexsec/plot/IEventDisplay.h
+++ b/include/rarexsec/plot/IEventDisplay.h
@@ -6,6 +6,7 @@
 
 #include "TCanvas.h"
 #include "TSystem.h"
+#include "TStyle.h"
 
 #include <rarexsec/utils/Logger.h>
 
@@ -32,6 +33,14 @@ public:
     canvas.SetFrameBorderMode(0);
     canvas.SetFrameLineColor(0);
     canvas.SetFrameLineWidth(0);
+
+    constexpr double margin = 0.10;
+    canvas.SetTopMargin(margin);
+    canvas.SetBottomMargin(margin);
+    canvas.SetLeftMargin(margin);
+    canvas.SetRightMargin(margin);
+    gStyle->SetTitleAlign(23);
+    gStyle->SetTitleX(0.5);
     this->draw(canvas);
     canvas.Update();
     canvas.SaveAs((output_directory_ + "/" + tag_ + "." + format).c_str());

--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -58,6 +58,9 @@ protected:
     hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
     hist_->GetXaxis()->CenterTitle(true);
     hist_->GetYaxis()->CenterTitle(true);
+    constexpr double axis_offset = 1.2;
+    hist_->GetXaxis()->SetTitleOffset(axis_offset);
+    hist_->GetYaxis()->SetTitleOffset(axis_offset);
     hist_->GetXaxis()->SetTickLength(0);
     hist_->GetYaxis()->SetTickLength(0);
     hist_->GetXaxis()->SetLabelSize(0);


### PR DESCRIPTION
## Summary
- Center event display titles with the x-axis and use uniform canvas margins
- Apply consistent title offsets to X/Y axes

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: /cvmfs/...: No such file or directory)*
- `source .build.sh` *(fails: could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c432d76ad0832e942ab2067048fc42