### PR TITLE
Use direct canvas PDF export for event displays

### DIFF
--- a/include/rarexsec/plot/IEventDisplay.h
+++ b/include/rarexsec/plot/IEventDisplay.h
@@ -5,7 +5,6 @@
 #include <utility>
 
 #include "TCanvas.h"
-#include "TImage.h"
 #include "TSystem.h"
 #include "TStyle.h"
 
@@ -56,13 +55,7 @@ public:
     this->draw(canvas);
     canvas.Update();
     if (format == "pdf") {
-      auto image = TImage::Create();
-      image->FromPad(&canvas);
-      canvas.Clear();
-      image->Draw();
-      canvas.Update();
       canvas.Print(out_file.c_str());
-      delete image;
     } else {
       canvas.SaveAs(out_file.c_str());
     }


### PR DESCRIPTION
## Summary
- Write PDFs directly from the canvas instead of using `TImage`
- Remove redundant `TImage` include in event display interface

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT"; environment missing ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c43db5c25c832eae3a1e6a71a3a63e