### PR TITLE
Add truth signal flag for survival plots

### DIFF
--- a/include/rarexsec/data/TruthChannelProcessor.h
+++ b/include/rarexsec/data/TruthChannelProcessor.h
@@ -256,7 +256,12 @@ private:
 
     auto chan_alias_df = chan_df.Define("channel_definitions", "channel_def");
 
-    return chan_alias_df;
+    auto signal_df =
+        chan_alias_df.Define("is_truth_signal",
+                              [](int ch) { return ch == 15 || ch == 16; },
+                              {"channel_def"});
+
+    return signal_df;
   }
 };
 


### PR DESCRIPTION
## Summary
- Add `is_truth_signal` derived column to `TruthChannelProcessor` so signal-survival plots can access a truth flag

## Testing
- `source .setup.sh` *(fails: No such file or directory)*
- `cmake -S . -B build` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c47d0c8664832ea53bd53f2a3ffbe0