### PR TITLE
Reduce event display axis label offset

### DIFF
--- a/include/rarexsec/plot/DetectorDisplay.h
+++ b/include/rarexsec/plot/DetectorDisplay.h
@@ -49,7 +49,7 @@ protected:
     hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
     hist_->GetXaxis()->CenterTitle(true);
     hist_->GetYaxis()->CenterTitle(true);
-    constexpr double axis_offset = 1.2;
+    constexpr double axis_offset = 0.4;
     hist_->GetXaxis()->SetTitleOffset(axis_offset);
     hist_->GetYaxis()->SetTitleOffset(axis_offset);
     hist_->GetXaxis()->SetTickLength(0);

--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -59,7 +59,7 @@ protected:
     hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
     hist_->GetXaxis()->CenterTitle(true);
     hist_->GetYaxis()->CenterTitle(true);
-    constexpr double axis_offset = 1.2;
+    constexpr double axis_offset = 0.4;
     hist_->GetXaxis()->SetTitleOffset(axis_offset);
     hist_->GetYaxis()->SetTitleOffset(axis_offset);
     hist_->GetXaxis()->SetTickLength(0);


### PR DESCRIPTION
## Summary
- Reduce axis title offsets in event display plots to position labels closer to the axes

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68c43606f450832ebde1dfc9a5c1c363