### PR TITLE
Customize event display titles

### DIFF
--- a/src/plug/plotting/EventDisplayPlugin.cc
+++ b/src/plug/plotting/EventDisplayPlugin.cc
@@ -201,10 +201,12 @@ public:
                                const std::vector<int> &sem) {
               std::string tag =
                   formatTag(cfg_copy.file_pattern, plane, run, sub, evt);
+              std::string title_prefix =
+                  cfg_copy.mode == "semantic" ? "Semantic Image, Plane "
+                                               : "Detector Image, Plane ";
               std::string title =
-                  "Detector Plane " + plane + " - Run " +
-                  std::to_string(run) + ", Subrun " +
-                  std::to_string(sub) + ", Event " +
+                  title_prefix + plane + " - Run " + std::to_string(run) +
+                  ", Subrun " + std::to_string(sub) + ", Event " +
                   std::to_string(evt);
 
               std::string out_file_record;


### PR DESCRIPTION
## Summary
- Differentiate detector vs semantic display titles with appropriate prefixes

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: Could not find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c456770560832eb332583b3231954f