### PR TITLE
Adjust event display axis title spacing

### DIFF
--- a/include/rarexsec/plot/DetectorDisplay.h
+++ b/include/rarexsec/plot/DetectorDisplay.h
@@ -51,9 +51,10 @@ protected:
     hist_->GetYaxis()->CenterTitle(true);
     // Increase the distance between the axis and its label to improve
     // readability of the event display.  The original value of 0.4 placed the
-    // labels very close to the axis; doubling the offset provides additional
-    // spacing without pushing the text too far away.
-    constexpr double axis_offset = 0.8;
+    // labels very close to the axis; tripling the offset aligns the title with
+    // the spacing used for the axis labels and provides additional clearance
+    // without pushing the text too far away.
+    constexpr double axis_offset = 1.2;
     hist_->GetXaxis()->SetTitleOffset(axis_offset);
     hist_->GetYaxis()->SetTitleOffset(axis_offset);
     hist_->GetXaxis()->SetTickLength(0);

--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -78,9 +78,11 @@ protected:
     hist_->GetYaxis()->SetTitle("Local Drift Coordinate");
     hist_->GetXaxis()->CenterTitle(true);
     hist_->GetYaxis()->CenterTitle(true);
-    // Double the axis title offset to separate the labels from the axes and
-    // make them easier to read in the rendered event displays.
-    constexpr double axis_offset = 0.8;
+    // Increase the distance between the axis and its label to improve
+    // readability.  The original value of 0.4 left little space; tripling the
+    // offset matches the separation used for axis labels and keeps the text
+    // clear in the rendered event displays.
+    constexpr double axis_offset = 1.2;
     hist_->GetXaxis()->SetTitleOffset(axis_offset);
     hist_->GetYaxis()->SetTitleOffset(axis_offset);
     hist_->GetXaxis()->SetTickLength(0);


### PR DESCRIPTION
## Summary
- Increase axis title offset for event display histograms to match label spacing

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c448f1c740832ea7b4f9482e477910