### PR TITLE
Expand neutrino energy plot range

### DIFF
--- a/src/run/study_neutrino_energy.cpp
+++ b/src/run/study_neutrino_energy.cpp
@@ -7,8 +7,11 @@ int main() {
   auto study = Study("MC Neutrino Energy")
     .data("config/catalogs/samples.json")
     .region("MC_ONLY", where("bnbdata == 0 && extdata == 0"))
-    .var("neutrino_energy")
-    .plot(stack("neutrino_energy").in("MC_ONLY").signal("channel_definitions"));
+    .var(VarDef("neutrino_energy").bins(100, 0.0, 10.0))
+    .plot(stack("neutrino_energy")
+              .in("MC_ONLY")
+              .signal("channel_definitions")
+              .logY());
 
   study.run("/tmp/neutrino_energy.root");
   return 0;


### PR DESCRIPTION
## Summary
- Expand neutrino_energy histogram to 0–10 GeV
- Enable logarithmic y-axis on neutrino energy plot

## Testing
- ⚠️ `. .container.sh` *(missing /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh)*
- ⚠️ `. .setup.sh` *(missing CVMFS setups and `setup` command)*
- ⚠️ `. .build.sh` *(could not find ROOT package configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c48d832844832e95bb685cc9c302bd