### PR TITLE
Remove redundant survival configuration

### DIFF
--- a/src/run/study_numucc_signal_survival.cpp
+++ b/src/run/study_numucc_signal_survival.cpp
@@ -9,10 +9,6 @@ int main() {
                .data("config/catalogs/samples.json")
                .region("NUMU_CC", where("quality_event && has_muon"))
                .plot(survival()
-                         .truth("is_truth_signal")
-                         .stages({"Pre", "Flash/CRT", "FV", "#mu-ID", "Topology/MVA", "Final"})
-                         .passes({"pass_pre", "pass_flash", "pass_fv", "pass_mu", "pass_topo", "pass_final"})
-                         .reasons({"", "reason_flash", "reason_fv", "reason_mu", "reason_topo", "reason_final"})
                          .name("numu_cc_signal_survival")
                          .out("plots/survival"));
 


### PR DESCRIPTION
## Summary
- Simplify `study_numucc_signal_survival.cpp` by using default survival settings

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOT package)*


------
https://chatgpt.com/codex/tasks/task_e_68c4997991b4832e8a35ce02e5c4260d