### PR TITLE
Fix event display builder usage

### DIFF
--- a/src/run/study_region_event_display.cpp
+++ b/src/run/study_region_event_display.cpp
@@ -7,24 +7,22 @@ int main() {
   auto study = Study("Region detector and semantic displays")
                    .data("config/catalogs/samples.json")
                    .region("NUMU_CC", where("quality_event && has_muon"))
-                   .display(events()
-                                .from("mc_strangeness_run1_fhc")
-                                .in("NUMU_CC")
-                               .limit(5)
-                               .size(512)
-                               .format("pdf")
-                               .mode(detector())
-                                .out("plots/event_displays/detector")
-                                .combinedPdf("detector_events.pdf"))
-                   .display(events()
-                                .from("mc_strangeness_run1_fhc")
-                                .in("NUMU_CC")
-                                .limit(5)
-                                .size(512)
-                                .format("pdf")
-                                .mode(semantic())
-                                .out("plots/event_displays/semantic")
-                                .combinedPdf("semantic_events.pdf"));
+                   .display(
+                       events().from("mc_strangeness_run1_fhc")
+                           .in("NUMU_CC")
+                           .limit(5)
+                           .size(512)
+                           .format("pdf")
+                           .mode(detector())
+                           .out("plots/event_displays/detector"))
+                   .display(
+                       events().from("mc_strangeness_run1_fhc")
+                           .in("NUMU_CC")
+                           .limit(5)
+                           .size(512)
+                           .format("pdf")
+                           .mode(semantic())
+                           .out("plots/event_displays/semantic"));
 
   study.run("/tmp/event_displays.root");
   return 0;


### PR DESCRIPTION
## Summary
- fix event display builder usage in region event display study
- output individual detector and semantic event display PDFs

## Testing
- `bash .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68c4576debb8832e813ad9cd484b08ba