### PR TITLE
Add MC-only filter to neutrino energy study

### DIFF
--- a/src/run/study_neutrino_energy.cpp
+++ b/src/run/study_neutrino_energy.cpp
@@ -6,6 +6,7 @@ using namespace analysis::dsl;
 int main() {
   auto study = Study("MC Neutrino Energy")
     .data("config/catalogs/samples.json")
+    .mcOnly()
     .region("EMPTY", where(""))
     // The WeightProcessor automatically scales MC event weights to the
     // total protons-on-target, so the resulting histogram is POT-normalised.


### PR DESCRIPTION
## Summary
- add `mcOnly` option to `Study` for Monte Carlo-only analyses
- update `study_neutrino_energy` to use `mcOnly` to avoid data samples without neutrino energy

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*

------
https://chatgpt.com/codex/tasks/task_e_68c4a34237d0832e86d5868551592390