### PR TITLE
Use variable stratifier as default category

### DIFF
--- a/include/rarexsec/plot/StackedHistogramPlot.h
+++ b/include/rarexsec/plot/StackedHistogramPlot.h
@@ -184,10 +184,11 @@ class StackedHistogramPlot : public IHistogramPlot {
         int n_cols = (n_entries > 4) ? 3 : 2;
         legend_->SetNColumns(n_cols);
 
+        const auto scheme = resolveCategoryColumn();
         for (const auto &[key, hist] : mc_hists) {
             TH1D *h_leg = new TH1D();
-            const auto &stratum = registry.getStratumProperties(
-                category_column_, std::stoi(key.str()));
+            const auto &stratum =
+                registry.getStratumProperties(scheme, std::stoi(key.str()));
             h_leg->SetFillColor(stratum.fill_colour);
             h_leg->SetFillStyle(stratum.fill_style);
             h_leg->SetLineColor(kBlack);
@@ -249,6 +250,7 @@ class StackedHistogramPlot : public IHistogramPlot {
             }
         }
 
+        const auto scheme = resolveCategoryColumn();
         for (const auto &[key, hist] : mc_hists) {
             TH1D *h = (TH1D *)hist.get()->Clone();
             if (use_uniform_binning_ && uniform_max_ > uniform_min_) {
@@ -259,8 +261,8 @@ class StackedHistogramPlot : public IHistogramPlot {
                 delete h;
                 h = h_tmp;
             }
-            const auto &stratum = registry.getStratumProperties(
-                category_column_, std::stoi(key.str()));
+            const auto &stratum =
+                registry.getStratumProperties(scheme, std::stoi(key.str()));
             h->SetFillColor(stratum.fill_colour);
             h->SetFillStyle(stratum.fill_style);
             h->SetLineColor(kBlack);
@@ -473,6 +475,12 @@ class StackedHistogramPlot : public IHistogramPlot {
     }
 
   private:
+    std::string resolveCategoryColumn() const {
+        if (!category_column_.empty())
+            return category_column_;
+        return variable_result_.binning_.getStratifierKey().str();
+    }
+
     const VariableResult &variable_result_;
     const RegionAnalysis &region_analysis_;
     std::string category_column_;

--- a/src/plug/plotting/StackedHistogramPlugin.cc
+++ b/src/plug/plotting/StackedHistogramPlugin.cc
@@ -17,7 +17,7 @@ class StackedHistogramPlugin : public IPlotPlugin {
     struct PlotConfig {
         std::string variable{};               // optional variable name
         std::string region{};                 // optional region key
-        std::string category_column{"inclusive"};
+        std::string category_column{};
         std::string output_directory = "plots";
         bool overlay_signal = true;
         std::string signal_group{"inclusive_strange_channels"};
@@ -38,7 +38,7 @@ class StackedHistogramPlugin : public IPlotPlugin {
                 PlotConfig pc;
                 pc.variable = p.value("variable", std::string());
                 pc.region = p.value("region", std::string());
-                pc.category_column = p.value("category_column", std::string("inclusive"));
+                pc.category_column = p.value("category_column", std::string());
                 pc.output_directory = p.value("output_directory", std::string("plots"));
                 pc.overlay_signal = p.value("overlay_signal", true);
                 pc.signal_group =


### PR DESCRIPTION
## Summary
- Avoid hard-coded `"inclusive"` category in `StackedHistogramPlugin`
- Resolve category scheme automatically from variable binning if not provided

## Testing
- `cmake ..` *(fails: Could not find ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c48a8026ac832ea22b4bd04d0dc5e6