### PR TITLE
Add configurable axis labels to survival cut flow plots

### DIFF
--- a/include/rarexsec/flow/PlotBuilders.h
+++ b/include/rarexsec/flow/PlotBuilders.h
@@ -196,6 +196,14 @@ class SurvivalBuilder {
         plot_name_ = std::move(n);
         return *this;
     }
+    SurvivalBuilder &x_label(std::string l) {
+        x_label_ = std::move(l);
+        return *this;
+    }
+    SurvivalBuilder &y_label(std::string l) {
+        y_label_ = std::move(l);
+        return *this;
+    }
     SurvivalBuilder &out(std::string d) {
         out_dir_ = std::move(d);
         return *this;
@@ -207,6 +215,8 @@ class SurvivalBuilder {
                 {"pass_columns", pass_cols_},
                 {"reason_columns", reason_cols_},
                 {"plot_name", plot_name_},
+                {"x_label", x_label_},
+                {"y_label", y_label_},
                 {"output_directory", out_dir_}};
     }
 
@@ -216,6 +226,8 @@ class SurvivalBuilder {
     std::vector<std::string> pass_cols_{"pass_pre", "pass_flash", "pass_fv", "pass_mu", "pass_topo", "pass_final"};
     std::vector<std::string> reason_cols_{"", "reason_flash", "reason_fv", "reason_mu", "reason_topo", "reason_final"};
     std::string plot_name_{"signal_cutflow_survival"};
+    std::string x_label_{"Cut Stage"};
+    std::string y_label_{"Survival Probability (%)"};
     std::string out_dir_{"plots"};
 };
 inline SurvivalBuilder survival() { return {}; }

--- a/include/rarexsec/plot/SignalCutFlowPlot.h
+++ b/include/rarexsec/plot/SignalCutFlowPlot.h
@@ -28,19 +28,21 @@ class SignalCutFlowPlot : public IHistogramPlot {
                       size_t N0,
                       std::vector<size_t> counts,
                       std::vector<CutFlowLossInfo> losses,
-                      std::string output_directory = "plots")
+                      std::string output_directory = "plots",
+                      std::string x_label = "Cut Stage",
+                      std::string y_label = "Survival Probability (%)")
         : IHistogramPlot(std::move(plot_name), std::move(output_directory)),
           stages_(std::move(stages)), survival_(std::move(survival)),
           err_low_(std::move(err_low)), err_high_(std::move(err_high)), N0_(N0),
-          counts_(std::move(counts)), losses_(std::move(losses)) {}
+          counts_(std::move(counts)), losses_(std::move(losses)),
+          x_label_(std::move(x_label)), y_label_(std::move(y_label)) {}
 
   protected:
     void draw(TCanvas &) override {
         int n = static_cast<int>(stages_.size());
+        std::string title = ";" + x_label_ + ";" + y_label_;
         auto *h =
-            new TH1F("h_surv",
-                     ";Cut Stage;Survival Probability (%)",
-                     n, 0.5, n + 0.5);
+            new TH1F("h_surv", title.c_str(), n, 0.5, n + 0.5);
         h->SetDirectory(nullptr);
         for (int i = 0; i < n; ++i) {
             h->GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
@@ -93,6 +95,8 @@ class SignalCutFlowPlot : public IHistogramPlot {
     size_t N0_;
     std::vector<size_t> counts_;
     std::vector<CutFlowLossInfo> losses_;
+    std::string x_label_;
+    std::string y_label_;
 };
 
 } // namespace analysis

--- a/src/plug/plotting/SignalCutFlowPlotPlugin.cc
+++ b/src/plug/plotting/SignalCutFlowPlotPlugin.cc
@@ -22,6 +22,8 @@ class SignalCutFlowPlotPlugin : public IPlotPlugin {
         std::vector<std::string> reason_columns;
         std::string truth_column;
         std::string plot_name;
+        std::string x_label{"Cut Stage"};
+        std::string y_label{"Survival Probability (%)"};
         std::string output_directory{"plots"};
     };
 
@@ -37,6 +39,8 @@ class SignalCutFlowPlotPlugin : public IPlotPlugin {
             pc.reason_columns = p.at("reason_columns").get<std::vector<std::string>>();
             pc.truth_column = p.at("truth_column").get<std::string>();
             pc.plot_name = p.value("plot_name", std::string{"signal_cutflow_survival"});
+            pc.x_label = p.value("x_label", std::string{"Cut Stage"});
+            pc.y_label = p.value("y_label", std::string{"Survival Probability (%)"});
             pc.output_directory = p.value("output_directory", std::string{"plots"});
             if (pc.stages.size() != pc.pass_columns.size() ||
                 pc.reason_columns.size() != pc.pass_columns.size())
@@ -150,7 +154,8 @@ class SignalCutFlowPlotPlugin : public IPlotPlugin {
         }
 
         SignalCutFlowPlot plot(pc.plot_name, pc.stages, survival, err_low, err_high,
-                               N0, cum_counts, losses, pc.output_directory);
+                               N0, cum_counts, losses, pc.output_directory,
+                               pc.x_label, pc.y_label);
         plot.drawAndSave("pdf");
         log::info("SignalCutFlowPlotPlugin::onPlot",
                   pc.output_directory + "/" + pc.plot_name + ".pdf");


### PR DESCRIPTION
## Summary
- allow specifying `x_label` and `y_label` in `SurvivalBuilder` JSON output
- teach `SignalCutFlowPlotPlugin` to read the new labels and pass them through
- extend `SignalCutFlowPlot` to accept custom axis labels

## Testing
- `source .container.sh` *(fails: No such file or directory)*
- `source .setup.sh` *(fails: command not found / missing CVMFS products)*
- `source .build.sh` *(fails: Could not find ROOT package)*

------
https://chatgpt.com/codex/tasks/task_e_68c4997f21dc832eae4a6baf54ddd23b