### PR TITLE
Fix stacked histogram plugin registration

### DIFF
--- a/include/rarexsec/flow/Study.h
+++ b/include/rarexsec/flow/Study.h
@@ -157,7 +157,7 @@ class Study {
                               p.region.empty() ? defaultRegionKey() : p.region},
                              {"signal_group", p.signal_group},
                              {"logy", p.logy}}})}}}};
-                plot_specs.push_back({"StackedPlotPlugin", std::move(args)});
+                plot_specs.push_back({"StackedHistogramPlugin", std::move(args)});
             } else if (p.kind == "roc") {
                 PluginArgs args{
                     {"performance_plots",


### PR DESCRIPTION
## Summary
- use `StackedHistogramPlugin` when defining stack plots in `Study`

## Testing
- `cmake ..` (fails: Could not find a package configuration file provided by "ROOT")

------
https://chatgpt.com/codex/tasks/task_e_68c47c7414a8832e8ad8d435c092a2da