### PR TITLE
Define pure slice signal variable

### DIFF
--- a/include/rarexsec/data/TruthChannelProcessor.h
+++ b/include/rarexsec/data/TruthChannelProcessor.h
@@ -258,10 +258,18 @@ private:
 
     auto signal_df =
         chan_alias_df.Define("is_truth_signal",
-                              [](int ch) { return ch == 15 || ch == 16; },
-                              {"channel_def"});
+                             [](int ch) { return ch == 15 || ch == 16; },
+                             {"channel_def"});
 
-    return signal_df;
+    auto pure_sig_df = signal_df.Define(
+        "pure_slice_signal",
+        [](bool is_sig, float purity, float completeness) {
+          return is_sig && purity > 0.5f && completeness > 0.1f;
+        },
+        {"is_truth_signal", "neutrino_purity_from_pfp",
+         "neutrino_completeness_from_pfp"});
+
+    return pure_sig_df;
   }
 };
 


### PR DESCRIPTION
## Summary
- drop `PURE_SLICE_SIGNAL` selection rule
- introduce `pure_slice_signal` derived variable requiring truth signal with slice purity > 0.5 and completeness > 0.1

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "ROOT")*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56b307570832eacc109ba01604c09