### PR TITLE
Handle preselection for non-data samples and fix cutflow plotting

### DIFF
--- a/include/rarexsec/data/NuMuCCSelectionProcessor.h
+++ b/include/rarexsec/data/NuMuCCSelectionProcessor.h
@@ -18,8 +18,16 @@ public:
     auto pre_df = df.Define(
         "pass_pre",
         [st](int bnb, int ext, float pe_beam, float pe_veto, bool swtrig) {
-          bool dataset_gate = (bnb == 0 && ext == 0) ?
-                                 (pe_beam > 0.f && pe_veto < 20.f) : true;
+          // For non-beam data samples (e.g. Monte Carlo or external), the
+          // dataset gate and software trigger do not apply, so we accept all
+          // events. This prevents the preselection from trivially failing
+          // for those samples where the necessary trigger information is
+          // absent or not meaningful.
+          if (st != SampleOrigin::kData)
+            return true;
+
+          bool dataset_gate =
+              (bnb == 0 && ext == 0) ? (pe_beam > 0.f && pe_veto < 20.f) : true;
           return dataset_gate && swtrig;
         },
         {"bnbdata", "extdata", "_opfilter_pe_beam", "_opfilter_pe_veto",

--- a/include/rarexsec/plot/SignalCutFlowPlot.h
+++ b/include/rarexsec/plot/SignalCutFlowPlot.h
@@ -37,23 +37,25 @@ class SignalCutFlowPlot : public IHistogramPlot {
   protected:
     void draw(TCanvas &) override {
         int n = static_cast<int>(stages_.size());
-        TH1F h("h_surv", "Truth-signal cut-flow;Stage;Cumulative survival [%]",
-               n, 0.5, n + 0.5);
+        auto *h = new TH1F("h_surv",
+                           "Truth-signal cut-flow;Stage;Cumulative survival [%]",
+                           n, 0.5, n + 0.5);
+        h->SetDirectory(nullptr);
         for (int i = 0; i < n; ++i) {
-            h.GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
-            h.SetBinContent(i + 1, survival_[i] * 100.0);
+            h->GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
+            h->SetBinContent(i + 1, survival_[i] * 100.0);
         }
-        h.SetMinimum(0.0);
-        h.SetMaximum(100.0);
-        h.Draw("hist");
+        h->SetMinimum(0.0);
+        h->SetMaximum(100.0);
+        h->Draw("hist");
 
-        TGraphAsymmErrors g(n);
+        auto *g = new TGraphAsymmErrors(n);
         for (int i = 0; i < n; ++i) {
-            g.SetPoint(i, i + 1, survival_[i] * 100.0);
-            g.SetPointError(i, 0.0, 0.0, err_low_[i] * 100.0,
-                            err_high_[i] * 100.0);
+            g->SetPoint(i, i + 1, survival_[i] * 100.0);
+            g->SetPointError(i, 0.0, 0.0, err_low_[i] * 100.0,
+                             err_high_[i] * 100.0);
         }
-        g.Draw("P SAME");
+        g->Draw("P SAME");
 
         TLatex latex;
         latex.SetTextAlign(21);


### PR DESCRIPTION
## Summary
- Skip dataset gate and trigger requirements for samples that are not on-beam data so Monte Carlo and external events don't fail preselection by default
- Keep histogram and graph objects alive when drawing signal cut-flow plots to avoid blank PDF output

## Testing
- `source .setup.sh` *(fails: /cvmfs/uboone.opensciencegrid.org/products/setup_uboone_mcc9.sh: No such file or directory)*
- `source .build.sh` *(fails: could not find package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68c48d4e2e14832ebe212a89e15d9179