### PR TITLE
Ensure square aspect ratio for event displays

### DIFF
--- a/include/rarexsec/plot/IEventDisplay.h
+++ b/include/rarexsec/plot/IEventDisplay.h
@@ -47,6 +47,7 @@ public:
     canvas.SetBottomMargin(margin);
     canvas.SetLeftMargin(margin);
     canvas.SetRightMargin(margin);
+    canvas.SetFixedAspectRatio();
     gStyle->SetTitleAlign(23);
     gStyle->SetTitleX(0.5);
     this->draw(canvas);


### PR DESCRIPTION
## Summary
- enforce equal x and y dimensions in event display plots by fixing canvas aspect ratio

## Testing
- `bash -lc "source .container.sh && source .setup.sh && source .build.sh"` *(fails: /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c436321130832e8de3fc2f93d39f11