### PR TITLE
Use solid fill style for semantic display legend

### DIFF
--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -131,8 +131,8 @@ protected:
         "#Sigma^{#pm}", "#Sigma^{0}", "Other"};
 
     const std::array<Style_t, palette_size> styles = {
-        1001, 3004, 1001, 1001, 1001, 3005, 1001, 3354,
-        1001, 3002, 1001, 1001, 3003, 1001, 1001};
+        1001, 1001, 1001, 1001, 1001, 1001, 1001, 1001,
+        1001, 1001, 1001, 1001, 1001, 1001, 1001};
     for (int idx : order) {
       auto h = std::make_unique<TH1F>((tag_ + std::to_string(idx)).c_str(), "",
                                       1, 0, 1);


### PR DESCRIPTION
## Summary
- Ensure semantic event display legend entries use solid fill instead of hashed styles

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: No such file or directory)*
- `source .build.sh` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d12cda8832e910d4ac06358113f