### PR TITLE
Rasterize PDF outputs

### DIFF
--- a/include/rarexsec/plot/IEventDisplay.h
+++ b/include/rarexsec/plot/IEventDisplay.h
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "TCanvas.h"
+#include "TImage.h"
 #include "TSystem.h"
 #include "TStyle.h"
 
@@ -57,7 +58,14 @@ public:
     gStyle->SetTitleY(1 - top_margin / 2.0);
     this->draw(canvas);
     canvas.Update();
-    canvas.SaveAs(out_file.c_str());
+    if (format == "pdf") {
+      auto image = TImage::Create();
+      image->FromPad(&canvas);
+      image->WriteImage(out_file.c_str());
+      delete image;
+    } else {
+      canvas.SaveAs(out_file.c_str());
+    }
   }
 
 protected:

--- a/include/rarexsec/plot/IHistogramPlot.h
+++ b/include/rarexsec/plot/IHistogramPlot.h
@@ -6,6 +6,7 @@
 
 #include "TCanvas.h"
 #include "TColor.h"
+#include "TImage.h"
 #include "TROOT.h"
 #include "TStyle.h"
 #include "TSystem.h"
@@ -31,7 +32,15 @@ class IHistogramPlot {
         this->setGlobalStyle();
         TCanvas canvas(plot_name_.c_str(), plot_name_.c_str(), 800, 600);
         this->draw(canvas);
-        canvas.SaveAs((output_directory_ + "/" + plot_name_ + "." + format).c_str());
+        auto out_path = output_directory_ + "/" + plot_name_ + "." + format;
+        if (format == "pdf") {
+            auto image = TImage::Create();
+            image->FromPad(&canvas);
+            image->WriteImage(out_path.c_str());
+            delete image;
+        } else {
+            canvas.SaveAs(out_path.c_str());
+        }
     }
 
     static std::string sanitise(std::string s) {


### PR DESCRIPTION
## Summary
- Add rasterized PDF output support for event displays and histogram plots
- Convert canvases to `TImage` for PDF saves to avoid heavy vector rendering

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory and missing setup commands)*
- `source .build.sh` *(fails: Could not find ROOT package configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68c437182bb0832ebbccae3d10a558fe