### PR TITLE
Run neutrino energy study over all samples without log scale

### DIFF
--- a/src/run/study_neutrino_energy.cpp
+++ b/src/run/study_neutrino_energy.cpp
@@ -6,12 +6,11 @@ using namespace analysis::dsl;
 int main() {
   auto study = Study("MC Neutrino Energy")
     .data("config/catalogs/samples.json")
-    .region("MC_ONLY", where("bnbdata == 0 && extdata == 0"))
+    .region("EMPTY", where(""))
     .var(VarDef("neutrino_energy").bins(100, 0.0, 10.0))
     .plot(stack("neutrino_energy")
-              .in("MC_ONLY")
-              .signal("channel_definitions")
-              .logY());
+              .in("EMPTY")
+              .signal("channel_definitions"));
 
   study.run("/tmp/neutrino_energy.root");
   return 0;


### PR DESCRIPTION
## Summary
- Study neutrino energy across all samples without any filtering
- Drop log-scale option from the neutrino energy plot

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*
- `apt-get update` *(fails: The repository is not signed and 403 errors encountered)*

------
https://chatgpt.com/codex/tasks/task_e_68c49a53a56c832ea80560c98b21e3a1