### PR TITLE
Avoid black in semantic event display

### DIFF
--- a/include/rarexsec/plot/SemanticDisplay.h
+++ b/include/rarexsec/plot/SemanticDisplay.h
@@ -47,7 +47,7 @@ protected:
     // High-contrast colour palette for particle classes
     std::array<int, palette_size> palette = {
         background,
-        TColor::GetColor("#000000"), // Cosmic
+        TColor::GetColor("#666666"), // Cosmic
         TColor::GetColor("#e41a1c"), // Muon
         TColor::GetColor("#377eb8"), // Electron
         TColor::GetColor("#4daf4a"), // Photon


### PR DESCRIPTION
## Summary
- remove black from semantic event display palette by using dark grey for cosmic

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: missing environment setup)*
- `source .build.sh` *(fails: CMake could not find ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c474bfaa6c832e8f2d1cbada92cb7e