### PR TITLE
Add signal cut-flow survival plotting plugin

### DIFF
--- a/include/rarexsec/flow/PlotBuilders.h
+++ b/include/rarexsec/flow/PlotBuilders.h
@@ -174,4 +174,50 @@ class CutFlowBuilder {
 };
 inline CutFlowBuilder cutflow() { return {}; }
 
+class SurvivalBuilder {
+  public:
+    SurvivalBuilder &truth(std::string t) {
+        truth_column_ = std::move(t);
+        return *this;
+    }
+    SurvivalBuilder &stages(std::vector<std::string> s) {
+        stages_ = std::move(s);
+        return *this;
+    }
+    SurvivalBuilder &passes(std::vector<std::string> p) {
+        pass_cols_ = std::move(p);
+        return *this;
+    }
+    SurvivalBuilder &reasons(std::vector<std::string> r) {
+        reason_cols_ = std::move(r);
+        return *this;
+    }
+    SurvivalBuilder &name(std::string n) {
+        plot_name_ = std::move(n);
+        return *this;
+    }
+    SurvivalBuilder &out(std::string d) {
+        out_dir_ = std::move(d);
+        return *this;
+    }
+
+    nlohmann::json to_json() const {
+        return {{"truth_column", truth_column_},
+                {"stages", stages_},
+                {"pass_columns", pass_cols_},
+                {"reason_columns", reason_cols_},
+                {"plot_name", plot_name_},
+                {"output_directory", out_dir_}};
+    }
+
+  private:
+    std::string truth_column_{"is_truth_signal"};
+    std::vector<std::string> stages_{"Pre", "Flash/CRT", "FV", "#mu-ID", "Topology/MVA", "Final"};
+    std::vector<std::string> pass_cols_{"pass_pre", "pass_flash", "pass_fv", "pass_mu", "pass_topo", "pass_final"};
+    std::vector<std::string> reason_cols_{"", "reason_flash", "reason_fv", "reason_mu", "reason_topo", "reason_final"};
+    std::string plot_name_{"signal_cutflow_survival"};
+    std::string out_dir_{"plots"};
+};
+inline SurvivalBuilder survival() { return {}; }
+
 }

--- a/include/rarexsec/flow/Study.h
+++ b/include/rarexsec/flow/Study.h
@@ -98,6 +98,10 @@ class Study {
         cutflow_.push_back(c.to_json());
         return *this;
     }
+    Study &plot(const SurvivalBuilder &s) {
+        survival_.push_back(s.to_json());
+        return *this;
+    }
     Study &display(const EventDisplayBuilder &ed) {
         displays_.push_back(ed.to_json());
         return *this;
@@ -175,6 +179,9 @@ class Study {
         if (!cutflow_.empty())
             plot_specs.push_back({"CutFlowPlotPlugin",
                                   {{"plot_configs", {{"plots", cutflow_}}}}});
+        if (!survival_.empty())
+            plot_specs.push_back({"SignalCutFlowPlotPlugin",
+                                  {{"plot_configs", {{"plots", survival_}}}}});
         if (!snaps_.empty())
             analysis_specs.push_back(
                 {"SnapshotPlugin",
@@ -223,6 +230,7 @@ class Study {
     std::vector<PlotDef> plots_;
     std::vector<nlohmann::json> perf_;
     std::vector<nlohmann::json> cutflow_;
+    std::vector<nlohmann::json> survival_;
     std::vector<nlohmann::json> snaps_;
     std::vector<nlohmann::json> displays_;
 };

--- a/include/rarexsec/plot/SignalCutFlowPlot.h
+++ b/include/rarexsec/plot/SignalCutFlowPlot.h
@@ -1,0 +1,96 @@
+#ifndef SIGNALCUTFLOWPLOT_H
+#define SIGNALCUTFLOWPLOT_H
+
+#include <string>
+#include <vector>
+
+#include "TH1F.h"
+#include "TGraphAsymmErrors.h"
+#include "TLatex.h"
+#include "TString.h"
+
+#include <rarexsec/plot/IHistogramPlot.h>
+
+namespace analysis {
+
+struct CutFlowLossInfo {
+    std::string reason;
+    int top_count{0};
+    int total{0};
+};
+
+class SignalCutFlowPlot : public IHistogramPlot {
+  public:
+    SignalCutFlowPlot(std::string plot_name, std::vector<std::string> stages,
+                      std::vector<double> survival,
+                      std::vector<double> err_low,
+                      std::vector<double> err_high,
+                      size_t N0,
+                      std::vector<size_t> counts,
+                      std::vector<CutFlowLossInfo> losses,
+                      std::string output_directory = "plots")
+        : IHistogramPlot(std::move(plot_name), std::move(output_directory)),
+          stages_(std::move(stages)), survival_(std::move(survival)),
+          err_low_(std::move(err_low)), err_high_(std::move(err_high)), N0_(N0),
+          counts_(std::move(counts)), losses_(std::move(losses)) {}
+
+  protected:
+    void draw(TCanvas &canvas) override {
+        int n = static_cast<int>(stages_.size());
+        TH1F h("h_surv", "Truth-signal cut-flow;Stage;Cumulative survival [%]",
+               n, 0.5, n + 0.5);
+        for (int i = 0; i < n; ++i) {
+            h.GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
+            h.SetBinContent(i + 1, survival_[i] * 100.0);
+        }
+        h.SetMinimum(0.0);
+        h.SetMaximum(100.0);
+        h.Draw("hist");
+
+        TGraphAsymmErrors g(n);
+        for (int i = 0; i < n; ++i) {
+            g.SetPoint(i, i + 1, survival_[i] * 100.0);
+            g.SetPointError(i, 0.0, 0.0, err_low_[i] * 100.0,
+                            err_high_[i] * 100.0);
+        }
+        g.Draw("P SAME");
+
+        TLatex latex;
+        latex.SetTextAlign(21);
+        latex.SetTextFont(42);
+        latex.SetTextSize(0.035);
+        for (int i = 0; i < n; ++i) {
+            std::string txt = std::to_string(counts_[i]) + "/" + std::to_string(N0_);
+            latex.DrawLatex(i + 1, survival_[i] * 100.0 + 1.5, txt.c_str());
+        }
+
+        double prev_s = 1.0;
+        for (int i = 1; i < n; ++i) {
+            double drop = (prev_s - survival_[i]) * 100.0;
+            prev_s = survival_[i];
+            const auto &info = losses_[i];
+            if (drop > 0.2 && info.total > 0) {
+                double frac = info.top_count > 0
+                                  ? static_cast<double>(info.top_count) / info.total
+                                  : 0.0;
+                auto txt = TString::Format("-%0.1f%%: %s (%0.0f%%)", drop,
+                                          info.reason.c_str(), frac * 100.0);
+                latex.DrawLatex(i + 1 - 0.05, survival_[i] * 100.0 + 4.0,
+                                txt.Data());
+            }
+        }
+    }
+
+  private:
+    std::vector<std::string> stages_;
+    std::vector<double> survival_;
+    std::vector<double> err_low_;
+    std::vector<double> err_high_;
+    size_t N0_;
+    std::vector<size_t> counts_;
+    std::vector<CutFlowLossInfo> losses_;
+};
+
+} // namespace analysis
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,7 @@ add_plugin(CutMatrixPlotPlugin plug/plotting/CutMatrixPlotPlugin.cc "")
 add_plugin(PerformancePlotPlugin plug/plotting/PerformancePlotPlugin.cc "")
 add_plugin(SystematicBreakdownPlugin plug/plotting/SystematicBreakdownPlugin.cc "")
 add_plugin(UnstackedHistogramPlugin plug/plotting/UnstackedHistogramPlugin.cc "")
+add_plugin(SignalCutFlowPlotPlugin plug/plotting/SignalCutFlowPlotPlugin.cc "")
 
 add_subdirectory(tests)
 add_subdirectory(run)

--- a/src/plug/plotting/SignalCutFlowPlotPlugin.cc
+++ b/src/plug/plotting/SignalCutFlowPlotPlugin.cc
@@ -1,0 +1,174 @@
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <rarexsec/plug/PluginRegistry.h>
+#include <rarexsec/plug/IPlotPlugin.h>
+#include <rarexsec/data/AnalysisDataLoader.h>
+#include <rarexsec/utils/Logger.h>
+#include <rarexsec/plot/SignalCutFlowPlot.h>
+
+namespace analysis {
+
+class SignalCutFlowPlotPlugin : public IPlotPlugin {
+  public:
+    struct PlotConfig {
+        std::vector<std::string> stages;
+        std::vector<std::string> pass_columns;
+        std::vector<std::string> reason_columns;
+        std::string truth_column;
+        std::string plot_name;
+        std::string output_directory{"plots"};
+    };
+
+    SignalCutFlowPlotPlugin(const PluginArgs &args, AnalysisDataLoader *loader)
+        : loader_(loader) {
+        const auto &cfg = args.plot_configs;
+        if (!cfg.contains("plots") || !cfg.at("plots").is_array())
+            throw std::runtime_error("SignalCutFlowPlotPlugin missing plots");
+        for (auto const &p : cfg.at("plots")) {
+            PlotConfig pc;
+            pc.stages = p.at("stages").get<std::vector<std::string>>();
+            pc.pass_columns = p.at("pass_columns").get<std::vector<std::string>>();
+            pc.reason_columns = p.at("reason_columns").get<std::vector<std::string>>();
+            pc.truth_column = p.at("truth_column").get<std::string>();
+            pc.plot_name = p.value("plot_name", std::string{"signal_cutflow_survival"});
+            pc.output_directory = p.value("output_directory", std::string{"plots"});
+            if (pc.stages.size() != pc.pass_columns.size() ||
+                pc.reason_columns.size() != pc.pass_columns.size())
+                throw std::runtime_error("SignalCutFlowPlotPlugin configuration size mismatch");
+            plots_.push_back(std::move(pc));
+        }
+    }
+
+    void onPlot(const AnalysisResult &) override {
+        if (!loader_) {
+            log::error("SignalCutFlowPlotPlugin::onPlot", "No AnalysisDataLoader context provided");
+            return;
+        }
+        for (const auto &pc : plots_) {
+            this->processPlot(pc);
+        }
+    }
+
+  private:
+    static std::pair<double, double> wilsonInterval(size_t k, size_t n,
+                                                    double z = 1.0) {
+        if (n == 0)
+            return {0.0, 0.0};
+        double p = static_cast<double>(k) / n;
+        double denom = 1 + z * z / n;
+        double center = (p + z * z / (2 * n)) / denom;
+        double half = z * std::sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / denom;
+        return {std::max(0.0, center - half), std::min(1.0, center + half)};
+    }
+
+    void processPlot(const PlotConfig &pc) const {
+        size_t N0 = 0;
+        std::vector<size_t> cum_counts(pc.stages.size(), 0);
+        std::vector<std::map<std::string, int>> loss_reason(pc.stages.size());
+
+        std::vector<std::string> cols;
+        cols.push_back(pc.truth_column);
+        for (auto const &c : pc.pass_columns)
+            cols.push_back(c);
+        for (size_t i = 1; i < pc.reason_columns.size(); ++i)
+            cols.push_back(pc.reason_columns[i]);
+
+        for (auto const &[skey, sample] : loader_->getSampleFrames()) {
+            auto df = sample.nominal_node_;
+            auto lam = [&](bool is_sig, bool p0, bool p1, bool p2, bool p3, bool p4,
+                            bool p5, const std::string &r1, const std::string &r2,
+                            const std::string &r3, const std::string &r4,
+                            const std::string &r5) {
+                if (!is_sig)
+                    return;
+                ++N0;
+                bool pass[6] = {p0, p1, p2, p3, p4, p5};
+                bool cum = true;
+                int first_fail = -1;
+                for (int i = 0; i < 6; ++i) {
+                    cum = cum && pass[i];
+                    if (cum)
+                        cum_counts[i]++;
+                    else {
+                        first_fail = i;
+                        break;
+                    }
+                }
+                if (first_fail > 0) {
+                    const std::string &reason =
+                        (first_fail == 1)
+                            ? r1
+                            : (first_fail == 2)
+                                  ? r2
+                                  : (first_fail == 3)
+                                        ? r3
+                                        : (first_fail == 4) ? r4 : r5;
+                    std::string key = reason.empty() ? "unspecified" : reason;
+                    loss_reason[first_fail][key]++;
+                }
+            };
+            df.Foreach(lam, cols);
+        }
+
+        std::vector<double> survival;
+        std::vector<double> err_low, err_high;
+        for (size_t i = 0; i < pc.stages.size(); ++i) {
+            double s = N0 > 0 ? static_cast<double>(cum_counts[i]) / N0 : 0.0;
+            survival.push_back(s);
+            auto [lo, hi] = wilsonInterval(cum_counts[i], N0);
+            err_low.push_back(s - lo);
+            err_high.push_back(hi - s);
+        }
+
+        std::vector<CutFlowLossInfo> losses(pc.stages.size());
+        for (size_t i = 1; i < pc.stages.size(); ++i) {
+            int total = 0;
+            std::string top_reason;
+            int top_count = 0;
+            for (const auto &[r, c] : loss_reason[i]) {
+                total += c;
+                if (c > top_count) {
+                    top_count = c;
+                    top_reason = r;
+                }
+            }
+            losses[i] = {top_reason, top_count, total};
+        }
+
+        SignalCutFlowPlot plot(pc.plot_name, pc.stages, survival, err_low, err_high,
+                               N0, cum_counts, losses, pc.output_directory);
+        plot.drawAndSave("pdf");
+        log::info("SignalCutFlowPlotPlugin::onPlot",
+                  pc.output_directory + "/" + pc.plot_name + ".pdf");
+    }
+
+    std::vector<PlotConfig> plots_;
+    AnalysisDataLoader *loader_;
+    inline static AnalysisDataLoader *legacy_loader_ = nullptr;
+  public:
+    static void setLegacyLoader(AnalysisDataLoader *ldr) { legacy_loader_ = ldr; }
+    static AnalysisDataLoader *legacyLoader() { return legacy_loader_; }
+};
+
+} // namespace analysis
+
+ANALYSIS_REGISTER_PLUGIN(analysis::IPlotPlugin, analysis::AnalysisDataLoader,
+                         "SignalCutFlowPlotPlugin", analysis::SignalCutFlowPlotPlugin)
+
+#ifdef BUILD_PLUGIN
+extern "C" analysis::IPlotPlugin *createSignalCutFlowPlotPlugin(
+    const analysis::PluginArgs &args) {
+    return new analysis::SignalCutFlowPlotPlugin(args, analysis::SignalCutFlowPlotPlugin::legacyLoader());
+}
+extern "C" analysis::IPlotPlugin *createPlotPlugin(const analysis::PluginArgs &args) {
+    return createSignalCutFlowPlotPlugin(args);
+}
+extern "C" void setPluginContext(analysis::AnalysisDataLoader *loader) {
+    analysis::SignalCutFlowPlotPlugin::setLegacyLoader(loader);
+}
+#endif

--- a/src/run/CMakeLists.txt
+++ b/src/run/CMakeLists.txt
@@ -20,6 +20,8 @@ add_executable(study_neutrino_energy
   study_neutrino_energy.cpp)
 add_executable(study_numucc_selection
   study_numucc_selection.cpp)
+add_executable(study_numucc_signal_survival
+  study_numucc_signal_survival.cpp)
 
 target_link_libraries(study_topo_score PRIVATE
   core
@@ -142,6 +144,21 @@ target_link_libraries(study_numucc_selection PRIVATE
   TMVA
   dl)
 
+target_link_libraries(study_numucc_signal_survival PRIVATE
+  core
+  plug
+  data
+  hist
+  plot
+  syst
+  utils
+  Eigen3::Eigen
+  nlohmann_json::nlohmann_json
+  ${ROOT_LIBRARIES}
+  TBB::tbb
+  TMVA
+  dl)
+
 
 set_target_properties(
   study_topo_score
@@ -157,6 +174,7 @@ set_target_properties(
 
 set_target_properties(
   study_numucc_selection
+  study_numucc_signal_survival
   PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin"
 )

--- a/src/run/study_numucc_signal_survival.cpp
+++ b/src/run/study_numucc_signal_survival.cpp
@@ -1,0 +1,21 @@
+#include <rarexsec/flow/PlotBuilders.h>
+#include <rarexsec/flow/Study.h>
+#include <rarexsec/flow/Where.h>
+
+using namespace analysis::dsl;
+
+int main() {
+  auto s = Study("NuMu CC signal survival")
+               .data("config/catalogs/samples.json")
+               .region("NUMU_CC", where("quality_event && has_muon"))
+               .plot(survival()
+                         .truth("is_truth_signal")
+                         .stages({"Pre", "Flash/CRT", "FV", "#mu-ID", "Topology/MVA", "Final"})
+                         .passes({"pass_pre", "pass_flash", "pass_fv", "pass_mu", "pass_topo", "pass_final"})
+                         .reasons({"", "reason_flash", "reason_fv", "reason_mu", "reason_topo", "reason_final"})
+                         .name("numu_cc_signal_survival")
+                         .out("plots/survival"));
+
+  s.run("/tmp/numu_cc_signal_survival.root");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Add `SignalCutFlowPlot` class to draw truth-signal cut-flow survival bars with error bars and failure annotations
- Introduce `SurvivalBuilder` and integrate with `Study` for easy configuration
- Implement `SignalCutFlowPlotPlugin` and register in build system
- Provide `study_numucc_signal_survival` runner to generate the inclusive ν_μ signal-survival plot

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: required setup scripts not found)*
- `source .build.sh` *(fails: ROOT package configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c47555a854832ea5a10f6f09f94c5b