### PR TITLE
Add systematic uncertainty band to SignalCutFlow plot

### DIFF
--- a/include/rarexsec/plot/SignalCutFlowPlot.h
+++ b/include/rarexsec/plot/SignalCutFlowPlot.h
@@ -21,17 +21,21 @@ struct CutFlowLossInfo {
 
 class SignalCutFlowPlot : public IHistogramPlot {
 public:
-  SignalCutFlowPlot(std::string plot_name, std::vector<std::string> stages,
-                    std::vector<double> survival, std::vector<double> err_low,
-                    std::vector<double> err_high, double N0,
-                    std::vector<double> counts,
-                    std::vector<CutFlowLossInfo> losses, double pot_scale = 1.0,
-                    std::string output_directory = "plots",
-                    std::string x_label = "Cut Stage",
-                    std::string y_label = "Survival Probability (%)")
+  SignalCutFlowPlot(
+      std::string plot_name, std::vector<std::string> stages,
+      std::vector<double> survival, std::vector<double> err_low,
+      std::vector<double> err_high, std::vector<double> syst_low,
+      std::vector<double> syst_high, double N0, std::vector<double> counts,
+      std::vector<CutFlowLossInfo> losses, double pot_scale = 1.0,
+      std::string output_directory = "plots",
+      std::string x_label = "Cut Stage",
+      std::string y_label = "Survival Probability (%)",
+      int band_color = 16, double band_alpha = 0.3)
       : IHistogramPlot(std::move(plot_name), std::move(output_directory)),
         stages_(std::move(stages)), survival_(std::move(survival)),
-        err_low_(std::move(err_low)), err_high_(std::move(err_high)), N0_(N0),
+        err_low_(std::move(err_low)), err_high_(std::move(err_high)),
+        syst_low_(std::move(syst_low)), syst_high_(std::move(syst_high)),
+        band_color_(band_color), band_alpha_(band_alpha), N0_(N0),
         counts_(std::move(counts)), losses_(std::move(losses)),
         pot_scale_(pot_scale), x_label_(std::move(x_label)),
         y_label_(std::move(y_label)) {}
@@ -49,6 +53,32 @@ protected:
     h->SetMinimum(0.0);
     h->SetMaximum(100.0);
     h->Draw("hist");
+
+    bool draw_band = false;
+    for (int i = 0; i < n; ++i) {
+      if ((i < static_cast<int>(syst_low_.size()) && syst_low_[i] > 0.0) ||
+          (i < static_cast<int>(syst_high_.size()) && syst_high_[i] > 0.0)) {
+        draw_band = true;
+        break;
+      }
+    }
+
+    if (draw_band) {
+      auto *gb = new TGraphAsymmErrors(n);
+      for (int i = 0; i < n; ++i) {
+        gb->SetPoint(i, i + 1, survival_[i] * 100.0);
+        double el = i < static_cast<int>(syst_low_.size())
+                        ? syst_low_[i] * 100.0
+                        : 0.0;
+        double eh = i < static_cast<int>(syst_high_.size())
+                        ? syst_high_[i] * 100.0
+                        : 0.0;
+        gb->SetPointError(i, 0.0, 0.0, el, eh);
+      }
+      gb->SetFillColorAlpha(band_color_, band_alpha_);
+      gb->SetLineColorAlpha(band_color_, band_alpha_);
+      gb->Draw("E3 SAME");
+    }
 
     auto *g = new TGraphAsymmErrors(n);
     for (int i = 0; i < n; ++i) {
@@ -89,6 +119,10 @@ private:
   std::vector<double> survival_;
   std::vector<double> err_low_;
   std::vector<double> err_high_;
+  std::vector<double> syst_low_;
+  std::vector<double> syst_high_;
+  int band_color_;
+  double band_alpha_;
   double N0_;
   std::vector<double> counts_;
   std::vector<CutFlowLossInfo> losses_;


### PR DESCRIPTION
## Summary
- Support systematic uncertainty bands in SignalCutFlowPlot
- Collect per-stage survival for configured weight and detector systematics
- Allow configuration of which systematics to include and band appearance

## Testing
- `bash ./.build.sh` *(fails: Could not find a package configuration file provided by "ROOT")*
- `sudo apt-get update` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c4aaffd32c832e88871f448166f8e3