### PR TITLE
Fix unused parameter warning in SignalCutFlowPlot

### DIFF
--- a/include/rarexsec/plot/SignalCutFlowPlot.h
+++ b/include/rarexsec/plot/SignalCutFlowPlot.h
@@ -35,7 +35,7 @@ class SignalCutFlowPlot : public IHistogramPlot {
           counts_(std::move(counts)), losses_(std::move(losses)) {}
 
   protected:
-    void draw(TCanvas &canvas) override {
+    void draw(TCanvas &) override {
         int n = static_cast<int>(stages_.size());
         TH1F h("h_surv", "Truth-signal cut-flow;Stage;Cumulative survival [%]",
                n, 0.5, n + 0.5);


### PR DESCRIPTION
## Summary
- Avoid unused parameter warning by removing the canvas variable name in `SignalCutFlowPlot::draw`

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: setup scripts not found)*
- `source .build.sh` *(fails: Could not find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c478fe9104832e878a8edb61c74901