### PR TITLE
Use nominal_pot for run configuration

### DIFF
--- a/config/catalogs/samples.json
+++ b/config/catalogs/samples.json
@@ -9,7 +9,7 @@
         "beamlines": {
             "numi_fhc": {
                 "run1": {
-                    "pot": 3.922e+20,
+                    "nominal_pot": 3.922e+20,
                     "samples": [
                         {
                             "sample_key": "mc_inclusive_run1_fhc",


### PR DESCRIPTION
## Summary
- rename run-level `pot` field to `nominal_pot` in `samples.json`

## Testing
- `python -m json.tool config/catalogs/samples.json`
- `source .container.sh` *(fails: No such file or directory)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5669d6c10832eb5163c52ad0ca415