### PR TITLE
Align event display axes

### DIFF
--- a/include/rarexsec/plot/IEventDisplay.h
+++ b/include/rarexsec/plot/IEventDisplay.h
@@ -42,8 +42,11 @@ public:
     canvas.SetFrameLineColor(0);
     canvas.SetFrameLineWidth(0);
 
-    constexpr double top_margin = 0.06;
     constexpr double side_margin = 0.10;
+    // Use the same margin on all sides so that the draw area has equal width
+    // and height, ensuring the x and y axes appear with the same absolute
+    // length.
+    constexpr double top_margin = side_margin;
     canvas.SetTopMargin(top_margin);
     canvas.SetBottomMargin(side_margin);
     canvas.SetLeftMargin(side_margin);


### PR DESCRIPTION
## Summary
- Ensure event display canvases use identical margins on all sides so x and y axes render at equal lengths

## Testing
- `source ./.build.sh` *(fails: Could not find ROOTConfig.cmake)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c444446178832eb00f878057b08fdc