### PR TITLE
Refine signal cutflow plotting

### DIFF
--- a/include/rarexsec/plot/SignalCutFlowPlot.h
+++ b/include/rarexsec/plot/SignalCutFlowPlot.h
@@ -38,6 +38,7 @@ public:
                     std::string output_directory = "plots",
                     std::string x_label = "Selection stage",
                     std::string y_label = "Selection efficiency",
+                    std::string eff_label = "Selection efficiency",
                     std::vector<double> mc_purity = {},
                     std::vector<double> total_purity = {},
                     std::string y2_label = "Purity (%)",
@@ -49,7 +50,8 @@ public:
         err_low_(std::move(err_low)), err_high_(std::move(err_high)), N0_(N0),
         counts_(std::move(counts)), losses_(std::move(losses)),
         pot_scale_(pot_scale), x_label_(std::move(x_label)),
-        y_label_(std::move(y_label)), mc_purity_(std::move(mc_purity)),
+        y_label_(std::move(y_label)), eff_label_(std::move(eff_label)),
+        mc_purity_(std::move(mc_purity)),
         total_purity_(std::move(total_purity)), y2_label_(std::move(y2_label)),
         syst_low_(std::move(syst_low)), syst_high_(std::move(syst_high)),
         band_color_(band_color), band_alpha_(band_alpha) {}
@@ -131,16 +133,16 @@ protected:
       gb->Draw("2 SAME");
     }
 
-    // Efficiency points with stat. errors
-    auto *g_eff = new TGraphAsymmErrors(n);
-    g_eff->SetMarkerStyle(20);
-    g_eff->SetMarkerSize(1.1);
-    g_eff->SetLineWidth(2);
+    // Statistical error bars on efficiency (no markers)
+    auto *g_err = new TGraphAsymmErrors(n);
+    g_err->SetMarkerStyle(0);
+    g_err->SetLineWidth(2);
     for (int i = 0; i < n; ++i) {
-      g_eff->SetPoint(i, i + 1, survival_.at(i) * 100.0);
-      g_eff->SetPointError(i, 0.0, 0.0, err_low_.at(i) * 100.0, err_high_.at(i) * 100.0);
+      g_err->SetPoint(i, i + 1, survival_.at(i) * 100.0);
+      g_err->SetPointError(i, 0.0, 0.0, err_low_.at(i) * 100.0,
+                          err_high_.at(i) * 100.0);
     }
-    g_eff->Draw("P SAME");
+    g_err->Draw("E SAME");
 
     // -- Overlay pad for purity (log-y) --------------------------------------
     TGraph *gp_mc = nullptr;
@@ -224,7 +226,7 @@ protected:
 
       // Right-hand axis in overlay pad user coords
       const double xRight = n + 0.5;
-      TGaxis *y2 = new TGaxis(xRight, y2min, xRight, y2max, y2min, y2max, 510, "G+");
+      TGaxis *y2 = new TGaxis(xRight, y2min, xRight, y2max, y2min, y2max, 510, "G");
       y2->SetTitle(y2_label_.c_str());    // e.g. "Purity (%)"
       y2->SetLabelFont(gStyle->GetLabelFont("Y"));
       y2->SetTitleFont(gStyle->GetTitleFont("Y"));
@@ -244,9 +246,10 @@ protected:
     legend->SetFillStyle(0);
     legend->SetTextFont(42);
 
-    int n_entries = 1 + (gb ? 1 : 0) + (gp_mc ? 1 : 0) + (gp_tot ? 1 : 0);
+    int n_entries = 1 + (gb ? 1 : 0) + 1 + (gp_mc ? 1 : 0) + (gp_tot ? 1 : 0);
     legend->SetNColumns((n_entries > 4) ? 3 : 2);
-    legend->AddEntry(g_eff, "Selection efficiency", "p");
+    legend->AddEntry(h, eff_label_.c_str(), "l");
+    legend->AddEntry(g_err, "Stat. unc.", "le");
     if (gb)     legend->AddEntry(gb, "Syst. unc.", "f");
     if (gp_mc)  legend->AddEntry(gp_mc, "MC purity (log)", "pl");
     if (gp_tot) legend->AddEntry(gp_tot, "Total purity (log)", "pl");
@@ -266,6 +269,7 @@ private:
   double pot_scale_;
   std::string x_label_;
   std::string y_label_;
+  std::string eff_label_;
   std::vector<double> mc_purity_;     // fractions [0..1]
   std::vector<double> total_purity_;  // fractions [0..1]
   std::string y2_label_;

--- a/src/plug/plotting/SignalCutFlowPlotPlugin.cc
+++ b/src/plug/plotting/SignalCutFlowPlotPlugin.cc
@@ -92,17 +92,23 @@ private:
   }
 
   void processPlot(const PlotConfig &pc) const {
+    auto stages = pc.stages;
     double N0 = 0.0;
     double N0_w2 = 0.0;
+    double N0_pure = 0.0;
+    double N0_pure_w2 = 0.0;
     [[maybe_unused]] double Ntot = 0.0;
     std::vector<double> cum_counts(pc.stages.size(), 0.0);
     std::vector<double> cum_counts_w2(pc.stages.size(), 0.0);
     std::vector<double> cum_counts_all(pc.stages.size(), 0.0);
+    std::vector<double> cum_counts_pure(pc.stages.size(), 0.0);
+    std::vector<double> cum_counts_pure_w2(pc.stages.size(), 0.0);
     std::vector<std::map<std::string, double>> loss_reason(pc.stages.size());
     std::mutex m;
 
     std::vector<std::string> cols;
     cols.push_back(pc.truth_column);
+    cols.push_back("pure_slice_signal");
     for (auto const &c : pc.pass_columns)
       cols.push_back(c);
     for (size_t i = 1; i < pc.reason_columns.size(); ++i)
@@ -116,10 +122,16 @@ private:
                   " missing column ", pc.truth_column, "; defaulting to false");
         df = df.Define(pc.truth_column.c_str(), "false");
       }
-      auto lam = [&](bool is_sig, bool p0, bool p1, bool p2, bool p3, bool p4,
-                     bool p5, const std::string &r1, const std::string &r2,
-                     const std::string &r3, const std::string &r4,
-                     const std::string &r5, double weight) {
+      if (!df.HasColumn("pure_slice_signal")) {
+        log::warn("SignalCutFlowPlotPlugin::processPlot", "Sample ", skey,
+                  " missing column pure_slice_signal; defaulting to false");
+        df = df.Define("pure_slice_signal", "false");
+      }
+      auto lam = [&](bool is_sig, bool is_pure, bool p0, bool p1, bool p2,
+                     bool p3, bool p4, bool p5, const std::string &r1,
+                     const std::string &r2, const std::string &r3,
+                     const std::string &r4, const std::string &r5,
+                     double weight) {
         std::lock_guard<std::mutex> lock(m);
         Ntot += weight;
         bool pass[6] = {p0, p1, p2, p3, p4, p5};
@@ -131,30 +143,44 @@ private:
           else
             break;
         }
-        if (!is_sig)
-          return;
-        N0 += weight;
-        N0_w2 += weight * weight;
-        cum = true;
-        int first_fail = -1;
-        for (int i = 0; i < 6; ++i) {
-          cum = cum && pass[i];
-          if (cum) {
-            cum_counts[i] += weight;
-            cum_counts_w2[i] += weight * weight;
-          } else {
-            first_fail = i;
-            break;
+        if (is_sig) {
+          N0 += weight;
+          N0_w2 += weight * weight;
+          cum = true;
+          int first_fail = -1;
+          for (int i = 0; i < 6; ++i) {
+            cum = cum && pass[i];
+            if (cum) {
+              cum_counts[i] += weight;
+              cum_counts_w2[i] += weight * weight;
+            } else {
+              first_fail = i;
+              break;
+            }
+          }
+          if (first_fail > 0) {
+            const std::string &reason = (first_fail == 1)   ? r1
+                                        : (first_fail == 2) ? r2
+                                        : (first_fail == 3) ? r3
+                                        : (first_fail == 4) ? r4
+                                                            : r5;
+            std::string key = reason.empty() ? "unspecified" : reason;
+            loss_reason[first_fail][key] += weight;
           }
         }
-        if (first_fail > 0) {
-          const std::string &reason = (first_fail == 1)   ? r1
-                                      : (first_fail == 2) ? r2
-                                      : (first_fail == 3) ? r3
-                                      : (first_fail == 4) ? r4
-                                                          : r5;
-          std::string key = reason.empty() ? "unspecified" : reason;
-          loss_reason[first_fail][key] += weight;
+        if (is_pure) {
+          N0_pure += weight;
+          N0_pure_w2 += weight * weight;
+          cum = true;
+          for (int i = 0; i < 6; ++i) {
+            cum = cum && pass[i];
+            if (cum) {
+              cum_counts_pure[i] += weight;
+              cum_counts_pure_w2[i] += weight * weight;
+            } else {
+              break;
+            }
+          }
         }
       };
       df.Foreach(lam, cols);
@@ -162,10 +188,11 @@ private:
 
     std::vector<double> survival;
     std::vector<double> err_low, err_high;
+    std::vector<double> survival_pure;
+    std::vector<double> err_low_pure, err_high_pure;
     for (size_t i = 0; i < pc.stages.size(); ++i) {
       double s = N0 > 0.0 ? cum_counts[i] / N0 : 0.0;
       survival.push_back(s);
-
       double cw = cum_counts[i];
       double cw2 = cum_counts_w2[i];
       double fw = N0 - cw;
@@ -176,6 +203,19 @@ private:
       auto [lo, hi] = wilsonInterval(k_eff, n_eff);
       err_low.push_back(s - lo);
       err_high.push_back(hi - s);
+
+      double sp = N0_pure > 0.0 ? cum_counts_pure[i] / N0_pure : 0.0;
+      survival_pure.push_back(sp);
+      double cwp = cum_counts_pure[i];
+      double cwp2 = cum_counts_pure_w2[i];
+      double fwp = N0_pure - cwp;
+      double fwp2 = N0_pure_w2 - cwp2;
+      double k_eff_p = (cwp2 > 0.0) ? (cwp * cwp) / cwp2 : 0.0;
+      double f_eff_p = (fwp2 > 0.0) ? (fwp * fwp) / fwp2 : 0.0;
+      double n_eff_p = k_eff_p + f_eff_p;
+      auto [lo_p, hi_p] = wilsonInterval(k_eff_p, n_eff_p);
+      err_low_pure.push_back(sp - lo_p);
+      err_high_pure.push_back(hi_p - sp);
     }
 
     std::vector<CutFlowLossInfo> losses(pc.stages.size());
@@ -300,14 +340,63 @@ private:
       }
     }
 
-    SignalCutFlowPlot plot(pc.plot_name, pc.stages, survival, err_low, err_high,
+    // Remove final stage and prepend empty-selection stage
+    if (!stages.empty()) {
+      stages.pop_back();
+      survival.pop_back();
+      err_low.pop_back();
+      err_high.pop_back();
+      cum_counts.pop_back();
+      losses.pop_back();
+      purity.pop_back();
+      if (!syst_low.empty()) {
+        syst_low.pop_back();
+        syst_high.pop_back();
+      }
+      survival_pure.pop_back();
+      err_low_pure.pop_back();
+      err_high_pure.pop_back();
+      cum_counts_pure.pop_back();
+    }
+    stages.insert(stages.begin(), "Empty selection");
+    survival.insert(survival.begin(), 1.0);
+    err_low.insert(err_low.begin(), 0.0);
+    err_high.insert(err_high.begin(), 0.0);
+    cum_counts.insert(cum_counts.begin(), N0);
+    losses.insert(losses.begin(), {});
+    purity.insert(purity.begin(), N0 > 0.0 ? N0 / Ntot : 0.0);
+    if (!syst_low.empty()) {
+      syst_low.insert(syst_low.begin(), 0.0);
+      syst_high.insert(syst_high.begin(), 0.0);
+    }
+    survival_pure.insert(survival_pure.begin(), 1.0);
+    err_low_pure.insert(err_low_pure.begin(), 0.0);
+    err_high_pure.insert(err_high_pure.begin(), 0.0);
+    cum_counts_pure.insert(cum_counts_pure.begin(), N0_pure);
+
+    SignalCutFlowPlot plot(pc.plot_name, stages, survival, err_low, err_high,
                            N0, cum_counts, losses, loader_->getTotalPot(),
                            pc.output_directory, pc.x_label, pc.y_label,
-                           purity, purity, "Purity (%)", syst_low, syst_high,
-                           pc.band_color, pc.band_alpha);
+                           "Nominal Selection Efficiency", purity, purity,
+                           "Purity (%)", syst_low, syst_high, pc.band_color,
+                           pc.band_alpha);
     plot.drawAndSave("pdf");
     log::info("SignalCutFlowPlotPlugin::onPlot",
               pc.output_directory + "/" + pc.plot_name + ".pdf");
+
+    // Well reconstructed signal efficiency plot
+    std::vector<CutFlowLossInfo> losses_pure(stages.size());
+    SignalCutFlowPlot plot_pure(pc.plot_name + "_pure", stages, survival_pure,
+                                err_low_pure, err_high_pure, N0_pure,
+                                cum_counts_pure, losses_pure,
+                                loader_->getTotalPot(), pc.output_directory,
+                                pc.x_label, pc.y_label,
+                                "Well-Reconstructed Selection Efficiency", {}, {},
+                                "Purity (%)", {}, {}, pc.band_color,
+                                pc.band_alpha);
+    plot_pure.drawAndSave("pdf");
+    log::info("SignalCutFlowPlotPlugin::onPlot",
+              pc.output_directory + "/" + pc.plot_name + "_pure.pdf");
   }
 
   std::vector<PlotConfig> plots_;


### PR DESCRIPTION
## Summary
- expose configurable efficiency label and drop markers for stat errors in SignalCutFlowPlot
- fix right-hand log axis and legend handling for nominal selection
- add pre-selection stage and generate well-reconstructed signal cutflow plot
- guard against missing `pure_slice_signal` column in SignalCutFlowPlotPlugin

## Testing
- `source .container.sh && source .setup.sh && source .build.sh` *(fails: /cvmfs/uboone.opensciencegrid.org/bin/shell_apptainer.sh: No such file or directory)*
- `source .setup.sh && source .build.sh` *(fails: ROOTConfig.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5acfed910832ebc42722b0535d14b