### PR TITLE
Adjust event display layout offsets

### DIFF
--- a/include/rarexsec/plot/DetectorDisplay.h
+++ b/include/rarexsec/plot/DetectorDisplay.h
@@ -49,7 +49,11 @@ protected:
     hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
     hist_->GetXaxis()->CenterTitle(true);
     hist_->GetYaxis()->CenterTitle(true);
-    constexpr double axis_offset = 0.4;
+    // Increase the distance between the axis and its label to improve
+    // readability of the event display.  The original value of 0.4 placed the
+    // labels very close to the axis; doubling the offset provides additional
+    // spacing without pushing the text too far away.
+    constexpr double axis_offset = 0.8;
     hist_->GetXaxis()->SetTitleOffset(axis_offset);
     hist_->GetYaxis()->SetTitleOffset(axis_offset);
     hist_->GetXaxis()->SetTickLength(0);

--- a/include/rarexsec/plot/IEventDisplay.h
+++ b/include/rarexsec/plot/IEventDisplay.h
@@ -42,14 +42,19 @@ public:
     canvas.SetFrameLineColor(0);
     canvas.SetFrameLineWidth(0);
 
-    constexpr double margin = 0.10;
-    canvas.SetTopMargin(margin);
-    canvas.SetBottomMargin(margin);
-    canvas.SetLeftMargin(margin);
-    canvas.SetRightMargin(margin);
+    // Use a slightly smaller margin at the top of the canvas so that the plot
+    // title sits closer to the displayed image while keeping the other margins
+    // unchanged.
+    constexpr double top_margin = 0.06;
+    constexpr double side_margin = 0.10;
+    canvas.SetTopMargin(top_margin);
+    canvas.SetBottomMargin(side_margin);
+    canvas.SetLeftMargin(side_margin);
+    canvas.SetRightMargin(side_margin);
     canvas.SetFixedAspectRatio();
     gStyle->SetTitleAlign(23);
     gStyle->SetTitleX(0.5);
+    gStyle->SetTitleY(1 - top_margin / 2.0);
     this->draw(canvas);
     canvas.Update();
     canvas.SaveAs(out_file.c_str());

--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -59,7 +59,9 @@ protected:
     hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
     hist_->GetXaxis()->CenterTitle(true);
     hist_->GetYaxis()->CenterTitle(true);
-    constexpr double axis_offset = 0.4;
+    // Double the axis title offset to separate the labels from the axes and
+    // make them easier to read in the rendered event displays.
+    constexpr double axis_offset = 0.8;
     hist_->GetXaxis()->SetTitleOffset(axis_offset);
     hist_->GetYaxis()->SetTitleOffset(axis_offset);
     hist_->GetXaxis()->SetTickLength(0);


### PR DESCRIPTION
## Summary
- Increase axis label offsets in detector and semantic event displays for better spacing
- Bring event display titles closer to plots by reducing top margin and explicitly positioning the title

## Testing
- `source .build.sh` *(fails: Could not find a package configuration file provided by "ROOT" with any of the following names: ROOTConfig.cmake, root-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c438e68f94832e80f5d2e2c974caec