### PR TITLE
Add cut flow gradient utilities

### DIFF
--- a/include/rarexsec/core/CutFlowGradient.h
+++ b/include/rarexsec/core/CutFlowGradient.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <rarexsec/core/RegionAnalysis.h>
+
+namespace analysis {
+
+namespace detail {
+// Compute survival efficiencies for given keys within a scheme.
+inline std::map<int, std::vector<double>>
+computeEfficiencies(const std::vector<RegionAnalysis::StageCount> &counts,
+                    const std::string &scheme,
+                    const std::vector<int> &keys) {
+  std::map<int, std::vector<double>> eff;
+  if (counts.empty())
+    return eff;
+
+  auto scheme_it0 = counts[0].schemes.find(scheme);
+  if (scheme_it0 == counts[0].schemes.end())
+    return eff;
+
+  std::map<int, double> initial;
+  for (int key : keys) {
+    auto it0 = scheme_it0->second.find(key);
+    initial[key] = (it0 != scheme_it0->second.end()) ? it0->second.first : 0.0;
+    eff[key].resize(counts.size(), 0.0);
+  }
+
+  for (size_t i = 0; i < counts.size(); ++i) {
+    auto scheme_it = counts[i].schemes.find(scheme);
+    for (int key : keys) {
+      double val = 0.0;
+      if (scheme_it != counts[i].schemes.end()) {
+        auto it = scheme_it->second.find(key);
+        if (it != scheme_it->second.end())
+          val = it->second.first;
+      }
+      double denom = initial[key];
+      eff[key][i] = denom > 0.0 ? val / denom : 0.0;
+    }
+  }
+
+  return eff;
+}
+} // namespace detail
+
+struct CutFlowGradient {
+  std::vector<double> signal;                       // gradient for signal per stage
+  std::map<int, std::vector<double>> backgrounds;   // gradients per background key
+};
+
+inline CutFlowGradient computeCutFlowGradient(
+    const std::vector<RegionAnalysis::StageCount> &plus,
+    const std::vector<RegionAnalysis::StageCount> &minus,
+    const std::string &scheme, int signal_key,
+    const std::vector<int> &background_keys) {
+  CutFlowGradient grad;
+  std::vector<int> keys = background_keys;
+  keys.push_back(signal_key);
+
+  auto eff_plus = detail::computeEfficiencies(plus, scheme, keys);
+  auto eff_minus = detail::computeEfficiencies(minus, scheme, keys);
+
+  size_t n = plus.size();
+  grad.signal.resize(n, 0.0);
+  for (size_t i = 0; i < n; ++i) {
+    grad.signal[i] = (eff_plus[signal_key][i] - eff_minus[signal_key][i]) / 2.0;
+  }
+
+  for (int bk : background_keys) {
+    auto &vec = grad.backgrounds[bk];
+    vec.resize(n, 0.0);
+    for (size_t i = 0; i < n; ++i) {
+      vec[i] = (eff_plus[bk][i] - eff_minus[bk][i]) / 2.0;
+    }
+  }
+
+  return grad;
+}
+
+} // namespace analysis
+

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -23,6 +23,10 @@ add_executable(test_cut_flow_summary
 target_link_libraries(test_cut_flow_summary PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json ${ROOT_LIBRARIES} TBB::tbb)
 catch_discover_tests(test_cut_flow_summary)
 
+add_executable(test_cut_flow_gradient test_cut_flow_gradient.cpp)
+target_link_libraries(test_cut_flow_gradient PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json ${ROOT_LIBRARIES} TBB::tbb)
+catch_discover_tests(test_cut_flow_gradient)
+
 add_executable(test_monte_carlo_processor test_monte_carlo_processor.cpp)
 target_link_libraries(test_monte_carlo_processor PRIVATE core hist utils syst Eigen3::Eigen Catch2::Catch2WithMain ${ROOT_LIBRARIES} TBB::tbb)
 catch_discover_tests(test_monte_carlo_processor)

--- a/src/tests/test_cut_flow_gradient.cpp
+++ b/src/tests/test_cut_flow_gradient.cpp
@@ -1,0 +1,42 @@
+#include <rarexsec/core/CutFlowGradient.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace analysis;
+
+namespace {
+RegionAnalysis::StageCount make_stage(double sig, double bkg) {
+    RegionAnalysis::StageCount sc;
+    sc.total = sig + bkg;
+    sc.schemes["chan"][1] = {sig, sig}; // signal key 1
+    sc.schemes["chan"][2] = {bkg, bkg}; // background key 2
+    return sc;
+}
+}
+
+TEST_CASE("compute finite difference gradients for cut flow") {
+    std::vector<RegionAnalysis::StageCount> plus{
+        make_stage(100.0, 200.0), // initial
+        make_stage(61.0, 30.0),   // after cut1
+        make_stage(31.0, 15.0)    // after cut2
+    };
+
+    std::vector<RegionAnalysis::StageCount> minus{
+        make_stage(100.0, 200.0),
+        make_stage(59.0, 50.0),
+        make_stage(29.0, 25.0)
+    };
+
+    auto grad = computeCutFlowGradient(plus, minus, "chan", 1, {2});
+
+    REQUIRE(grad.signal.size() == 3);
+    REQUIRE(grad.backgrounds.at(2).size() == 3);
+
+    // Stage 1 gradients
+    CHECK(grad.signal[1] == Approx((0.61 - 0.59) / 2.0));
+    CHECK(grad.backgrounds.at(2)[1] == Approx((0.15 - 0.25) / 2.0));
+
+    // Stage 2 gradients
+    CHECK(grad.signal[2] == Approx((0.31 - 0.29) / 2.0));
+    CHECK(grad.backgrounds.at(2)[2] == Approx((0.075 - 0.125) / 2.0));
+}


### PR DESCRIPTION
## Summary
- add `CutFlowGradient` helper for finite-difference survival sensitivities
- add unit test for gradient calculations

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "ROOT" – required ROOT components not installed)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4aabe3de4832e83a01529b9988521