### PR TITLE
Clarify MC-only neutrino energy study

### DIFF
--- a/src/run/study_neutrino_energy.cpp
+++ b/src/run/study_neutrino_energy.cpp
@@ -7,10 +7,15 @@ int main() {
   auto study = Study("MC Neutrino Energy")
     .data("config/catalogs/samples.json")
     .region("EMPTY", where(""))
-    .var(VarDef("neutrino_energy").bins(100, 0.0, 10.0))
+    // The WeightProcessor automatically scales MC event weights to the
+    // total protons-on-target, so the resulting histogram is POT-normalised.
+    .var(VarDef("neutrino_energy")
+             .bins(100, 0.0, 10.0)
+             .stratify("channel_definitions"))
     .plot(stack("neutrino_energy")
               .in("EMPTY")
-              .signal("channel_definitions"));
+              .signal("channel_definitions")
+              .channel("channel_definitions"));
 
   study.run("/tmp/neutrino_energy.root");
   return 0;


### PR DESCRIPTION
## Summary
- Ensure neutrino energy study stacks only Monte Carlo channels by explicitly stratifying and selecting the channel definitions
- Document that WeightProcessor POT-normalises the histogram

## Testing
- ❌ `cmake -S . -B build` (missing ROOT development package)
- ⚠️ `apt-get update` (403 errors; package repositories unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68c49dcfbc00832e938afe5afc6055f1