### PR TITLE
Scale SignalCutFlow by event weight

### DIFF
--- a/include/rarexsec/plot/SignalCutFlowPlot.h
+++ b/include/rarexsec/plot/SignalCutFlowPlot.h
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
-#include "TH1F.h"
 #include "TGraphAsymmErrors.h"
+#include "TH1F.h"
 #include "TLatex.h"
 #include "TString.h"
 
@@ -14,85 +14,76 @@
 namespace analysis {
 
 struct CutFlowLossInfo {
-    std::string reason;
-    int top_count{0};
-    int total{0};
+  std::string reason;
+  double top_count{0.0};
+  double total{0.0};
 };
 
 class SignalCutFlowPlot : public IHistogramPlot {
-  public:
-    SignalCutFlowPlot(std::string plot_name, std::vector<std::string> stages,
-                      std::vector<double> survival,
-                      std::vector<double> err_low,
-                      std::vector<double> err_high,
-                      size_t N0,
-                      std::vector<size_t> counts,
-                      std::vector<CutFlowLossInfo> losses,
-                      std::string output_directory = "plots")
-        : IHistogramPlot(std::move(plot_name), std::move(output_directory)),
-          stages_(std::move(stages)), survival_(std::move(survival)),
-          err_low_(std::move(err_low)), err_high_(std::move(err_high)), N0_(N0),
-          counts_(std::move(counts)), losses_(std::move(losses)) {}
+public:
+  SignalCutFlowPlot(std::string plot_name, std::vector<std::string> stages,
+                    std::vector<double> survival, std::vector<double> err_low,
+                    std::vector<double> err_high, double N0,
+                    std::vector<double> counts,
+                    std::vector<CutFlowLossInfo> losses,
+                    std::string output_directory = "plots")
+      : IHistogramPlot(std::move(plot_name), std::move(output_directory)),
+        stages_(std::move(stages)), survival_(std::move(survival)),
+        err_low_(std::move(err_low)), err_high_(std::move(err_high)), N0_(N0),
+        counts_(std::move(counts)), losses_(std::move(losses)) {}
 
-  protected:
-    void draw(TCanvas &) override {
-        int n = static_cast<int>(stages_.size());
-        auto *h =
-            new TH1F("h_surv",
-                     ";Cut Stage;Survival Probability (%)",
-                     n, 0.5, n + 0.5);
-        h->SetDirectory(nullptr);
-        for (int i = 0; i < n; ++i) {
-            h->GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
-            h->SetBinContent(i + 1, survival_[i] * 100.0);
-        }
-        h->SetMinimum(0.0);
-        h->SetMaximum(100.0);
-        h->Draw("hist");
+protected:
+  void draw(TCanvas &) override {
+    int n = static_cast<int>(stages_.size());
+    auto *h = new TH1F("h_surv", ";Cut Stage;Survival Probability (%)", n, 0.5,
+                       n + 0.5);
+    h->SetDirectory(nullptr);
+    for (int i = 0; i < n; ++i) {
+      h->GetXaxis()->SetBinLabel(i + 1, stages_[i].c_str());
+      h->SetBinContent(i + 1, survival_[i] * 100.0);
+    }
+    h->SetMinimum(0.0);
+    h->SetMaximum(100.0);
+    h->Draw("hist");
 
-        auto *g = new TGraphAsymmErrors(n);
-        for (int i = 0; i < n; ++i) {
-            g->SetPoint(i, i + 1, survival_[i] * 100.0);
-            g->SetPointError(i, 0.0, 0.0, err_low_[i] * 100.0,
-                             err_high_[i] * 100.0);
-        }
-        g->Draw("P SAME");
+    auto *g = new TGraphAsymmErrors(n);
+    for (int i = 0; i < n; ++i) {
+      g->SetPoint(i, i + 1, survival_[i] * 100.0);
+      g->SetPointError(i, 0.0, 0.0, err_low_[i] * 100.0, err_high_[i] * 100.0);
+    }
+    g->Draw("P SAME");
 
-        TLatex latex;
-        latex.SetTextAlign(21);
-        latex.SetTextFont(42);
-        latex.SetTextSize(0.035);
-        for (int i = 0; i < n; ++i) {
-            std::string txt = std::to_string(counts_[i]) + "/" +
-                              std::to_string(N0_);
-            latex.DrawLatex(i + 1, survival_[i] * 100.0 + 3.0, txt.c_str());
-        }
-
-        double prev_s = 1.0;
-        for (int i = 1; i < n; ++i) {
-            double drop = (prev_s - survival_[i]) * 100.0;
-            prev_s = survival_[i];
-            const auto &info = losses_[i];
-            if (drop > 0.2 && info.total > 0) {
-                double frac = info.top_count > 0
-                                  ? static_cast<double>(info.top_count) / info.total
-                                  : 0.0;
-                auto txt = TString::Format("-%0.1f%%: %s (%0.0f%%)", drop,
-                                          info.reason.c_str(), frac * 100.0);
-                latex.DrawLatex(i + 1 - 0.05, survival_[i] * 100.0 + 5.0,
-                                txt.Data());
-            }
-        }
+    TLatex latex;
+    latex.SetTextAlign(21);
+    latex.SetTextFont(42);
+    latex.SetTextSize(0.035);
+    for (int i = 0; i < n; ++i) {
+      auto txt = TString::Format("%0.0f/%0.0f", counts_[i], N0_);
+      latex.DrawLatex(i + 1, survival_[i] * 100.0 + 3.0, txt.Data());
     }
 
-  private:
-    std::vector<std::string> stages_;
-    std::vector<double> survival_;
-    std::vector<double> err_low_;
-    std::vector<double> err_high_;
-    size_t N0_;
-    std::vector<size_t> counts_;
-    std::vector<CutFlowLossInfo> losses_;
+    double prev_s = 1.0;
+    for (int i = 1; i < n; ++i) {
+      double drop = (prev_s - survival_[i]) * 100.0;
+      prev_s = survival_[i];
+      const auto &info = losses_[i];
+      if (drop > 0.2 && info.total > 0) {
+        double frac = info.top_count > 0 ? info.top_count / info.total : 0.0;
+        auto txt = TString::Format("-%0.1f%%: %s (%0.0f%%)", drop,
+                                   info.reason.c_str(), frac * 100.0);
+        latex.DrawLatex(i + 1 - 0.05, survival_[i] * 100.0 + 5.0, txt.Data());
+      }
+    }
+  }
+
+private:
+  std::vector<std::string> stages_;
+  std::vector<double> survival_;
+  std::vector<double> err_low_;
+  std::vector<double> err_high_;
+  double N0_;
+  std::vector<double> counts_;
+  std::vector<CutFlowLossInfo> losses_;
 };
 
 } // namespace analysis

--- a/src/plug/plotting/SignalCutFlowPlotPlugin.cc
+++ b/src/plug/plotting/SignalCutFlowPlotPlugin.cc
@@ -6,178 +6,187 @@
 #include <string>
 #include <vector>
 
-#include <rarexsec/plug/PluginRegistry.h>
-#include <rarexsec/plug/IPlotPlugin.h>
 #include <rarexsec/data/AnalysisDataLoader.h>
-#include <rarexsec/utils/Logger.h>
 #include <rarexsec/plot/SignalCutFlowPlot.h>
+#include <rarexsec/plug/IPlotPlugin.h>
+#include <rarexsec/plug/PluginRegistry.h>
+#include <rarexsec/utils/Logger.h>
 
 namespace analysis {
 
 class SignalCutFlowPlotPlugin : public IPlotPlugin {
-  public:
-    struct PlotConfig {
-        std::vector<std::string> stages;
-        std::vector<std::string> pass_columns;
-        std::vector<std::string> reason_columns;
-        std::string truth_column;
-        std::string plot_name;
-        std::string output_directory{"plots"};
-    };
+public:
+  struct PlotConfig {
+    std::vector<std::string> stages;
+    std::vector<std::string> pass_columns;
+    std::vector<std::string> reason_columns;
+    std::string truth_column;
+    std::string plot_name;
+    std::string output_directory{"plots"};
+  };
 
-    SignalCutFlowPlotPlugin(const PluginArgs &args, AnalysisDataLoader *loader)
-        : loader_(loader) {
-        const auto &cfg = args.plot_configs;
-        if (!cfg.contains("plots") || !cfg.at("plots").is_array())
-            throw std::runtime_error("SignalCutFlowPlotPlugin missing plots");
-        for (auto const &p : cfg.at("plots")) {
-            PlotConfig pc;
-            pc.stages = p.at("stages").get<std::vector<std::string>>();
-            pc.pass_columns = p.at("pass_columns").get<std::vector<std::string>>();
-            pc.reason_columns = p.at("reason_columns").get<std::vector<std::string>>();
-            pc.truth_column = p.at("truth_column").get<std::string>();
-            pc.plot_name = p.value("plot_name", std::string{"signal_cutflow_survival"});
-            pc.output_directory = p.value("output_directory", std::string{"plots"});
-            if (pc.stages.size() != pc.pass_columns.size() ||
-                pc.reason_columns.size() != pc.pass_columns.size())
-                throw std::runtime_error("SignalCutFlowPlotPlugin configuration size mismatch");
-            plots_.push_back(std::move(pc));
+  SignalCutFlowPlotPlugin(const PluginArgs &args, AnalysisDataLoader *loader)
+      : loader_(loader) {
+    const auto &cfg = args.plot_configs;
+    if (!cfg.contains("plots") || !cfg.at("plots").is_array())
+      throw std::runtime_error("SignalCutFlowPlotPlugin missing plots");
+    for (auto const &p : cfg.at("plots")) {
+      PlotConfig pc;
+      pc.stages = p.at("stages").get<std::vector<std::string>>();
+      pc.pass_columns = p.at("pass_columns").get<std::vector<std::string>>();
+      pc.reason_columns =
+          p.at("reason_columns").get<std::vector<std::string>>();
+      pc.truth_column = p.at("truth_column").get<std::string>();
+      pc.plot_name =
+          p.value("plot_name", std::string{"signal_cutflow_survival"});
+      pc.output_directory = p.value("output_directory", std::string{"plots"});
+      if (pc.stages.size() != pc.pass_columns.size() ||
+          pc.reason_columns.size() != pc.pass_columns.size())
+        throw std::runtime_error(
+            "SignalCutFlowPlotPlugin configuration size mismatch");
+      plots_.push_back(std::move(pc));
+    }
+  }
+
+  void onPlot(const AnalysisResult &) override {
+    if (!loader_) {
+      log::error("SignalCutFlowPlotPlugin::onPlot",
+                 "No AnalysisDataLoader context provided");
+      return;
+    }
+    for (const auto &pc : plots_) {
+      this->processPlot(pc);
+    }
+  }
+
+private:
+  static std::pair<double, double> wilsonInterval(double k, double n,
+                                                  double z = 1.0) {
+    if (n <= 0.0)
+      return {0.0, 0.0};
+    double p = k / n;
+    double denom = 1 + z * z / n;
+    double center = (p + z * z / (2 * n)) / denom;
+    double half = z * std::sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / denom;
+    return {std::max(0.0, center - half), std::min(1.0, center + half)};
+  }
+
+  void processPlot(const PlotConfig &pc) const {
+    double N0 = 0.0;
+    double sum_w2 = 0.0;
+    std::vector<double> cum_counts(pc.stages.size(), 0.0);
+    std::vector<std::map<std::string, double>> loss_reason(pc.stages.size());
+    std::mutex m;
+
+    std::vector<std::string> cols;
+    cols.push_back("nominal_event_weight");
+    cols.push_back(pc.truth_column);
+    for (auto const &c : pc.pass_columns)
+      cols.push_back(c);
+    for (size_t i = 1; i < pc.reason_columns.size(); ++i)
+      cols.push_back(pc.reason_columns[i]);
+
+    for (auto const &[skey, sample] : loader_->getSampleFrames()) {
+      auto df = sample.nominal_node_;
+      if (!df.HasColumn(pc.truth_column)) {
+        log::warn("SignalCutFlowPlotPlugin::processPlot", "Sample ", skey,
+                  " missing column ", pc.truth_column, "; defaulting to false");
+        df = df.Define(pc.truth_column.c_str(), "false");
+      }
+      auto lam = [&](double w, bool is_sig, bool p0, bool p1, bool p2, bool p3,
+                     bool p4, bool p5, const std::string &r1,
+                     const std::string &r2, const std::string &r3,
+                     const std::string &r4, const std::string &r5) {
+        if (!is_sig)
+          return;
+        std::lock_guard<std::mutex> lock(m);
+        N0 += w;
+        sum_w2 += w * w;
+        bool pass[6] = {p0, p1, p2, p3, p4, p5};
+        bool cum = true;
+        int first_fail = -1;
+        for (int i = 0; i < 6; ++i) {
+          cum = cum && pass[i];
+          if (cum)
+            cum_counts[i] += w;
+          else {
+            first_fail = i;
+            break;
+          }
         }
+        if (first_fail > 0) {
+          const std::string &reason = (first_fail == 1)   ? r1
+                                      : (first_fail == 2) ? r2
+                                      : (first_fail == 3) ? r3
+                                      : (first_fail == 4) ? r4
+                                                          : r5;
+          std::string key = reason.empty() ? "unspecified" : reason;
+          loss_reason[first_fail][key] += w;
+        }
+      };
+      df.Foreach(lam, cols);
     }
 
-    void onPlot(const AnalysisResult &) override {
-        if (!loader_) {
-            log::error("SignalCutFlowPlotPlugin::onPlot", "No AnalysisDataLoader context provided");
-            return;
-        }
-        for (const auto &pc : plots_) {
-            this->processPlot(pc);
-        }
+    std::vector<double> survival;
+    std::vector<double> err_low, err_high;
+    double n_eff = sum_w2 > 0.0 ? (N0 * N0) / sum_w2 : 0.0;
+    for (size_t i = 0; i < pc.stages.size(); ++i) {
+      double s = N0 > 0.0 ? cum_counts[i] / N0 : 0.0;
+      survival.push_back(s);
+      double k_eff = s * n_eff;
+      auto [lo, hi] = wilsonInterval(k_eff, n_eff);
+      err_low.push_back(s - lo);
+      err_high.push_back(hi - s);
     }
 
-  private:
-    static std::pair<double, double> wilsonInterval(size_t k, size_t n,
-                                                    double z = 1.0) {
-        if (n == 0)
-            return {0.0, 0.0};
-        double p = static_cast<double>(k) / n;
-        double denom = 1 + z * z / n;
-        double center = (p + z * z / (2 * n)) / denom;
-        double half = z * std::sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / denom;
-        return {std::max(0.0, center - half), std::min(1.0, center + half)};
+    std::vector<CutFlowLossInfo> losses(pc.stages.size());
+    for (size_t i = 1; i < pc.stages.size(); ++i) {
+      double total = 0.0;
+      std::string top_reason;
+      double top_count = 0.0;
+      for (const auto &[r, c] : loss_reason[i]) {
+        total += c;
+        if (c > top_count) {
+          top_count = c;
+          top_reason = r;
+        }
+      }
+      losses[i] = {top_reason, top_count, total};
     }
 
-    void processPlot(const PlotConfig &pc) const {
-        size_t N0 = 0;
-        std::vector<size_t> cum_counts(pc.stages.size(), 0);
-        std::vector<std::map<std::string, int>> loss_reason(pc.stages.size());
-        std::mutex m;
+    SignalCutFlowPlot plot(pc.plot_name, pc.stages, survival, err_low, err_high,
+                           N0, cum_counts, losses, pc.output_directory);
+    plot.drawAndSave("pdf");
+    log::info("SignalCutFlowPlotPlugin::onPlot",
+              pc.output_directory + "/" + pc.plot_name + ".pdf");
+  }
 
-        std::vector<std::string> cols;
-        cols.push_back(pc.truth_column);
-        for (auto const &c : pc.pass_columns)
-            cols.push_back(c);
-        for (size_t i = 1; i < pc.reason_columns.size(); ++i)
-            cols.push_back(pc.reason_columns[i]);
+  std::vector<PlotConfig> plots_;
+  AnalysisDataLoader *loader_;
+  inline static AnalysisDataLoader *legacy_loader_ = nullptr;
 
-        for (auto const &[skey, sample] : loader_->getSampleFrames()) {
-            auto df = sample.nominal_node_;
-            if (!df.HasColumn(pc.truth_column)) {
-                log::warn("SignalCutFlowPlotPlugin::processPlot",
-                          "Sample ", skey, " missing column ", pc.truth_column,
-                          "; defaulting to false");
-                df = df.Define(pc.truth_column.c_str(), "false");
-            }
-            auto lam = [&](bool is_sig, bool p0, bool p1, bool p2, bool p3,
-                            bool p4, bool p5, const std::string &r1,
-                            const std::string &r2, const std::string &r3,
-                            const std::string &r4, const std::string &r5) {
-                if (!is_sig)
-                    return;
-                std::lock_guard<std::mutex> lock(m);
-                ++N0;
-                bool pass[6] = {p0, p1, p2, p3, p4, p5};
-                bool cum = true;
-                int first_fail = -1;
-                for (int i = 0; i < 6; ++i) {
-                    cum = cum && pass[i];
-                    if (cum)
-                        cum_counts[i]++;
-                    else {
-                        first_fail = i;
-                        break;
-                    }
-                }
-                if (first_fail > 0) {
-                    const std::string &reason =
-                        (first_fail == 1)
-                            ? r1
-                            : (first_fail == 2)
-                                  ? r2
-                                  : (first_fail == 3)
-                                        ? r3
-                                        : (first_fail == 4) ? r4 : r5;
-                    std::string key = reason.empty() ? "unspecified" : reason;
-                    loss_reason[first_fail][key]++;
-                }
-            };
-            df.Foreach(lam, cols);
-        }
-
-        std::vector<double> survival;
-        std::vector<double> err_low, err_high;
-        for (size_t i = 0; i < pc.stages.size(); ++i) {
-            double s = N0 > 0 ? static_cast<double>(cum_counts[i]) / N0 : 0.0;
-            survival.push_back(s);
-            auto [lo, hi] = wilsonInterval(cum_counts[i], N0);
-            err_low.push_back(s - lo);
-            err_high.push_back(hi - s);
-        }
-
-        std::vector<CutFlowLossInfo> losses(pc.stages.size());
-        for (size_t i = 1; i < pc.stages.size(); ++i) {
-            int total = 0;
-            std::string top_reason;
-            int top_count = 0;
-            for (const auto &[r, c] : loss_reason[i]) {
-                total += c;
-                if (c > top_count) {
-                    top_count = c;
-                    top_reason = r;
-                }
-            }
-            losses[i] = {top_reason, top_count, total};
-        }
-
-        SignalCutFlowPlot plot(pc.plot_name, pc.stages, survival, err_low, err_high,
-                               N0, cum_counts, losses, pc.output_directory);
-        plot.drawAndSave("pdf");
-        log::info("SignalCutFlowPlotPlugin::onPlot",
-                  pc.output_directory + "/" + pc.plot_name + ".pdf");
-    }
-
-    std::vector<PlotConfig> plots_;
-    AnalysisDataLoader *loader_;
-    inline static AnalysisDataLoader *legacy_loader_ = nullptr;
-  public:
-    static void setLegacyLoader(AnalysisDataLoader *ldr) { legacy_loader_ = ldr; }
-    static AnalysisDataLoader *legacyLoader() { return legacy_loader_; }
+public:
+  static void setLegacyLoader(AnalysisDataLoader *ldr) { legacy_loader_ = ldr; }
+  static AnalysisDataLoader *legacyLoader() { return legacy_loader_; }
 };
 
 } // namespace analysis
 
 ANALYSIS_REGISTER_PLUGIN(analysis::IPlotPlugin, analysis::AnalysisDataLoader,
-                         "SignalCutFlowPlotPlugin", analysis::SignalCutFlowPlotPlugin)
+                         "SignalCutFlowPlotPlugin",
+                         analysis::SignalCutFlowPlotPlugin)
 
 #ifdef BUILD_PLUGIN
-extern "C" analysis::IPlotPlugin *createSignalCutFlowPlotPlugin(
-    const analysis::PluginArgs &args) {
-    return new analysis::SignalCutFlowPlotPlugin(args, analysis::SignalCutFlowPlotPlugin::legacyLoader());
+extern "C" analysis::IPlotPlugin *
+createSignalCutFlowPlotPlugin(const analysis::PluginArgs &args) {
+  return new analysis::SignalCutFlowPlotPlugin(
+      args, analysis::SignalCutFlowPlotPlugin::legacyLoader());
 }
-extern "C" analysis::IPlotPlugin *createPlotPlugin(const analysis::PluginArgs &args) {
-    return createSignalCutFlowPlotPlugin(args);
+extern "C" analysis::IPlotPlugin *
+createPlotPlugin(const analysis::PluginArgs &args) {
+  return createSignalCutFlowPlotPlugin(args);
 }
 extern "C" void setPluginContext(analysis::AnalysisDataLoader *loader) {
-    analysis::SignalCutFlowPlotPlugin::setLegacyLoader(loader);
+  analysis::SignalCutFlowPlotPlugin::setLegacyLoader(loader);
 }
 #endif


### PR DESCRIPTION
## Summary
- weight SignalCutFlow cut counts by nominal event weight
- compute survival uncertainties using effective event counts
- show POT-scaled totals and weighted loss reasons on plot

## Testing
- `cmake -S . -B build` *(fails: Could not find ROOTConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c4996bbb9c832e9bdebf3d4fcd1e78