### PR TITLE
Restrict grey background to plot bounds

### DIFF
--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -42,7 +42,8 @@ protected:
         kGreen + 2, kYellow, kCyan,    kOrange + 7, kSpring + 4,
         kTeal + 3,  kAzure + 5, kPink + 5, kViolet + 5, kGray + 1};
     gStyle->SetPalette(palette_size, palette.data());
-    canvas.SetFillColor(background);
+    canvas.SetFillColor(kWhite);
+    canvas.SetFrameFillColor(background);
 
     for (int r = 0; r < dim; ++r) {
       for (int c = 0; c < dim; ++c) {


### PR DESCRIPTION
## Summary
- keep semantic event displays white outside the axes by setting canvas fill to kWhite
- leave gray backdrop only within plot bounds by applying frame fill color

## Testing
- `source .build.sh` *(fails: Could not find package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68c4340df1bc832ebac8ccb888e471b5