### PR TITLE
Use base styles for SignalCutFlow plot

### DIFF
--- a/include/rarexsec/plot/SignalCutFlowPlot.h
+++ b/include/rarexsec/plot/SignalCutFlowPlot.h
@@ -60,8 +60,6 @@ class SignalCutFlowPlot : public IHistogramPlot {
 
         TLatex latex;
         latex.SetTextAlign(21);
-        latex.SetTextFont(42);
-        latex.SetTextSize(0.035);
         for (int i = 0; i < n; ++i) {
             std::string txt = std::to_string(counts_[i]) + "/" +
                               std::to_string(N0_);


### PR DESCRIPTION
## Summary
- Remove local font overrides in SignalCutFlowPlot so it respects IHistogramPlot styling

## Testing
- `bash -lc 'source .setup.sh'` *(failed: /cvmfs/... no such file or directory)*
- `bash -lc 'source .build.sh'` *(failed: Could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68c499401f74832ebf082fc9bbf5d8b9