### PR TITLE
Resolve n_muons_tot type mismatch in selection processors

### DIFF
--- a/include/rarexsec/data/MuonSelectionProcessor.h
+++ b/include/rarexsec/data/MuonSelectionProcessor.h
@@ -14,7 +14,7 @@ public:
   ROOT::RDF::RNode process(ROOT::RDF::RNode df,
                            SampleOrigin st) const override {
     if (!df.HasColumn("track_shower_scores")) {
-      auto no_mu_df = df.Define("n_muons_tot", []() { return 0; })
+      auto no_mu_df = df.Define("n_muons_tot", []() { return 0UL; })
                           .Define("has_muon", []() { return false; });
       return next_ ? next_->process(no_mu_df, st) : no_mu_df;
     }

--- a/include/rarexsec/data/NuMuCCSelectionProcessor.h
+++ b/include/rarexsec/data/NuMuCCSelectionProcessor.h
@@ -72,7 +72,7 @@ public:
     auto mu_df = fv_df
         .Define("pass_mu", "n_muons_tot > 0")
         .Define("reason_mu",
-                [](int nmu) {
+                [](unsigned long nmu) {
                   return nmu > 0 ? std::string{} : std::string{"no_muon"};
                 },
                 {"n_muons_tot"});


### PR DESCRIPTION
## Summary
- Fix n_muons_tot definition to use unsigned long in MuonSelectionProcessor
- Adjust NuMuCCSelectionProcessor to handle unsigned long n_muons_tot

## Testing
- `bash ./.build.sh` *(fails: Could not find ROOT package)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c47ee87f48832e86eb0bc3af948956