### PR TITLE
Add legend and log-scale purity to SignalCutFlow plot

### DIFF
--- a/src/plug/plotting/SignalCutFlowPlotPlugin.cc
+++ b/src/plug/plotting/SignalCutFlowPlotPlugin.cc
@@ -302,9 +302,9 @@ private:
 
     SignalCutFlowPlot plot(pc.plot_name, pc.stages, survival, err_low, err_high,
                            N0, cum_counts, losses, loader_->getTotalPot(),
-                           pc.output_directory, pc.x_label, pc.y_label, purity,
-                           "Purity (%)", syst_low, syst_high, pc.band_color,
-                           pc.band_alpha);
+                           pc.output_directory, pc.x_label, pc.y_label,
+                           purity, purity, "Purity (%)", syst_low, syst_high,
+                           pc.band_color, pc.band_alpha);
     plot.drawAndSave("pdf");
     log::info("SignalCutFlowPlotPlugin::onPlot",
               pc.output_directory + "/" + pc.plot_name + ".pdf");


### PR DESCRIPTION
## Summary
- Add MC and total purity lines with log-scale secondary axis
- Match axis label sizing and include legend like StackedHistogram
- Shrink cut-flow annotations for clearer display

## Testing
- `source .build.sh` *(fails: Could not find ROOT)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c566383774832e8299edc9b29057a0