### PR TITLE
Fix semantic display legend and pixel counts

### DIFF
--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -3,10 +3,9 @@
 
 #include <array>
 #include <cmath>
-#include <iomanip>
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include "TCanvas.h"
@@ -98,12 +97,19 @@ protected:
       if (v >= 0 && v < palette_size)
         counts[v]++;
     }
-    const double total = static_cast<double>(data_.size());
-
     // Legend describing semantic classes
     legend_entries_.clear();
-    // Wide legend across the top of the canvas
-    legend_ = std::make_unique<TLegend>(0.02, 0.89, 0.98, 0.99);
+    // Place legend using axis coordinates so it stays within histogram bounds
+    const double x_min = hist_->GetXaxis()->GetXmin();
+    const double x_max = hist_->GetXaxis()->GetXmax();
+    const double y_min = hist_->GetYaxis()->GetXmin();
+    const double y_max = hist_->GetYaxis()->GetXmax();
+    const double leg_x1 = x_min + 0.02 * (x_max - x_min);
+    const double leg_x2 = x_min + 0.98 * (x_max - x_min);
+    const double leg_y2 = y_max - 0.05 * (y_max - y_min);
+    const double leg_y1 = leg_y2 - 0.13 * (y_max - y_min);
+    legend_ =
+        std::make_unique<TLegend>(leg_x1, leg_y1, leg_x2, leg_y2, "", "br");
     legend_->SetNColumns(5);
     legend_->SetFillColor(background);
     legend_->SetFillStyle(1001);
@@ -119,7 +125,7 @@ protected:
     const std::array<Style_t, palette_size> styles = {
         1001, 3004, 1001, 1001, 1001, 3005, 1001, 3354,
         1001, 3002, 1001, 1001, 3003, 1001, 1001};
-    for (int i = 0; i < palette_size; ++i) {
+    for (int i = 1; i < palette_size; ++i) {
       auto h = std::make_unique<TH1F>((tag_ + std::to_string(i)).c_str(), "", 1,
                                       0, 1);
       h->SetFillColor(palette[i]);
@@ -127,11 +133,7 @@ protected:
       h->SetLineWidth(1);
       h->SetFillStyle(styles[i]);
       std::ostringstream lab;
-      double frac = 0.0;
-      if (total > 0.0)
-        frac = 100.0 * counts[i] / total;
-      lab << labels[i] << " (" << std::fixed << std::setprecision(1) << frac
-          << "%)";
+      lab << labels[i] << " (" << counts[i] << ")";
       legend_->AddEntry(h.get(), lab.str().c_str(), "f");
       legend_entries_.push_back(std::move(h));
     }


### PR DESCRIPTION
## Summary
- Keep semantic legend within canvas bounds and below top
- Report raw pixel counts in legend and skip empty entry
- Place legend using axis coordinates to stay within x/y ranges

## Testing
- `source .build.sh` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c45b056780832e8dacaf10c7c02fd9