### PR TITLE
refactor: clarify event display title

### DIFF
--- a/src/plug/plotting/EventDisplayPlugin.cc
+++ b/src/plug/plotting/EventDisplayPlugin.cc
@@ -201,10 +201,11 @@ public:
                                const std::vector<int> &sem) {
               std::string tag =
                   formatTag(cfg_copy.file_pattern, plane, run, sub, evt);
-              std::string title = "Plane " + plane + " Detector (" +
-                                  std::to_string(run) + " Run, " +
-                                  std::to_string(sub) + " Subrun, " +
-                                  std::to_string(evt) + " Event)";
+              std::string title =
+                  "Detector Plane " + plane + " - Run " +
+                  std::to_string(run) + ", Subrun " +
+                  std::to_string(sub) + ", Event " +
+                  std::to_string(evt);
 
               std::string out_file_record;
               std::string save_target;


### PR DESCRIPTION
## Summary
- Rephrase event display titles to clearly show run, subrun, event, and detector plane

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory; setup commands missing)*
- `source .build.sh` *(fails: Could not find ROOT package configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c4490bb064832ea0bcd933908ae33b