### PR TITLE
Use 'Subrun' in event display titles

### DIFF
--- a/src/plug/plotting/EventDisplayPlugin.cc
+++ b/src/plug/plotting/EventDisplayPlugin.cc
@@ -203,7 +203,7 @@ public:
                   formatTag(cfg_copy.file_pattern, plane, run, sub, evt);
               std::string title = "Plane " + plane + " Detector (" +
                                   std::to_string(run) + " Run, " +
-                                  std::to_string(sub) + " SubRun, " +
+                                  std::to_string(sub) + " Subrun, " +
                                   std::to_string(evt) + " Event)";
 
               std::string out_file_record;


### PR DESCRIPTION
## Summary
- standardize event display titles to use `Subrun`

## Testing
- `pytest -q` *(fails: missing numpy/uproot, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c436673aa0832eb5768dc3cbc7d494