### PR TITLE
Fix PDF export for histogram plots

### DIFF
--- a/include/rarexsec/plot/IHistogramPlot.h
+++ b/include/rarexsec/plot/IHistogramPlot.h
@@ -34,12 +34,12 @@ class IHistogramPlot {
         this->draw(canvas);
         auto out_path = output_directory_ + "/" + plot_name_ + "." + format;
         if (format == "pdf") {
+            canvas.SaveAs(out_path.c_str());
+        } else {
             auto image = TImage::Create();
             image->FromPad(&canvas);
             image->WriteImage(out_path.c_str());
             delete image;
-        } else {
-            canvas.SaveAs(out_path.c_str());
         }
     }
 


### PR DESCRIPTION
## Summary
- Ensure histogram plots use ROOT's `TCanvas::SaveAs` for PDF output to avoid `TASImage` format errors.

## Testing
- `source .build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68c486f440b0832e93e286adf7642b8b