### PR TITLE
Fix log-scale flag for stacked histogram plots

### DIFF
--- a/include/rarexsec/flow/Study.h
+++ b/include/rarexsec/flow/Study.h
@@ -156,7 +156,7 @@ class Study {
                              {"region",
                               p.region.empty() ? defaultRegionKey() : p.region},
                              {"signal_group", p.signal_group},
-                             {"logy", p.logy}}})}}}};
+                             {"log_y", p.logy}}})}}}};
                 plot_specs.push_back({"StackedHistogramPlugin", std::move(args)});
             } else if (p.kind == "roc") {
                 PluginArgs args{


### PR DESCRIPTION
## Summary
- Correct the JSON key used to enable logarithmic y-axes in stacked histogram plots so `.logY()` works as intended

## Testing
- ⚠️ `cmake -S . -B build` *(missing ROOT dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c494e9db80832ebcfe538d26205153