### PR TITLE
Weight SignalCutFlow by nominal event weight

### DIFF
--- a/include/rarexsec/plot/SignalCutFlowPlot.h
+++ b/include/rarexsec/plot/SignalCutFlowPlot.h
@@ -76,8 +76,9 @@ protected:
         double frac = info.top_count > 0
                           ? static_cast<double>(info.top_count) / info.total
                           : 0.0;
-        auto txt = TString::Format("-%0.1f%%: %s (%0.0f%%)", drop,
-                                   info.reason.c_str(), frac * 100.0);
+        auto txt = TString::Format(
+            "-%0.1f%%: %s (%0.1f/%0.1f, %0.0f%%)", drop, info.reason.c_str(),
+            info.top_count * pot_scale_, info.total * pot_scale_, frac * 100.0);
         latex.DrawLatex(i + 1 - 0.1, survival_[i] * 100.0 + 7.0, txt.Data());
       }
     }


### PR DESCRIPTION
## Summary
- Weight cut flow counts by nominal event weight and compute survival uncertainties using effective event counts
- Display POT-scaled totals and weighted loss reasons on SignalCutFlow plots

## Testing
- `source .container.sh` *(fails: shell_apptainer.sh missing)*
- `source .setup.sh` *(fails: setup scripts missing)*
- `source .build.sh` *(fails: could not find ROOT CMake package)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a600e690832eab5fbd8ca01ae04c